### PR TITLE
Add simulation iteration selector to tournament predictions

### DIFF
--- a/frontend/src/client/client-db/tournaments/prediction.ts
+++ b/frontend/src/client/client-db/tournaments/prediction.ts
@@ -15,6 +15,7 @@ export class TournamentPrediction {
   predictTournament(
     tournamentId: string,
     callback: (data: { simulationTimes?: number[]; data?: TournamentPredictionResult; progress: number }) => void,
+    numSimulations: number = NUM_SIMULATIONS,
   ): void {
     const tournament = this.parent.tournaments.getTournament(tournamentId);
     if (!tournament) {
@@ -30,7 +31,7 @@ export class TournamentPrediction {
 
     for (let i = 0; i < simulationTimePoints.length; i++) {
       const timePoint = simulationTimePoints[i];
-      const result = this.predictTournamentAtTime(tournamentId, timePoint);
+      const result = this.predictTournamentAtTime(tournamentId, timePoint, numSimulations);
       callback({
         data: result,
         progress: (i + 1) / simulationTimePoints.length,
@@ -76,7 +77,11 @@ export class TournamentPrediction {
     return tournament.skippedGames.map((s) => s.time);
   }
 
-  private predictTournamentAtTime(tournamentId: string, simulationTime: number): TournamentPredictionResult {
+  private predictTournamentAtTime(
+    tournamentId: string,
+    simulationTime: number,
+    numSimulations: number = NUM_SIMULATIONS,
+  ): TournamentPredictionResult {
     const winCounts = new Map<string, { wins: number }>();
 
     // Create state at this point in time with only events up to simulationTime
@@ -103,7 +108,7 @@ export class TournamentPrediction {
     let totalConfidenceSum = 0;
 
     // Run Monte Carlo simulations from this time point
-    for (let i = 0; i < NUM_SIMULATIONS; i++) {
+    for (let i = 0; i < numSimulations; i++) {
       const {
         winner,
         gamesSimulatedCount: gsc,

--- a/frontend/src/client/client-db/web-worker/web-worker.ts
+++ b/frontend/src/client/client-db/web-worker/web-worker.ts
@@ -6,7 +6,10 @@ export type WorkerMessage =
   | { type: "start-simulating-elo-over-time"; data: { playerId: string; events: EventType[] } }
   | { type: "simulated-elo-delivery"; data: { elements: { elo: number; time: number }[]; progress: number } }
   | { type: "done-with-simulation" }
-  | { type: "start-tournament-prediction"; data: { tournamentId: string; events: EventType[] } }
+  | {
+      type: "start-tournament-prediction";
+      data: { tournamentId: string; events: EventType[]; numSimulations?: number };
+    }
   | { type: "tournament-prediction-times"; data: { times: number[]; progress: number } }
   | { type: "tournament-prediction-data"; data: { result: TournamentPredictionResult; progress: number } }
   | { type: "tournament-prediction-complete" };
@@ -29,19 +32,23 @@ function handleWorkerMessage(message: WorkerMessage) {
 
     case "start-tournament-prediction":
       const tennisTableForTournament = new TennisTable({ events: message.data.events });
-      tennisTableForTournament.tournaments.tournamentPrediction.predictTournament(message.data.tournamentId, (data) => {
-        if (data.simulationTimes) {
-          postWorkerMessage({
-            type: "tournament-prediction-times",
-            data: { times: data.simulationTimes, progress: data.progress },
-          });
-        } else if (data.data) {
-          postWorkerMessage({
-            type: "tournament-prediction-data",
-            data: { result: data.data, progress: data.progress },
-          });
-        }
-      });
+      tennisTableForTournament.tournaments.tournamentPrediction.predictTournament(
+        message.data.tournamentId,
+        (data) => {
+          if (data.simulationTimes) {
+            postWorkerMessage({
+              type: "tournament-prediction-times",
+              data: { times: data.simulationTimes, progress: data.progress },
+            });
+          } else if (data.data) {
+            postWorkerMessage({
+              type: "tournament-prediction-data",
+              data: { result: data.data, progress: data.progress },
+            });
+          }
+        },
+        message.data.numSimulations,
+      );
       setTimeout(() => postWorkerMessage({ type: "tournament-prediction-complete" }), 1000);
       break;
   }

--- a/frontend/src/hooks/use-tournament-prediction-worker.ts
+++ b/frontend/src/hooks/use-tournament-prediction-worker.ts
@@ -47,7 +47,7 @@ export function useTournamentPredictionWorker() {
 
   // Function to start simulation
   const startSimulation = useCallback(
-    (tournamentId: string) => {
+    (tournamentId: string, numSimulations?: number) => {
       // Reset state when starting new simulation
       setSimulationIsDone(false);
       setSimulationTimes([]);
@@ -57,7 +57,7 @@ export function useTournamentPredictionWorker() {
       if (workerRef.current) {
         const message: WorkerMessage = {
           type: "start-tournament-prediction",
-          data: { tournamentId, events: context.events },
+          data: { tournamentId, events: context.events, numSimulations },
         };
         workerRef.current.postMessage(message);
       } else {

--- a/frontend/src/pages/tournament/tournament-predictions.tsx
+++ b/frontend/src/pages/tournament/tournament-predictions.tsx
@@ -15,9 +15,17 @@ const ZOOM_FACTOR = 0.7; // Each click multiplies/divides by this (30% relative 
 const MIN_Y_MAX = 1; // Allow zooming down to 1%
 const DEFAULT_Y_MAX = 100;
 
+const SIMULATION_OPTIONS: { label: string; value: number }[] = [
+  { label: "Normal (5,000)", value: NUM_SIMULATIONS },
+  { label: "Heavy (15,000)", value: 15_000 },
+  { label: "Extreme (50,000)", value: 50_000 },
+];
+
 export const TournamentPredictions = ({ tournament }: { tournament: Tournament }) => {
   const [range, setRange] = useState(2);
   const [yMax, setYMax] = useState(DEFAULT_Y_MAX);
+  const [selectedNumSimulations, setSelectedNumSimulations] = useState<number>(NUM_SIMULATIONS);
+  const [runNumSimulations, setRunNumSimulations] = useState<number>(NUM_SIMULATIONS);
 
   const { startSimulation, simulationTimes, predictionResults, simulationIsDone, simulationProgress } =
     useTournamentPredictionWorker();
@@ -62,13 +70,13 @@ export const TournamentPredictions = ({ tournament }: { tournament: Tournament }
       // If we have data for this time, fill in the player percentages
       if (result) {
         Object.keys(result.players).forEach((playerId) => {
-          dataPoint[playerId] = (result.players[playerId].wins / NUM_SIMULATIONS) * 100;
+          dataPoint[playerId] = (result.players[playerId].wins / runNumSimulations) * 100;
         });
       }
 
       return dataPoint;
     });
-  }, [simulationTimes, predictionResults]);
+  }, [simulationTimes, predictionResults, runNumSimulations]);
 
   const [graphDataToSee, setGraphDataToSee] = useState<Record<string, number | string>[]>(graphData);
 
@@ -100,7 +108,8 @@ export const TournamentPredictions = ({ tournament }: { tournament: Tournament }
   }, [predictionResults]);
 
   const handleSimulate = () => {
-    startSimulation(tournament.id);
+    setRunNumSimulations(selectedNumSimulations);
+    startSimulation(tournament.id, selectedNumSimulations);
   };
 
   return (
@@ -108,14 +117,25 @@ export const TournamentPredictions = ({ tournament }: { tournament: Tournament }
       <section className="flex flex-col items-center bg-primary-background rounded-lg w-full max-w-[1050px]">
         {/* Simulate Button */}
         {predictionResults.length === 0 && (
-          <>
+          <div className="mb-4 flex items-center gap-2">
+            <select
+              value={selectedNumSimulations}
+              onChange={(e) => setSelectedNumSimulations(parseInt(e.target.value, 10))}
+              className="px-3 py-2 bg-secondary-background text-secondary-text font-medium rounded-lg"
+            >
+              {SIMULATION_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
             <button
               onClick={handleSimulate}
-              className="mb-4 px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
+              className="px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors"
             >
               Run Simulation
             </button>
-          </>
+          </div>
         )}
 
         {/* Graph Controls and Display */}
@@ -230,7 +250,7 @@ export const TournamentPredictions = ({ tournament }: { tournament: Tournament }
         </div>
       </section>
       {predictionResults.length > 0 && (
-        <LatestPredictionTable predictionResults={predictionResults} />
+        <LatestPredictionTable predictionResults={predictionResults} numSimulations={runNumSimulations} />
       )}
     </div>
   );
@@ -238,8 +258,10 @@ export const TournamentPredictions = ({ tournament }: { tournament: Tournament }
 
 const LatestPredictionTable = ({
   predictionResults,
+  numSimulations,
 }: {
   predictionResults: { time: number; players: Record<string, { wins: number }>; confidence: number }[];
+  numSimulations: number;
 }) => {
   const context = useEventDbContext();
 
@@ -252,7 +274,7 @@ const LatestPredictionTable = ({
       playerId,
       name: context.playerName(playerId),
       wins,
-      winPct: (wins / NUM_SIMULATIONS) * 100,
+      winPct: (wins / numSimulations) * 100,
     }))
     .sort((a, b) => b.winPct - a.winPct);
 
@@ -312,7 +334,7 @@ const LatestPredictionTable = ({
         </table>
       </div>
       <p className="text-xs md:text-sm text-primary-text/50 mt-2">
-        Confidence: {(latest.confidence * 100).toFixed(1)}% &middot; {NUM_SIMULATIONS.toLocaleString()} simulations
+        Confidence: {(latest.confidence * 100).toFixed(1)}% &middot; {numSimulations.toLocaleString()} simulations
       </p>
     </section>
   );


### PR DESCRIPTION
Users can now choose Normal (5,000), Heavy (15,000), or Extreme (50,000)
iterations via a native dropdown on the tournament predictions tab. The
dropdown is hidden once the simulation starts.

https://claude.ai/code/session_01ARW88WeayU1u351zdRWdWs