### PR TITLE
Add 1M iteration "Melt your pc" option to tournament predictions

### DIFF
--- a/frontend/src/pages/tournament/tournament-predictions.tsx
+++ b/frontend/src/pages/tournament/tournament-predictions.tsx
@@ -19,6 +19,7 @@ const SIMULATION_OPTIONS: { label: string; value: number }[] = [
   { label: "Normal (5,000)", value: NUM_SIMULATIONS },
   { label: "Heavy (15,000)", value: 15_000 },
   { label: "Extreme (50,000)", value: 50_000 },
+  { label: "Melt your pc (1,000,000)", value: 1_000_000 },
 ];
 
 export const TournamentPredictions = ({ tournament }: { tournament: Tournament }) => {


### PR DESCRIPTION
## Summary
- Adds a fourth simulation iteration option, "Melt your pc (1,000,000)", to the tournament predictions dropdown.

Builds on top of `claude/add-iteration-selector-0TB0f`.

## Test plan
- [ ] Open the tournament predictions tab and verify "Melt your pc (1,000,000)" appears in the dropdown alongside Normal/Heavy/Extreme.
- [ ] Select the new option and start a simulation; confirm it runs with 1,000,000 iterations and the dropdown hides once the simulation starts.
- [ ] Verify win % and "1,000,000 simulations" label in the latest prediction table are correct after completion.

https://claude.ai/code/session_01ARW88WeayU1u351zdRWdWs