### PR TITLE
Persist tournament available players selection in localStorage

### DIFF
--- a/frontend/src/pages/tournament/tournament-available-players.tsx
+++ b/frontend/src/pages/tournament/tournament-available-players.tsx
@@ -14,8 +14,10 @@ export const TournamentAvailablePlayers = ({ tournament }: { tournament: Tournam
     try {
       const raw = localStorage.getItem(storageKey);
       if (!raw) return new Set();
-      const parsed: { players: string[]; date: string } = JSON.parse(raw);
-      if (parsed.date !== new Date().toDateString()) {
+      const parsed: { players: string[]; storedAt: number } = JSON.parse(raw);
+      const midnight = new Date();
+      midnight.setHours(0, 0, 0, 0);
+      if (parsed.storedAt < midnight.getTime()) {
         localStorage.removeItem(storageKey);
         return new Set();
       }
@@ -27,7 +29,7 @@ export const TournamentAvailablePlayers = ({ tournament }: { tournament: Tournam
 
   useEffect(() => {
     try {
-      const data = JSON.stringify({ players: Array.from(checkedPlayers), date: new Date().toDateString() });
+      const data = JSON.stringify({ players: Array.from(checkedPlayers), storedAt: Date.now() });
       localStorage.setItem(storageKey, data);
     } catch {
       // ignore storage errors

--- a/frontend/src/pages/tournament/tournament-available-players.tsx
+++ b/frontend/src/pages/tournament/tournament-available-players.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { classNames } from "../../common/class-names";
 import { ProfilePicture } from "../player/profile-picture";
 import { useEventDbContext } from "../../wrappers/event-db-context";
@@ -7,7 +7,32 @@ import { Link } from "react-router-dom";
 
 export const TournamentAvailablePlayers = ({ tournament }: { tournament: Tournament }) => {
   const context = useEventDbContext();
-  const [checkedPlayers, setCheckedPlayers] = useState<Set<string>>(new Set());
+
+  const storageKey = `tournament-available-${tournament.id}`;
+
+  const [checkedPlayers, setCheckedPlayers] = useState<Set<string>>(() => {
+    try {
+      const raw = localStorage.getItem(storageKey);
+      if (!raw) return new Set();
+      const parsed: { players: string[]; date: string } = JSON.parse(raw);
+      if (parsed.date !== new Date().toDateString()) {
+        localStorage.removeItem(storageKey);
+        return new Set();
+      }
+      return new Set(parsed.players);
+    } catch {
+      return new Set();
+    }
+  });
+
+  useEffect(() => {
+    try {
+      const data = JSON.stringify({ players: Array.from(checkedPlayers), date: new Date().toDateString() });
+      localStorage.setItem(storageKey, data);
+    } catch {
+      // ignore storage errors
+    }
+  }, [checkedPlayers, storageKey]);
 
   const allPendingGames = tournament.findAllPendingGames();
 


### PR DESCRIPTION
Store checked players in localStorage keyed per tournament, with today's
date stamp. On load, the selection is restored if the date matches today,
otherwise it's cleared — effectively expiring at midnight.

https://claude.ai/code/session_01Kv1qX6WQtRPZMiECbKhu5j