### PR TITLE
Add public and admin live-game pages

### DIFF
--- a/DenoServer/auth-service/auth-handler.ts
+++ b/DenoServer/auth-service/auth-handler.ts
@@ -11,6 +11,7 @@ const resources = {
   roles: ["write"],
   event: ["manage"],
   tournament: ["create", "update", "delete"],
+  "live-game": ["update"],
 } as const;
 
 const roles: Record<string, { resource: string; actions: "*" | string[] }[]> = {
@@ -21,6 +22,7 @@ const roles: Record<string, { resource: string; actions: "*" | string[] }[]> = {
     { resource: "user", actions: "*" },
     { resource: "event", actions: "*" },
     { resource: "tournament", actions: "*" },
+    { resource: "live-game", actions: "*" },
   ],
 };
 

--- a/DenoServer/live-game/live-game.routes.ts
+++ b/DenoServer/live-game/live-game.routes.ts
@@ -4,17 +4,11 @@ import { clearLiveGame, getLiveGame, LiveGameState, setLiveGame } from "./live-g
 import { webSocketClientManager } from "../server.ts";
 
 export function registerLiveGameRoutes(api: Router) {
-  /**
-   * Get the current live game state. Public.
-   */
   api.get("/live-game", async (context) => {
     const state = await getLiveGame();
     context.response.body = state;
   });
 
-  /**
-   * Update the live game state. Admin only.
-   */
   api.put("/live-game", async (context) => {
     if ((await hasAccess(context, "live-game", "update")) === false) {
       context.response.status = 403;
@@ -29,9 +23,6 @@ export function registerLiveGameRoutes(api: Router) {
     context.response.body = updated;
   });
 
-  /**
-   * Clear the current live game. Admin only.
-   */
   api.delete("/live-game", async (context) => {
     if ((await hasAccess(context, "live-game", "update")) === false) {
       context.response.status = 403;

--- a/DenoServer/live-game/live-game.routes.ts
+++ b/DenoServer/live-game/live-game.routes.ts
@@ -1,0 +1,45 @@
+import { Router } from "oak";
+import { hasAccess } from "../auth-service/middleware.ts";
+import { clearLiveGame, getLiveGame, LiveGameState, setLiveGame } from "./live-game.ts";
+import { webSocketClientManager } from "../server.ts";
+
+export function registerLiveGameRoutes(api: Router) {
+  /**
+   * Get the current live game state. Public.
+   */
+  api.get("/live-game", async (context) => {
+    const state = await getLiveGame();
+    context.response.body = state;
+  });
+
+  /**
+   * Update the live game state. Admin only.
+   */
+  api.put("/live-game", async (context) => {
+    if ((await hasAccess(context, "live-game", "update")) === false) {
+      context.response.status = 403;
+      return;
+    }
+
+    const payload = (await context.request.body.json()) as LiveGameState;
+    const updated: LiveGameState = { ...payload, updatedAt: Date.now() };
+    await setLiveGame(updated);
+    webSocketClientManager.broadcastLiveGame();
+    context.response.status = 200;
+    context.response.body = updated;
+  });
+
+  /**
+   * Clear the current live game. Admin only.
+   */
+  api.delete("/live-game", async (context) => {
+    if ((await hasAccess(context, "live-game", "update")) === false) {
+      context.response.status = 403;
+      return;
+    }
+
+    await clearLiveGame();
+    webSocketClientManager.broadcastLiveGame();
+    context.response.status = 204;
+  });
+}

--- a/DenoServer/live-game/live-game.ts
+++ b/DenoServer/live-game/live-game.ts
@@ -1,0 +1,34 @@
+import { kv } from "../db.ts";
+
+export type SetPoint = {
+  player1: number;
+  player2: number;
+};
+
+export type LiveGameState = {
+  player1Id: string | null;
+  player2Id: string | null;
+  setsWon: {
+    player1: number;
+    player2: number;
+  };
+  currentSet: SetPoint;
+  completedSets: SetPoint[];
+  startedAt: number | null;
+  updatedAt: number;
+};
+
+const LIVE_GAME_KEY = ["live-game"];
+
+export async function getLiveGame(): Promise<LiveGameState | null> {
+  const result = await kv.get<LiveGameState>(LIVE_GAME_KEY);
+  return result.value;
+}
+
+export async function setLiveGame(state: LiveGameState): Promise<void> {
+  await kv.set(LIVE_GAME_KEY, state);
+}
+
+export async function clearLiveGame(): Promise<void> {
+  await kv.delete(LIVE_GAME_KEY);
+}

--- a/DenoServer/server.ts
+++ b/DenoServer/server.ts
@@ -6,6 +6,7 @@ import { WebSocketClientManager } from "./web-socket/web-socket-client-manager.t
 import { registerEventStoreRoutes } from "./event-store/event-store.routes.ts";
 import { registerMigrationsRoutes } from "./migrations/migrations.routes.ts";
 import { registerImageKitRoutes } from "./image-kit/image-kit.routes.ts";
+import { registerLiveGameRoutes } from "./live-game/live-game.routes.ts";
 
 // Start background services
 import "./integrations/gamebot/poller.ts";
@@ -37,6 +38,7 @@ registerWebSocketRoutes(api);
 registerUserRoutes(api);
 
 registerEventStoreRoutes(api);
+registerLiveGameRoutes(api);
 
 app.use(api.routes());
 app.use(api.allowedMethods());

--- a/DenoServer/web-socket/web-socket-client-manager.ts
+++ b/DenoServer/web-socket/web-socket-client-manager.ts
@@ -8,6 +8,7 @@ enum WS_MESSAGE {
   CONNECTION_ID = "connection-id",
   HEART_BEAT = "heart-beat",
   LATEST_EVENT = "latest-event",
+  LIVE_GAME = "live-game",
 }
 
 export class WebSocketClientManager {
@@ -145,6 +146,14 @@ export class WebSocketClientManager {
    */
   broadcastRefetch() {
     this.broadcastMessage(WS_MESSAGE.LATEST_EVENT + ":999999999999999");
+  }
+
+  /**
+   * Notify all clients that the live game state has changed.
+   * Clients should refetch `/live-game` to get the new state.
+   */
+  broadcastLiveGame() {
+    this.broadcastMessage(WS_MESSAGE.LIVE_GAME + ":" + Date.now());
   }
 
   /**

--- a/DenoServer/web-socket/web-socket-client-manager.ts
+++ b/DenoServer/web-socket/web-socket-client-manager.ts
@@ -153,7 +153,7 @@ export class WebSocketClientManager {
    * Clients should refetch `/live-game` to get the new state.
    */
   broadcastLiveGame() {
-    this.broadcastMessage(WS_MESSAGE.LIVE_GAME + ":" + Date.now());
+    this.broadcastMessage(WS_MESSAGE.LIVE_GAME);
   }
 
   /**

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -46,6 +46,8 @@ import { SeasonPlayerPage } from "./pages/seasons/season-player-page";
 import { RecentGamesPage } from "./pages/recent-games/recent-games-page";
 import { HallOfFamePage } from "./pages/hall-of-fame/hall-of-fame-page";
 import { HallOfFamePlayerPage } from "./pages/hall-of-fame/hall-of-fame-player-page";
+import { LiveGamePage } from "./pages/live-game/live-game-page";
+import { LiveGameAdminPage } from "./pages/live-game/live-game-admin-page";
 
 const RequireAuth: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   if (!session.isAuthenticated) {
@@ -93,6 +95,15 @@ function App() {
                           <Route path="list" element={<SeasonsListPage />} />
                           <Route path="player" element={<SeasonPlayerPage />} />
                         </Route>
+                        <Route path="/live-game" element={<LiveGamePage />} />
+                        <Route
+                          path="/live-game/admin"
+                          element={
+                            <RequireAuth>
+                              <LiveGameAdminPage />
+                            </RequireAuth>
+                          }
+                        />
                         <Route path="/recent-games" element={<RecentGamesPage />} />
                         <Route path="/achievements" element={<AchievementsPage />} />
                         <Route path="/hall-of-fame">

--- a/frontend/src/hooks/use-web-socket.tsx
+++ b/frontend/src/hooks/use-web-socket.tsx
@@ -6,6 +6,7 @@ export enum WS_MESSAGE {
   CONNECTION_ID = "connection-id",
   HEART_BEAT = "heart-beat",
   LATEST_EVENT = "latest-event",
+  LIVE_GAME = "live-game",
 }
 
 export const useWebSocket = (

--- a/frontend/src/pages/live-game/completed-sets-list.tsx
+++ b/frontend/src/pages/live-game/completed-sets-list.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { classNames } from "../../common/class-names";
+import { LiveGameSetPoint } from "./live-game-types";
+
+export const CompletedSetsList: React.FC<{ sets: LiveGameSetPoint[] }> = ({ sets }) => {
+  if (sets.length === 0) return null;
+
+  return (
+    <div className="bg-white rounded-xl shadow-lg p-4 text-black">
+      <h3 className="text-gray-400 text-xs uppercase tracking-widest font-bold mb-3">
+        Completed Sets
+      </h3>
+      <div className="space-y-2">
+        {sets.map((set, index) => {
+          const setWinner = set.player1 > set.player2 ? 1 : 2;
+          return (
+            <div
+              key={index}
+              className="flex items-center justify-between p-3 bg-gray-50 rounded-lg text-sm"
+            >
+              <span className="font-semibold text-gray-700">Set {index + 1}</span>
+              <div className="flex items-center gap-3">
+                <div className="w-5 text-right">{setWinner === 1 && "🏆"}</div>
+                <div className="w-16 flex items-center justify-between text-lg">
+                  <span
+                    className={classNames(
+                      "font-bold",
+                      setWinner === 1 ? "text-blue-600" : "text-gray-400",
+                    )}
+                  >
+                    {set.player1}
+                  </span>
+                  <span className="text-gray-400">-</span>
+                  <span
+                    className={classNames(
+                      "font-bold",
+                      setWinner === 2 ? "text-purple-600" : "text-gray-400",
+                    )}
+                  >
+                    {set.player2}
+                  </span>
+                </div>
+                <div className="w-5">{setWinner === 2 && "🏆"}</div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/live-game/live-game-admin-page.tsx
+++ b/frontend/src/pages/live-game/live-game-admin-page.tsx
@@ -20,32 +20,36 @@ import {
   useUpdateLiveGameMutation,
 } from "./use-live-game";
 import { emptyLiveGame, LiveGameSetPoint, LiveGameState } from "./live-game-types";
+import { CompletedSetsList } from "./completed-sets-list";
 
 export const LiveGameAdminPage: React.FC = () => {
   const context = useEventDbContext();
   const navigate = useNavigate();
   const addEventMutation = useEventMutation();
 
-  const liveGameQuery = useLiveGameQuery({ refetchIntervalMs: 5_000 });
+  // Admin is the source of truth for writes — fetch once on mount, no polling.
+  const liveGameQuery = useLiveGameQuery({ refetchIntervalMs: false });
   const updateLiveGame = useUpdateLiveGameMutation();
   const clearLiveGame = useClearLiveGameMutation();
 
-  const [localState, setLocalState] = useState<LiveGameState>(emptyLiveGame);
-  const [syncedFromServer, setSyncedFromServer] = useState(false);
+  const [localState, setLocalState] = useState<LiveGameState | null>(null);
   const [validationError, setValidationError] = useState<string>("");
-  const [isSubmitting, setIsSubmitting] = useState(false);
 
   useEffect(() => {
-    if (!syncedFromServer && liveGameQuery.data !== undefined) {
+    if (localState === null && liveGameQuery.isSuccess) {
       setLocalState(liveGameQuery.data ?? emptyLiveGame);
-      setSyncedFromServer(true);
     }
-  }, [liveGameQuery.data, syncedFromServer]);
+  }, [localState, liveGameQuery.isSuccess, liveGameQuery.data]);
 
   if (session.sessionData?.role !== "admin") {
     return <div className="p-4">Not authorized</div>;
   }
 
+  if (localState === null) {
+    return <div className="p-4">Loading…</div>;
+  }
+
+  const isSubmitting = addEventMutation.isPending || clearLiveGame.isPending;
   const isActive = localState.startedAt !== null;
   const hasPlayers = !!localState.player1Id && !!localState.player2Id;
 
@@ -55,103 +59,91 @@ export const LiveGameAdminPage: React.FC = () => {
   }
 
   function setPlayer(slot: 1 | 2, playerId: string | null) {
-    const next: LiveGameState = {
-      ...localState,
+    setLocalState({
+      ...localState!,
       [slot === 1 ? "player1Id" : "player2Id"]: playerId,
-    };
-    setLocalState(next);
+    });
   }
 
   function startMatch() {
     if (!hasPlayers) return;
-    const next: LiveGameState = {
-      ...localState,
+    pushState({
+      ...localState!,
       setsWon: { player1: 0, player2: 0 },
       currentSet: { player1: 0, player2: 0 },
       completedSets: [],
       startedAt: Date.now(),
       updatedAt: Date.now(),
-    };
-    pushState(next);
+    });
   }
 
   function addPoint(player: 1 | 2) {
     const key: keyof LiveGameSetPoint = player === 1 ? "player1" : "player2";
-    const next: LiveGameState = {
-      ...localState,
+    pushState({
+      ...localState!,
       currentSet: {
-        ...localState.currentSet,
-        [key]: localState.currentSet[key] + 1,
-      },
-    };
-    pushState(next);
-  }
-
-  function removePoint(player: 1 | 2) {
-    const key: keyof LiveGameSetPoint = player === 1 ? "player1" : "player2";
-    const next: LiveGameState = {
-      ...localState,
-      currentSet: {
-        ...localState.currentSet,
-        [key]: Math.max(0, localState.currentSet[key] - 1),
-      },
-    };
-    pushState(next);
-  }
-
-  function setWon(player: 1 | 2) {
-    const completed: LiveGameSetPoint = {
-      player1: localState.currentSet.player1,
-      player2: localState.currentSet.player2,
-    };
-    const next: LiveGameState = {
-      ...localState,
-      setsWon: {
-        player1: localState.setsWon.player1 + (player === 1 ? 1 : 0),
-        player2: localState.setsWon.player2 + (player === 2 ? 1 : 0),
-      },
-      completedSets: [...localState.completedSets, completed],
-      currentSet: { player1: 0, player2: 0 },
-    };
-    pushState(next);
-  }
-
-  function resetMatch() {
-    if (!window.confirm("Reset current match score? Players stay selected.")) return;
-    const next: LiveGameState = {
-      ...localState,
-      setsWon: { player1: 0, player2: 0 },
-      currentSet: { player1: 0, player2: 0 },
-      completedSets: [],
-      startedAt: localState.startedAt,
-      updatedAt: Date.now(),
-    };
-    pushState(next);
-  }
-
-  function endLiveGame() {
-    if (!window.confirm("End this live game? This clears the public scoreboard.")) return;
-    clearLiveGame.mutate(undefined, {
-      onSuccess: () => {
-        setLocalState(emptyLiveGame);
+        ...localState!.currentSet,
+        [key]: localState!.currentSet[key] + 1,
       },
     });
   }
 
+  function removePoint(player: 1 | 2) {
+    const key: keyof LiveGameSetPoint = player === 1 ? "player1" : "player2";
+    pushState({
+      ...localState!,
+      currentSet: {
+        ...localState!.currentSet,
+        [key]: Math.max(0, localState!.currentSet[key] - 1),
+      },
+    });
+  }
+
+  function setWon(player: 1 | 2) {
+    pushState({
+      ...localState!,
+      setsWon: {
+        player1: localState!.setsWon.player1 + (player === 1 ? 1 : 0),
+        player2: localState!.setsWon.player2 + (player === 2 ? 1 : 0),
+      },
+      completedSets: [...localState!.completedSets, { ...localState!.currentSet }],
+      currentSet: { player1: 0, player2: 0 },
+    });
+  }
+
+  function resetMatch() {
+    if (!window.confirm("Reset current match score? Players stay selected.")) return;
+    pushState({
+      ...localState!,
+      setsWon: { player1: 0, player2: 0 },
+      currentSet: { player1: 0, player2: 0 },
+      completedSets: [],
+      updatedAt: Date.now(),
+    });
+  }
+
+  async function endLiveGame() {
+    if (!window.confirm("End this live game? This clears the public scoreboard.")) return;
+    await clearLiveGame.mutateAsync();
+    setLocalState(emptyLiveGame);
+  }
+
   async function saveAsGame() {
     setValidationError("");
-    if (!localState.player1Id || !localState.player2Id) {
+    if (!localState!.player1Id || !localState!.player2Id) {
       setValidationError("Both players must be selected");
       return;
     }
-    if (localState.setsWon.player1 === localState.setsWon.player2) {
+    if (localState!.setsWon.player1 === localState!.setsWon.player2) {
       setValidationError("Match is tied — complete another set before saving.");
       return;
     }
 
-    const player1WinnerSide = localState.setsWon.player1 > localState.setsWon.player2;
-    const winner = player1WinnerSide ? localState.player1Id : localState.player2Id;
-    const loser = player1WinnerSide ? localState.player2Id : localState.player1Id;
+    const player1Won = localState!.setsWon.player1 > localState!.setsWon.player2;
+    const winner = player1Won ? localState!.player1Id : localState!.player2Id;
+    const loser = player1Won ? localState!.player2Id : localState!.player1Id;
+    const winnerSets = player1Won ? localState!.setsWon.player1 : localState!.setsWon.player2;
+    const loserSets = player1Won ? localState!.setsWon.player2 : localState!.setsWon.player1;
 
     const now = Date.now();
     const gameCreatedEvent: GameCreated = {
@@ -172,15 +164,12 @@ export const LiveGameAdminPage: React.FC = () => {
       time: gameCreatedEvent.time + 1,
       stream: gameCreatedEvent.stream,
       data: {
-        setsWon: {
-          gameWinner: player1WinnerSide ? localState.setsWon.player1 : localState.setsWon.player2,
-          gameLoser: player1WinnerSide ? localState.setsWon.player2 : localState.setsWon.player1,
-        },
+        setsWon: { gameWinner: winnerSets, gameLoser: loserSets },
         setPoints:
-          localState.completedSets.length > 0
-            ? localState.completedSets.map((set) => ({
-                gameWinner: player1WinnerSide ? set.player1 : set.player2,
-                gameLoser: player1WinnerSide ? set.player2 : set.player1,
+          localState!.completedSets.length > 0
+            ? localState!.completedSets.map((set) => ({
+                gameWinner: player1Won ? set.player1 : set.player2,
+                gameLoser: player1Won ? set.player2 : set.player1,
               }))
             : undefined,
       },
@@ -192,22 +181,12 @@ export const LiveGameAdminPage: React.FC = () => {
       return;
     }
 
-    setIsSubmitting(true);
-    try {
-      await addEventMutation.mutateAsync(gameCreatedEvent);
-      await addEventMutation.mutateAsync(gameScoreEvent);
-      await new Promise<void>((resolve) => {
-        clearLiveGame.mutate(undefined, {
-          onSuccess: () => resolve(),
-          onError: () => resolve(),
-        });
-      });
-      setLocalState(emptyLiveGame);
-      queryClient.invalidateQueries();
-      navigate(`/1v1/?player1=${winner}&player2=${loser}`);
-    } finally {
-      setIsSubmitting(false);
-    }
+    await addEventMutation.mutateAsync(gameCreatedEvent);
+    await addEventMutation.mutateAsync(gameScoreEvent);
+    await clearLiveGame.mutateAsync();
+    setLocalState(emptyLiveGame);
+    queryClient.invalidateQueries();
+    navigate(`/1v1/?player1=${winner}&player2=${loser}`);
   }
 
   return (
@@ -286,24 +265,14 @@ export const LiveGameAdminPage: React.FC = () => {
                 score={localState.currentSet.player1}
                 onAdd={() => addPoint(1)}
                 onRemove={() => removePoint(1)}
-                colorClasses={{
-                  bg: "bg-blue-50",
-                  score: "text-blue-600",
-                  addBtn: "bg-blue-600 hover:bg-blue-700",
-                  removeBtn: "bg-blue-400 hover:bg-blue-500",
-                }}
+                variant="player1"
               />
               <PlayerScoreControls
                 name={context.playerName(localState.player2Id)}
                 score={localState.currentSet.player2}
                 onAdd={() => addPoint(2)}
                 onRemove={() => removePoint(2)}
-                colorClasses={{
-                  bg: "bg-purple-50",
-                  score: "text-purple-600",
-                  addBtn: "bg-purple-600 hover:bg-purple-700",
-                  removeBtn: "bg-purple-400 hover:bg-purple-500",
-                }}
+                variant="player2"
               />
             </div>
 
@@ -335,49 +304,7 @@ export const LiveGameAdminPage: React.FC = () => {
             </div>
           </div>
 
-          {localState.completedSets.length > 0 && (
-            <div className="bg-white rounded-xl shadow-lg p-4 text-black">
-              <h3 className="text-gray-400 text-xs uppercase tracking-widest font-bold mb-3">
-                Completed Sets
-              </h3>
-              <div className="space-y-2">
-                {localState.completedSets.map((set, index) => {
-                  const setWinner = set.player1 > set.player2 ? 1 : 2;
-                  return (
-                    <div
-                      key={index}
-                      className="flex items-center justify-between p-3 bg-gray-50 rounded-lg text-sm"
-                    >
-                      <span className="font-semibold text-gray-700">Set {index + 1}</span>
-                      <div className="flex items-center gap-3">
-                        <div className="w-5">{setWinner === 1 && "🏆"}</div>
-                        <div className="w-16 flex items-center justify-between text-lg">
-                          <span
-                            className={classNames(
-                              "font-bold",
-                              setWinner === 1 ? "text-blue-600" : "text-gray-400",
-                            )}
-                          >
-                            {set.player1}
-                          </span>
-                          <span className="text-gray-400">-</span>
-                          <span
-                            className={classNames(
-                              "font-bold",
-                              setWinner === 2 ? "text-purple-600" : "text-gray-400",
-                            )}
-                          >
-                            {set.player2}
-                          </span>
-                        </div>
-                        <div className="w-5">{setWinner === 2 && "🏆"}</div>
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-          )}
+          <CompletedSetsList sets={localState.completedSets} />
 
           {validationError && (
             <div className="p-3 bg-red-100 border border-red-400 text-red-700 rounded-lg text-sm">
@@ -419,39 +346,40 @@ export const LiveGameAdminPage: React.FC = () => {
   );
 };
 
-type ScoreControlsProps = {
+const VARIANT_STYLES = {
+  player1: {
+    bg: "bg-blue-50",
+    score: "text-blue-600",
+    addBtn: "bg-blue-600 hover:bg-blue-700",
+    removeBtn: "bg-blue-400 hover:bg-blue-500",
+  },
+  player2: {
+    bg: "bg-purple-50",
+    score: "text-purple-600",
+    addBtn: "bg-purple-600 hover:bg-purple-700",
+    removeBtn: "bg-purple-400 hover:bg-purple-500",
+  },
+} as const;
+
+const PlayerScoreControls: React.FC<{
   name: string;
   score: number;
   onAdd: () => void;
   onRemove: () => void;
-  colorClasses: {
-    bg: string;
-    score: string;
-    addBtn: string;
-    removeBtn: string;
-  };
-};
-
-const PlayerScoreControls: React.FC<ScoreControlsProps> = ({
-  name,
-  score,
-  onAdd,
-  onRemove,
-  colorClasses,
-}) => {
+  variant: "player1" | "player2";
+}> = ({ name, score, onAdd, onRemove, variant }) => {
+  const styles = VARIANT_STYLES[variant];
   return (
-    <div className={classNames("rounded-lg p-2", colorClasses.bg)}>
+    <div className={classNames("rounded-lg p-2", styles.bg)}>
       <h3 className="text-sm font-semibold text-gray-700 mb-1 text-center truncate">{name}</h3>
       <div className="flex flex-col items-center justify-center gap-2">
-        <div className={classNames("text-5xl font-bold text-center", colorClasses.score)}>
-          {score}
-        </div>
+        <div className={classNames("text-5xl font-bold text-center", styles.score)}>{score}</div>
         <div className="flex flex-col gap-2 w-full items-center">
           <button
             onClick={onAdd}
             className={classNames(
               "w-full max-w-28 aspect-square text-center text-white text-4xl font-bold rounded-lg transition",
-              colorClasses.addBtn,
+              styles.addBtn,
             )}
           >
             +
@@ -463,7 +391,7 @@ const PlayerScoreControls: React.FC<ScoreControlsProps> = ({
               "w-full max-w-28 h-12 text-center rounded-lg transition text-2xl font-bold",
               score === 0
                 ? "bg-gray-300 text-gray-500 cursor-not-allowed"
-                : classNames("text-white", colorClasses.removeBtn),
+                : classNames("text-white", styles.removeBtn),
             )}
           >
             -

--- a/frontend/src/pages/live-game/live-game-admin-page.tsx
+++ b/frontend/src/pages/live-game/live-game-admin-page.tsx
@@ -1,0 +1,475 @@
+import React, { useEffect, useState } from "react";
+import { StepSelectPlayers } from "../add-game/step-select-players";
+import { useEventDbContext } from "../../wrappers/event-db-context";
+import { useEventMutation } from "../../hooks/use-event-mutation";
+import { queryClient } from "../../common/query-client";
+import { useNavigate } from "react-router-dom";
+import {
+  EventTypeEnum,
+  GameCreated,
+  GameScore,
+} from "../../client/client-db/event-store/event-types";
+import { newId } from "../../common/nani-id";
+import { classNames } from "../../common/class-names";
+import { ProfilePicture } from "../player/profile-picture";
+import { stringToColor } from "../../common/string-to-color";
+import { session } from "../../services/auth";
+import {
+  useClearLiveGameMutation,
+  useLiveGameQuery,
+  useUpdateLiveGameMutation,
+} from "./use-live-game";
+import { emptyLiveGame, LiveGameSetPoint, LiveGameState } from "./live-game-types";
+
+export const LiveGameAdminPage: React.FC = () => {
+  const context = useEventDbContext();
+  const navigate = useNavigate();
+  const addEventMutation = useEventMutation();
+
+  const liveGameQuery = useLiveGameQuery({ refetchIntervalMs: 5_000 });
+  const updateLiveGame = useUpdateLiveGameMutation();
+  const clearLiveGame = useClearLiveGameMutation();
+
+  const [localState, setLocalState] = useState<LiveGameState>(emptyLiveGame);
+  const [syncedFromServer, setSyncedFromServer] = useState(false);
+  const [validationError, setValidationError] = useState<string>("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!syncedFromServer && liveGameQuery.data !== undefined) {
+      setLocalState(liveGameQuery.data ?? emptyLiveGame);
+      setSyncedFromServer(true);
+    }
+  }, [liveGameQuery.data, syncedFromServer]);
+
+  if (session.sessionData?.role !== "admin") {
+    return <div className="p-4">Not authorized</div>;
+  }
+
+  const isActive = localState.startedAt !== null;
+  const hasPlayers = !!localState.player1Id && !!localState.player2Id;
+
+  function pushState(next: LiveGameState) {
+    setLocalState(next);
+    updateLiveGame.mutate(next);
+  }
+
+  function setPlayer(slot: 1 | 2, playerId: string | null) {
+    const next: LiveGameState = {
+      ...localState,
+      [slot === 1 ? "player1Id" : "player2Id"]: playerId,
+    };
+    setLocalState(next);
+  }
+
+  function startMatch() {
+    if (!hasPlayers) return;
+    const next: LiveGameState = {
+      ...localState,
+      setsWon: { player1: 0, player2: 0 },
+      currentSet: { player1: 0, player2: 0 },
+      completedSets: [],
+      startedAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    pushState(next);
+  }
+
+  function addPoint(player: 1 | 2) {
+    const key: keyof LiveGameSetPoint = player === 1 ? "player1" : "player2";
+    const next: LiveGameState = {
+      ...localState,
+      currentSet: {
+        ...localState.currentSet,
+        [key]: localState.currentSet[key] + 1,
+      },
+    };
+    pushState(next);
+  }
+
+  function removePoint(player: 1 | 2) {
+    const key: keyof LiveGameSetPoint = player === 1 ? "player1" : "player2";
+    const next: LiveGameState = {
+      ...localState,
+      currentSet: {
+        ...localState.currentSet,
+        [key]: Math.max(0, localState.currentSet[key] - 1),
+      },
+    };
+    pushState(next);
+  }
+
+  function setWon(player: 1 | 2) {
+    const completed: LiveGameSetPoint = {
+      player1: localState.currentSet.player1,
+      player2: localState.currentSet.player2,
+    };
+    const next: LiveGameState = {
+      ...localState,
+      setsWon: {
+        player1: localState.setsWon.player1 + (player === 1 ? 1 : 0),
+        player2: localState.setsWon.player2 + (player === 2 ? 1 : 0),
+      },
+      completedSets: [...localState.completedSets, completed],
+      currentSet: { player1: 0, player2: 0 },
+    };
+    pushState(next);
+  }
+
+  function resetMatch() {
+    if (!window.confirm("Reset current match score? Players stay selected.")) return;
+    const next: LiveGameState = {
+      ...localState,
+      setsWon: { player1: 0, player2: 0 },
+      currentSet: { player1: 0, player2: 0 },
+      completedSets: [],
+      startedAt: localState.startedAt,
+      updatedAt: Date.now(),
+    };
+    pushState(next);
+  }
+
+  function endLiveGame() {
+    if (!window.confirm("End this live game? This clears the public scoreboard.")) return;
+    clearLiveGame.mutate(undefined, {
+      onSuccess: () => {
+        setLocalState(emptyLiveGame);
+      },
+    });
+  }
+
+  async function saveAsGame() {
+    setValidationError("");
+    if (!localState.player1Id || !localState.player2Id) {
+      setValidationError("Both players must be selected");
+      return;
+    }
+    if (localState.setsWon.player1 === localState.setsWon.player2) {
+      setValidationError("Match is tied — complete another set before saving.");
+      return;
+    }
+
+    const player1WinnerSide = localState.setsWon.player1 > localState.setsWon.player2;
+    const winner = player1WinnerSide ? localState.player1Id : localState.player2Id;
+    const loser = player1WinnerSide ? localState.player2Id : localState.player1Id;
+
+    const now = Date.now();
+    const gameCreatedEvent: GameCreated = {
+      type: EventTypeEnum.GAME_CREATED,
+      time: now,
+      stream: newId(),
+      data: { winner, loser, playedAt: now },
+    };
+
+    const validateCreated = context.eventStore.gamesProjector.validateCreateGame(gameCreatedEvent);
+    if (validateCreated.valid === false) {
+      setValidationError(validateCreated.message);
+      return;
+    }
+
+    const gameScoreEvent: GameScore = {
+      type: EventTypeEnum.GAME_SCORE,
+      time: gameCreatedEvent.time + 1,
+      stream: gameCreatedEvent.stream,
+      data: {
+        setsWon: {
+          gameWinner: player1WinnerSide ? localState.setsWon.player1 : localState.setsWon.player2,
+          gameLoser: player1WinnerSide ? localState.setsWon.player2 : localState.setsWon.player1,
+        },
+        setPoints:
+          localState.completedSets.length > 0
+            ? localState.completedSets.map((set) => ({
+                gameWinner: player1WinnerSide ? set.player1 : set.player2,
+                gameLoser: player1WinnerSide ? set.player2 : set.player1,
+              }))
+            : undefined,
+      },
+    };
+
+    const validateScore = context.eventStore.gamesProjector.validateScoreGame(gameScoreEvent);
+    if (validateScore.valid === false) {
+      setValidationError(validateScore.message);
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await addEventMutation.mutateAsync(gameCreatedEvent);
+      await addEventMutation.mutateAsync(gameScoreEvent);
+      await new Promise<void>((resolve) => {
+        clearLiveGame.mutate(undefined, {
+          onSuccess: () => resolve(),
+          onError: () => resolve(),
+        });
+      });
+      setLocalState(emptyLiveGame);
+      queryClient.invalidateQueries();
+      navigate(`/1v1/?player1=${winner}&player2=${loser}`);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-bold text-primary-text">Live Game Admin</h1>
+        <button
+          onClick={() => navigate("/live-game")}
+          className="text-sm px-3 py-1 rounded-md bg-tertiary-background text-tertiary-text hover:bg-tertiary-background/80"
+        >
+          View public
+        </button>
+      </div>
+
+      {!isActive && (
+        <div className="space-y-4">
+          <div className="bg-secondary-background text-secondary-text rounded-lg p-3 text-sm">
+            Select the two players, then press Start to make the game visible on the public /live-game page.
+          </div>
+          <StepSelectPlayers
+            player1={{ id: localState.player1Id, set: (id) => setPlayer(1, id) }}
+            player2={{ id: localState.player2Id, set: (id) => setPlayer(2, id) }}
+          />
+          {hasPlayers && (
+            <button
+              onClick={startMatch}
+              disabled={updateLiveGame.isPending}
+              className="w-full py-3 rounded-lg font-semibold bg-tertiary-background text-tertiary-text hover:bg-tertiary-background/80 disabled:opacity-50"
+            >
+              Start live game
+            </button>
+          )}
+        </div>
+      )}
+
+      {isActive && hasPlayers && (
+        <div className="space-y-4">
+          <div className="bg-white rounded-xl shadow-lg p-4 text-black">
+            <h2 className="text-gray-400 text-xs uppercase tracking-widest font-bold mb-3 text-center">
+              Total Score
+            </h2>
+            <div className="flex justify-center items-center gap-6 mb-2">
+              <div className="flex flex-col items-center gap-1">
+                <ProfilePicture playerId={localState.player1Id} size={50} border={2} />
+                <span
+                  className="font-bold text-sm"
+                  style={{ color: stringToColor(localState.player1Id || "") }}
+                >
+                  {context.playerName(localState.player1Id)}
+                </span>
+              </div>
+              <div className="flex items-center gap-2 bg-gray-50 px-4 py-1 rounded-xl shadow-inner">
+                <span className="text-3xl font-black">{localState.setsWon.player1}</span>
+                <span className="font-bold text-xl">-</span>
+                <span className="text-3xl font-black">{localState.setsWon.player2}</span>
+              </div>
+              <div className="flex flex-col items-center gap-1">
+                <ProfilePicture playerId={localState.player2Id} size={50} border={2} />
+                <span
+                  className="font-bold text-sm"
+                  style={{ color: stringToColor(localState.player2Id || "") }}
+                >
+                  {context.playerName(localState.player2Id)}
+                </span>
+              </div>
+            </div>
+            <h2 className="text-gray-400 text-xs uppercase tracking-widest font-bold mt-4 text-center">
+              Set {localState.completedSets.length + 1}
+            </h2>
+          </div>
+
+          <div className="bg-white rounded-xl shadow-lg p-4 text-black">
+            <div className="grid grid-cols-2 gap-2">
+              <PlayerScoreControls
+                name={context.playerName(localState.player1Id)}
+                score={localState.currentSet.player1}
+                onAdd={() => addPoint(1)}
+                onRemove={() => removePoint(1)}
+                colorClasses={{
+                  bg: "bg-blue-50",
+                  score: "text-blue-600",
+                  addBtn: "bg-blue-600 hover:bg-blue-700",
+                  removeBtn: "bg-blue-400 hover:bg-blue-500",
+                }}
+              />
+              <PlayerScoreControls
+                name={context.playerName(localState.player2Id)}
+                score={localState.currentSet.player2}
+                onAdd={() => addPoint(2)}
+                onRemove={() => removePoint(2)}
+                colorClasses={{
+                  bg: "bg-purple-50",
+                  score: "text-purple-600",
+                  addBtn: "bg-purple-600 hover:bg-purple-700",
+                  removeBtn: "bg-purple-400 hover:bg-purple-500",
+                }}
+              />
+            </div>
+
+            <div className="space-y-2 mt-4">
+              <button
+                onClick={() => setWon(1)}
+                disabled={localState.currentSet.player1 <= localState.currentSet.player2}
+                className={classNames(
+                  "w-full py-3 rounded-lg font-semibold text-base",
+                  localState.currentSet.player1 > localState.currentSet.player2
+                    ? "bg-blue-500 text-white hover:bg-blue-600"
+                    : "bg-gray-300 text-gray-500 cursor-not-allowed",
+                )}
+              >
+                Set won by {context.playerName(localState.player1Id)}
+              </button>
+              <button
+                onClick={() => setWon(2)}
+                disabled={localState.currentSet.player2 <= localState.currentSet.player1}
+                className={classNames(
+                  "w-full py-3 rounded-lg font-semibold text-base",
+                  localState.currentSet.player2 > localState.currentSet.player1
+                    ? "bg-purple-500 text-white hover:bg-purple-600"
+                    : "bg-gray-300 text-gray-500 cursor-not-allowed",
+                )}
+              >
+                Set won by {context.playerName(localState.player2Id)}
+              </button>
+            </div>
+          </div>
+
+          {localState.completedSets.length > 0 && (
+            <div className="bg-white rounded-xl shadow-lg p-4 text-black">
+              <h3 className="text-gray-400 text-xs uppercase tracking-widest font-bold mb-3">
+                Completed Sets
+              </h3>
+              <div className="space-y-2">
+                {localState.completedSets.map((set, index) => {
+                  const setWinner = set.player1 > set.player2 ? 1 : 2;
+                  return (
+                    <div
+                      key={index}
+                      className="flex items-center justify-between p-3 bg-gray-50 rounded-lg text-sm"
+                    >
+                      <span className="font-semibold text-gray-700">Set {index + 1}</span>
+                      <div className="flex items-center gap-3">
+                        <div className="w-5">{setWinner === 1 && "🏆"}</div>
+                        <div className="w-16 flex items-center justify-between text-lg">
+                          <span
+                            className={classNames(
+                              "font-bold",
+                              setWinner === 1 ? "text-blue-600" : "text-gray-400",
+                            )}
+                          >
+                            {set.player1}
+                          </span>
+                          <span className="text-gray-400">-</span>
+                          <span
+                            className={classNames(
+                              "font-bold",
+                              setWinner === 2 ? "text-purple-600" : "text-gray-400",
+                            )}
+                          >
+                            {set.player2}
+                          </span>
+                        </div>
+                        <div className="w-5">{setWinner === 2 && "🏆"}</div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {validationError && (
+            <div className="p-3 bg-red-100 border border-red-400 text-red-700 rounded-lg text-sm">
+              {validationError}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <button
+              onClick={saveAsGame}
+              disabled={isSubmitting}
+              className={classNames(
+                "w-full py-3 rounded-lg font-semibold text-base",
+                isSubmitting
+                  ? "bg-gray-400 text-white cursor-not-allowed"
+                  : "bg-green-600 text-white hover:bg-green-700",
+              )}
+            >
+              {isSubmitting ? "Saving…" : "✅ Save match & end live game"}
+            </button>
+            <button
+              onClick={resetMatch}
+              disabled={isSubmitting}
+              className="w-full py-3 rounded-lg font-semibold bg-gray-200 text-gray-700 hover:bg-gray-300 disabled:opacity-50"
+            >
+              Reset score
+            </button>
+            <button
+              onClick={endLiveGame}
+              disabled={isSubmitting}
+              className="w-full py-3 rounded-lg font-semibold bg-red-100 text-red-700 hover:bg-red-200 disabled:opacity-50"
+            >
+              ❌ End live game (discard)
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+type ScoreControlsProps = {
+  name: string;
+  score: number;
+  onAdd: () => void;
+  onRemove: () => void;
+  colorClasses: {
+    bg: string;
+    score: string;
+    addBtn: string;
+    removeBtn: string;
+  };
+};
+
+const PlayerScoreControls: React.FC<ScoreControlsProps> = ({
+  name,
+  score,
+  onAdd,
+  onRemove,
+  colorClasses,
+}) => {
+  return (
+    <div className={classNames("rounded-lg p-2", colorClasses.bg)}>
+      <h3 className="text-sm font-semibold text-gray-700 mb-1 text-center truncate">{name}</h3>
+      <div className="flex flex-col items-center justify-center gap-2">
+        <div className={classNames("text-5xl font-bold text-center", colorClasses.score)}>
+          {score}
+        </div>
+        <div className="flex flex-col gap-2 w-full items-center">
+          <button
+            onClick={onAdd}
+            className={classNames(
+              "w-full max-w-28 aspect-square text-center text-white text-4xl font-bold rounded-lg transition",
+              colorClasses.addBtn,
+            )}
+          >
+            +
+          </button>
+          <button
+            onClick={onRemove}
+            disabled={score === 0}
+            className={classNames(
+              "w-full max-w-28 h-12 text-center rounded-lg transition text-2xl font-bold",
+              score === 0
+                ? "bg-gray-300 text-gray-500 cursor-not-allowed"
+                : classNames("text-white", colorClasses.removeBtn),
+            )}
+          >
+            -
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/live-game/live-game-page.tsx
+++ b/frontend/src/pages/live-game/live-game-page.tsx
@@ -3,13 +3,18 @@ import { useLiveGameQuery } from "./use-live-game";
 import { useEventDbContext } from "../../wrappers/event-db-context";
 import { ProfilePicture } from "../player/profile-picture";
 import { stringToColor } from "../../common/string-to-color";
-import { classNames } from "../../common/class-names";
 import { Link } from "react-router-dom";
 import { session } from "../../services/auth";
+import { CompletedSetsList } from "./completed-sets-list";
+import { LiveGameSetPoint } from "./live-game-types";
+
+// Fallback poll in case the WebSocket drops — primary updates come from
+// the LIVE_GAME broadcast handled in WebSocketRefetcher.
+const POLL_FALLBACK_MS = 30_000;
 
 export const LiveGamePage: React.FC = () => {
   const context = useEventDbContext();
-  const liveGameQuery = useLiveGameQuery({ refetchIntervalMs: 2_000 });
+  const liveGameQuery = useLiveGameQuery({ refetchIntervalMs: POLL_FALLBACK_MS });
 
   const isAdmin = session.sessionData?.role === "admin";
   const state = liveGameQuery.data;
@@ -59,8 +64,8 @@ type ScoreboardProps = {
   player1Id: string;
   player2Id: string;
   setsWon: { player1: number; player2: number };
-  currentSet: { player1: number; player2: number };
-  completedSets: { player1: number; player2: number }[];
+  currentSet: LiveGameSetPoint;
+  completedSets: LiveGameSetPoint[];
   player1Name: string;
   player2Name: string;
 };
@@ -123,49 +128,7 @@ const LiveScoreboard: React.FC<ScoreboardProps> = ({
         </div>
       </div>
 
-      {completedSets.length > 0 && (
-        <div className="bg-white rounded-xl shadow-lg p-4 text-black">
-          <h3 className="text-gray-400 text-xs uppercase tracking-widest font-bold mb-3">
-            Completed Sets
-          </h3>
-          <div className="space-y-2">
-            {completedSets.map((set, index) => {
-              const setWinner = set.player1 > set.player2 ? 1 : 2;
-              return (
-                <div
-                  key={index}
-                  className="flex items-center justify-between p-3 bg-gray-50 rounded-lg text-sm"
-                >
-                  <span className="font-semibold text-gray-700">Set {index + 1}</span>
-                  <div className="flex items-center gap-3">
-                    <div className="w-5 text-right">{setWinner === 1 && "🏆"}</div>
-                    <div className="w-16 flex items-center justify-between text-lg">
-                      <span
-                        className={classNames(
-                          "font-bold",
-                          setWinner === 1 ? "text-blue-600" : "text-gray-400",
-                        )}
-                      >
-                        {set.player1}
-                      </span>
-                      <span className="text-gray-400">-</span>
-                      <span
-                        className={classNames(
-                          "font-bold",
-                          setWinner === 2 ? "text-purple-600" : "text-gray-400",
-                        )}
-                      >
-                        {set.player2}
-                      </span>
-                    </div>
-                    <div className="w-5">{setWinner === 2 && "🏆"}</div>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      )}
+      <CompletedSetsList sets={completedSets} />
     </div>
   );
 };

--- a/frontend/src/pages/live-game/live-game-page.tsx
+++ b/frontend/src/pages/live-game/live-game-page.tsx
@@ -1,0 +1,171 @@
+import React from "react";
+import { useLiveGameQuery } from "./use-live-game";
+import { useEventDbContext } from "../../wrappers/event-db-context";
+import { ProfilePicture } from "../player/profile-picture";
+import { stringToColor } from "../../common/string-to-color";
+import { classNames } from "../../common/class-names";
+import { Link } from "react-router-dom";
+import { session } from "../../services/auth";
+
+export const LiveGamePage: React.FC = () => {
+  const context = useEventDbContext();
+  const liveGameQuery = useLiveGameQuery({ refetchIntervalMs: 2_000 });
+
+  const isAdmin = session.sessionData?.role === "admin";
+  const state = liveGameQuery.data;
+  const isActive = !!state && !!state.player1Id && !!state.player2Id && state.startedAt !== null;
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto">
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-bold text-primary-text">Live Game</h1>
+        {isAdmin && (
+          <Link
+            to="/live-game/admin"
+            className="text-sm px-3 py-1 rounded-md bg-tertiary-background text-tertiary-text hover:bg-tertiary-background/80"
+          >
+            Admin
+          </Link>
+        )}
+      </div>
+
+      {liveGameQuery.isLoading && (
+        <div className="text-center py-16 text-primary-text/70">Loading…</div>
+      )}
+
+      {!liveGameQuery.isLoading && !isActive && (
+        <div className="bg-secondary-background text-secondary-text rounded-xl p-8 text-center">
+          <p className="text-lg font-semibold">No live game is currently being played.</p>
+          <p className="text-sm mt-2 opacity-80">Check back soon — this page updates automatically.</p>
+        </div>
+      )}
+
+      {isActive && state && (
+        <LiveScoreboard
+          player1Id={state.player1Id!}
+          player2Id={state.player2Id!}
+          setsWon={state.setsWon}
+          currentSet={state.currentSet}
+          completedSets={state.completedSets}
+          player1Name={context.playerName(state.player1Id)}
+          player2Name={context.playerName(state.player2Id)}
+        />
+      )}
+    </div>
+  );
+};
+
+type ScoreboardProps = {
+  player1Id: string;
+  player2Id: string;
+  setsWon: { player1: number; player2: number };
+  currentSet: { player1: number; player2: number };
+  completedSets: { player1: number; player2: number }[];
+  player1Name: string;
+  player2Name: string;
+};
+
+const LiveScoreboard: React.FC<ScoreboardProps> = ({
+  player1Id,
+  player2Id,
+  setsWon,
+  currentSet,
+  completedSets,
+  player1Name,
+  player2Name,
+}) => {
+  return (
+    <div className="space-y-4">
+      <div className="bg-white rounded-xl shadow-lg p-4 text-black">
+        <h2 className="text-gray-400 text-xs uppercase tracking-widest font-bold mb-3 text-center">
+          Match Score
+        </h2>
+        <div className="grid grid-cols-3 items-center gap-2">
+          <div className="flex flex-col items-center gap-2">
+            <ProfilePicture playerId={player1Id} size={80} border={3} />
+            <span
+              className="font-bold text-base text-center truncate max-w-full"
+              style={{ color: stringToColor(player1Id) }}
+            >
+              {player1Name}
+            </span>
+          </div>
+          <div className="flex items-center justify-center gap-2">
+            <span className="text-6xl font-black">{setsWon.player1}</span>
+            <span className="font-bold text-3xl text-gray-400">-</span>
+            <span className="text-6xl font-black">{setsWon.player2}</span>
+          </div>
+          <div className="flex flex-col items-center gap-2">
+            <ProfilePicture playerId={player2Id} size={80} border={3} />
+            <span
+              className="font-bold text-base text-center truncate max-w-full"
+              style={{ color: stringToColor(player2Id) }}
+            >
+              {player2Name}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-xl shadow-lg p-4 text-black">
+        <h2 className="text-gray-400 text-xs uppercase tracking-widest font-bold mb-3 text-center">
+          Current Set {completedSets.length + 1}
+        </h2>
+        <div className="grid grid-cols-2 gap-4">
+          <div className="bg-blue-50 rounded-lg p-4 text-center">
+            <h3 className="text-sm font-semibold text-gray-700 mb-1 truncate">{player1Name}</h3>
+            <div className="text-7xl font-bold text-blue-600">{currentSet.player1}</div>
+          </div>
+          <div className="bg-purple-50 rounded-lg p-4 text-center">
+            <h3 className="text-sm font-semibold text-gray-700 mb-1 truncate">{player2Name}</h3>
+            <div className="text-7xl font-bold text-purple-600">{currentSet.player2}</div>
+          </div>
+        </div>
+      </div>
+
+      {completedSets.length > 0 && (
+        <div className="bg-white rounded-xl shadow-lg p-4 text-black">
+          <h3 className="text-gray-400 text-xs uppercase tracking-widest font-bold mb-3">
+            Completed Sets
+          </h3>
+          <div className="space-y-2">
+            {completedSets.map((set, index) => {
+              const setWinner = set.player1 > set.player2 ? 1 : 2;
+              return (
+                <div
+                  key={index}
+                  className="flex items-center justify-between p-3 bg-gray-50 rounded-lg text-sm"
+                >
+                  <span className="font-semibold text-gray-700">Set {index + 1}</span>
+                  <div className="flex items-center gap-3">
+                    <div className="w-5 text-right">{setWinner === 1 && "🏆"}</div>
+                    <div className="w-16 flex items-center justify-between text-lg">
+                      <span
+                        className={classNames(
+                          "font-bold",
+                          setWinner === 1 ? "text-blue-600" : "text-gray-400",
+                        )}
+                      >
+                        {set.player1}
+                      </span>
+                      <span className="text-gray-400">-</span>
+                      <span
+                        className={classNames(
+                          "font-bold",
+                          setWinner === 2 ? "text-purple-600" : "text-gray-400",
+                        )}
+                      >
+                        {set.player2}
+                      </span>
+                    </div>
+                    <div className="w-5">{setWinner === 2 && "🏆"}</div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/pages/live-game/live-game-types.ts
+++ b/frontend/src/pages/live-game/live-game-types.ts
@@ -1,0 +1,27 @@
+export type LiveGameSetPoint = {
+  player1: number;
+  player2: number;
+};
+
+export type LiveGameState = {
+  player1Id: string | null;
+  player2Id: string | null;
+  setsWon: {
+    player1: number;
+    player2: number;
+  };
+  currentSet: LiveGameSetPoint;
+  completedSets: LiveGameSetPoint[];
+  startedAt: number | null;
+  updatedAt: number;
+};
+
+export const emptyLiveGame: LiveGameState = {
+  player1Id: null,
+  player2Id: null,
+  setsWon: { player1: 0, player2: 0 },
+  currentSet: { player1: 0, player2: 0 },
+  completedSets: [],
+  startedAt: null,
+  updatedAt: 0,
+};

--- a/frontend/src/pages/live-game/use-live-game.ts
+++ b/frontend/src/pages/live-game/use-live-game.ts
@@ -1,0 +1,52 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { httpClient } from "../../common/http-client";
+import { LiveGameState } from "./live-game-types";
+import { queryClient } from "../../common/query-client";
+
+const LIVE_GAME_QUERY_KEY = ["live-game"];
+
+export function useLiveGameQuery(options?: { refetchIntervalMs?: number }) {
+  return useQuery<LiveGameState | null>({
+    queryKey: LIVE_GAME_QUERY_KEY,
+    queryFn: async () => {
+      const res = await fetch(`${process.env.REACT_APP_API_BASE_URL}/live-game`);
+      if (!res.ok) {
+        throw new Error(`HTTP error ${res.status}: ${res.statusText}`);
+      }
+      const text = await res.text();
+      if (!text) return null;
+      return JSON.parse(text) as LiveGameState;
+    },
+    refetchInterval: options?.refetchIntervalMs ?? 2_000,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+  });
+}
+
+export function useUpdateLiveGameMutation() {
+  return useMutation({
+    mutationFn: async (state: LiveGameState) => {
+      const res = await httpClient(`${process.env.REACT_APP_API_BASE_URL}/live-game`, {
+        method: "PUT",
+        body: JSON.stringify(state),
+      });
+      return (await res.json()) as LiveGameState;
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(LIVE_GAME_QUERY_KEY, data);
+    },
+  });
+}
+
+export function useClearLiveGameMutation() {
+  return useMutation({
+    mutationFn: async () => {
+      await httpClient(`${process.env.REACT_APP_API_BASE_URL}/live-game`, {
+        method: "DELETE",
+      });
+    },
+    onSuccess: () => {
+      queryClient.setQueryData(LIVE_GAME_QUERY_KEY, null);
+    },
+  });
+}

--- a/frontend/src/pages/live-game/use-live-game.ts
+++ b/frontend/src/pages/live-game/use-live-game.ts
@@ -5,7 +5,7 @@ import { queryClient } from "../../common/query-client";
 
 const LIVE_GAME_QUERY_KEY = ["live-game"];
 
-export function useLiveGameQuery(options?: { refetchIntervalMs?: number }) {
+export function useLiveGameQuery(options?: { refetchIntervalMs?: number | false }) {
   return useQuery<LiveGameState | null>({
     queryKey: LIVE_GAME_QUERY_KEY,
     queryFn: async () => {
@@ -17,7 +17,7 @@ export function useLiveGameQuery(options?: { refetchIntervalMs?: number }) {
       if (!text) return null;
       return JSON.parse(text) as LiveGameState;
     },
-    refetchInterval: options?.refetchIntervalMs ?? 2_000,
+    refetchInterval: options?.refetchIntervalMs ?? false,
     refetchOnWindowFocus: true,
     refetchOnReconnect: true,
   });

--- a/frontend/src/wrappers/web-socket-refetcher.tsx
+++ b/frontend/src/wrappers/web-socket-refetcher.tsx
@@ -47,6 +47,10 @@ export const WebSocketRefetcher: React.FC<Props> = ({ children }) => {
       }
       return;
     }
+    if (message.startsWith(WS_MESSAGE.LIVE_GAME)) {
+      queryClient.invalidateQueries({ queryKey: ["live-game"] });
+      return;
+    }
   }
 
   const { webSocket } = useWebSocket(process.env.REACT_APP_API_BASE_URL + "/ws-updates", {


### PR DESCRIPTION
- Public /live-game page shows the active game score and polls every 2s
  (also invalidated by a new WS `live-game` broadcast for low latency)
- Admin /live-game/admin lets admins pick players, start a live game,
  and update the score in real time; each change is pushed to the single
  KV key `["live-game"]` via a new PUT /live-game endpoint
- New DELETE /live-game clears the scoreboard; Save & end also persists
  the finished match as regular GAME_CREATED/GAME_SCORE events
- Adds `live-game` resource with `update` action to the auth model