### PR TITLE
add hall of fame score history graph with tabs

### DIFF
--- a/frontend/src/client/client-db/hall-of-fame.ts
+++ b/frontend/src/client/client-db/hall-of-fame.ts
@@ -1,3 +1,4 @@
+import { EventTypeEnum } from "./event-store/event-types";
 import { TennisTable } from "./tennis-table";
 
 export type SeasonDetail = { rank: number; points: number };
@@ -20,10 +21,16 @@ export type HallOfFameEntry = {
   score: HallOfFameScoreBreakdown;
 };
 
+export type HallOfFameScoreHistoryEntry = {
+  time: number;
+  score: number;
+};
+
 export class HallOfFame {
   private parent: TennisTable;
   private cache: HallOfFameEntry[] | undefined;
   private playerCache = new Map<string, HallOfFameEntry>();
+  private historyCache = new Map<string, HallOfFameScoreHistoryEntry[]>();
 
   constructor(parent: TennisTable) {
     this.parent = parent;
@@ -54,6 +61,49 @@ export class HallOfFame {
   clearCache() {
     this.cache = undefined;
     this.playerCache.clear();
+    this.historyCache.clear();
+  }
+
+  getScoreHistoryForPlayer(playerId: string): HallOfFameScoreHistoryEntry[] {
+    const cached = this.historyCache.get(playerId);
+    if (cached) return cached;
+
+    const player = this.parent.eventStore.playersProjector.getPlayer(playerId);
+    if (!player) return [];
+
+    const playerCreatedEvent = this.parent.events.find(
+      (e) => e.type === EventTypeEnum.PLAYER_CREATED && e.stream === playerId,
+    );
+    if (!playerCreatedEvent) return [];
+
+    const startTime = playerCreatedEvent.time;
+    let endTime: number;
+    if (player.active) {
+      endTime = Date.now();
+    } else {
+      const deactivationEvents = this.parent.events.filter(
+        (e) => e.type === EventTypeEnum.PLAYER_DEACTIVATED && e.stream === playerId,
+      );
+      if (deactivationEvents.length === 0) return [];
+      endTime = deactivationEvents[deactivationEvents.length - 1].time;
+    }
+
+    if (endTime <= startTime) return [];
+
+    const SAMPLES = 50;
+    const step = (endTime - startTime) / (SAMPLES - 1);
+    const history: HallOfFameScoreHistoryEntry[] = [];
+
+    for (let i = 0; i < SAMPLES; i++) {
+      const time = i === SAMPLES - 1 ? endTime : Math.floor(startTime + step * i);
+      const eventsAtTime = this.parent.events.filter((e) => e.time <= time);
+      const snapshotTable = new TennisTable({ events: eventsAtTime });
+      const entry = snapshotTable.hallOfFame.getScoreForAnyPlayer(playerId);
+      history.push({ time, score: entry?.score.total ?? 0 });
+    }
+
+    this.historyCache.set(playerId, history);
+    return history;
   }
 
   #calculateAll(): HallOfFameEntry[] {

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
@@ -1,10 +1,17 @@
 import React from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useParams, useSearchParams } from "react-router-dom";
 import { useEventDbContext } from "../../wrappers/event-db-context";
 import { ProfilePicture } from "../player/profile-picture";
 import { HallOfFameScoreBreakdown } from "../../client/client-db/hall-of-fame";
 import { fmtNum } from "../../common/number-utils";
 import { classNames } from "../../common/class-names";
+import { HallOfFameScoreHistory } from "./hall-of-fame-score-history";
+
+type TabType = "details" | "history";
+const TABS: { id: TabType; label: string }[] = [
+  { id: "details", label: "Details" },
+  { id: "history", label: "History" },
+];
 
 type FactorKey = keyof Omit<HallOfFameScoreBreakdown, "total">;
 
@@ -179,6 +186,16 @@ const FACTORS: { key: FactorKey; emoji: string; name: string }[] = [
 export const HallOfFamePlayerPage: React.FC = () => {
   const { playerId } = useParams<{ playerId: string }>();
   const context = useEventDbContext();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = (searchParams.get("hofTab") as TabType) || "details";
+
+  const setActiveTab = (tab: TabType) => {
+    setSearchParams((prev) => {
+      const newParams = new URLSearchParams(prev);
+      newParams.set("hofTab", tab);
+      return newParams;
+    });
+  };
 
   if (!playerId) {
     return <div className="text-primary-text text-center p-8">Player not found</div>;
@@ -225,58 +242,81 @@ export const HallOfFamePlayerPage: React.FC = () => {
           <h1 className="text-2xl text-primary-text font-semibold">{entry.playerName}</h1>
         </div>
 
-        {/* Score breakdown */}
-        <div className="bg-primary-background rounded-lg p-4">
-          {isActive && (
-            <div className="bg-secondary-background text-secondary-text rounded-lg px-3 py-2 mb-4 text-sm">
-              This is a hypothetical score — {entry.playerName} is still an active player.
-            </div>
-          )}
-          <div className="flex justify-between items-center mb-1">
-            <h2 className="text-xl text-primary-text font-semibold">Hall of Fame Score Breakdown</h2>
-            <span className="text-primary-text font-bold text-2xl">{fmtNum(entry.score.total)} pts</span>
-          </div>
-          <p className="text-primary-text text-sm mb-4">
-            A combined score of everything you accomplished during your career.
-          </p>
-
-          <div className="space-y-6">
-            {segments.map((segment) => (
-              <div key={segment.key} className="ring-1 ring-secondary-background rounded-xl p-3">
-                <div className="flex justify-between items-center mb-1">
-                  <span className="text-primary-text text-sm">
-                    {segment.emoji} {segment.name}
-                  </span>
-                  <span className="text-primary-text font-medium text-sm">
-                    {fmtNum(segment.value)} pts
-                  </span>
-                </div>
-                <div className="w-full bg-secondary-background rounded-full h-6 overflow-hidden">
-                  <div
-                    className="bg-tertiary-background h-6 rounded-full transition-all shadow-md"
-                    style={{
-                      marginLeft: `${segment.startPct}%`,
-                      width: `${segment.widthPct}%`,
-                    }}
-                  />
-                </div>
-                <div className="mt-2">
-                  {renderDetails(entry.score, segment.key)}
-                </div>
-              </div>
+        {/* Tabs */}
+        <div className="bg-secondary-background rounded-lg px-0">
+          <div className="flex space-x-2 overflow-auto">
+            {TABS.map((tab) => (
+              <button
+                key={tab.id}
+                onClick={() => setActiveTab(tab.id)}
+                className={classNames(
+                  "flex items-center py-2 px-4 border-b-4 font-medium text-sm transition-colors",
+                  activeTab === tab.id
+                    ? "text-secondary-text border-secondary-text"
+                    : "text-secondary-text/80 border-transparent hover:text-secondary-text hover:border-secondary-text border-dotted",
+                )}
+              >
+                {tab.label}
+              </button>
             ))}
           </div>
-
-          {/* Total */}
-          <div className="mt-6 pt-4 border-t border-secondary-background flex justify-between items-center">
-            <span className="text-primary-text font-bold text-sm uppercase tracking-wide">
-              Final Hall of Fame Score
-            </span>
-            <span className="text-primary-text font-bold text-2xl">
-              {fmtNum(entry.score.total)} pts
-            </span>
-          </div>
         </div>
+
+        {activeTab === "details" && (
+          <div className="bg-primary-background rounded-lg p-4">
+            {isActive && (
+              <div className="bg-secondary-background text-secondary-text rounded-lg px-3 py-2 mb-4 text-sm">
+                This is a hypothetical score — {entry.playerName} is still an active player.
+              </div>
+            )}
+            <div className="flex justify-between items-center mb-1">
+              <h2 className="text-xl text-primary-text font-semibold">Hall of Fame Score Breakdown</h2>
+              <span className="text-primary-text font-bold text-2xl">{fmtNum(entry.score.total)} pts</span>
+            </div>
+            <p className="text-primary-text text-sm mb-4">
+              A combined score of everything you accomplished during your career.
+            </p>
+
+            <div className="space-y-6">
+              {segments.map((segment) => (
+                <div key={segment.key} className="ring-1 ring-secondary-background rounded-xl p-3">
+                  <div className="flex justify-between items-center mb-1">
+                    <span className="text-primary-text text-sm">
+                      {segment.emoji} {segment.name}
+                    </span>
+                    <span className="text-primary-text font-medium text-sm">
+                      {fmtNum(segment.value)} pts
+                    </span>
+                  </div>
+                  <div className="w-full bg-secondary-background rounded-full h-6 overflow-hidden">
+                    <div
+                      className="bg-tertiary-background h-6 rounded-full transition-all shadow-md"
+                      style={{
+                        marginLeft: `${segment.startPct}%`,
+                        width: `${segment.widthPct}%`,
+                      }}
+                    />
+                  </div>
+                  <div className="mt-2">
+                    {renderDetails(entry.score, segment.key)}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* Total */}
+            <div className="mt-6 pt-4 border-t border-secondary-background flex justify-between items-center">
+              <span className="text-primary-text font-bold text-sm uppercase tracking-wide">
+                Final Hall of Fame Score
+              </span>
+              <span className="text-primary-text font-bold text-2xl">
+                {fmtNum(entry.score.total)} pts
+              </span>
+            </div>
+          </div>
+        )}
+
+        {activeTab === "history" && <HallOfFameScoreHistory playerId={playerId} />}
       </div>
     </div>
   );

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-score-history.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-score-history.tsx
@@ -1,0 +1,146 @@
+import { useMemo } from "react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  TooltipProps,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { NameType, ValueType } from "recharts/types/component/DefaultTooltipContent";
+import { useEventDbContext } from "../../wrappers/event-db-context";
+import { fmtNum } from "../../common/number-utils";
+import { relativeTimeString } from "../../common/date-utils";
+
+type Props = {
+  playerId: string;
+};
+
+export const HallOfFameScoreHistory = ({ playerId }: Props) => {
+  const context = useEventDbContext();
+
+  const history = useMemo(
+    () => context.hallOfFame.getScoreHistoryForPlayer(playerId),
+    [context.hallOfFame, playerId],
+  );
+
+  const chartData = useMemo(() => {
+    return history.map((entry) => {
+      const date = new Date(entry.time);
+      const isToday = date.toDateString() === new Date().toDateString();
+      const timeStr = date.toLocaleTimeString("no-NO", { hour: "2-digit", minute: "2-digit" });
+      const dateStr = date.toLocaleDateString("no-NO", { month: "short", day: "numeric" });
+      return {
+        time: entry.time,
+        name: isToday ? `Today ${timeStr}` : `${dateStr} ${timeStr}`,
+        score: entry.score,
+      };
+    });
+  }, [history]);
+
+  if (history.length === 0) {
+    return (
+      <div className="w-full h-64 flex items-center justify-center bg-primary-background/50 rounded-xl border border-white/10 text-primary-text/50 italic">
+        No score history available for this player.
+      </div>
+    );
+  }
+
+  const latest = chartData[chartData.length - 1];
+  const peak = chartData.reduce((max, e) => (e.score > max.score ? e : max), chartData[0]);
+
+  return (
+    <div className="w-full overflow-hidden bg-primary-background rounded-2xl border border-white/10 p-4 md:p-6 backdrop-blur-sm shadow-2xl">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center justify-between mb-4 md:mb-5">
+        <h2 className="text-lg md:text-xl font-bold text-primary-text flex items-center gap-2 whitespace-nowrap">
+          <span className="w-1.5 h-5 bg-blue-500 rounded-full" />
+          Hall of Fame Score History
+        </h2>
+        <div className="flex items-center gap-1.5 text-primary-text whitespace-nowrap text-[10px] md:text-[11px] font-semibold">
+          <div className="w-2 h-2 rounded-full bg-primary-text" />
+          Score
+        </div>
+      </div>
+
+      <div className="w-full h-[350px] md:h-[450px]">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={chartData} margin={{ top: 5, right: 10, left: -15, bottom: 5 }}>
+            <CartesianGrid
+              strokeDasharray="1 4"
+              vertical={false}
+              stroke="rgb(var(--color-primary-text))"
+              opacity={0.1}
+            />
+            <XAxis
+              dataKey="name"
+              stroke="rgb(var(--color-primary-text))"
+              fontSize={12}
+              tickLine={false}
+              axisLine={false}
+              dy={10}
+              opacity={0.6}
+            />
+            <YAxis
+              type="number"
+              stroke="rgb(var(--color-primary-text))"
+              fontSize={12}
+              tickLine={false}
+              axisLine={false}
+              dx={-5}
+              opacity={0.6}
+            />
+            <Tooltip content={<CustomTooltip />} />
+            <Line
+              type="monotone"
+              dataKey="score"
+              stroke="rgb(var(--color-primary-text))"
+              strokeWidth={3}
+              animationDuration={300}
+              dot={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-4 px-2 py-3 rounded-xl bg-white/5 border border-white/10">
+        <div className="flex items-center gap-1.5">
+          <span className="text-primary-text/50 text-xs font-medium">Current</span>
+          <span className="text-primary-text text-sm font-bold">{fmtNum(latest.score)} pts</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="text-primary-text/50 text-xs font-medium">Peak</span>
+          <span className="text-primary-text text-sm font-bold">{fmtNum(peak.score)} pts</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const CustomTooltip = ({ active, payload }: TooltipProps<ValueType, NameType>) => {
+  if (active && payload && payload.length) {
+    const data = payload[0].payload;
+    const score = payload[0].value as number;
+    return (
+      <div className="bg-primary-background/95 border border-primary-text/20 p-2 rounded-lg shadow-xl backdrop-blur-md">
+        <div className="flex flex-col gap-1.5 min-w-[140px]">
+          <div className="flex items-center justify-between border-b border-primary-text/10 pb-1 mb-0.5">
+            <span className="text-primary-text font-bold text-[11px] truncate pr-2">Score</span>
+            <span className="text-primary-text/40 text-[9px] whitespace-nowrap">
+              {relativeTimeString(new Date(data.time))}
+            </span>
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-1.5">
+              <div className="w-1.5 h-1.5 rounded-full bg-blue-500" />
+              <span className="text-primary-text/80 text-[11px]">Total</span>
+            </div>
+            <span className="text-primary-text font-bold text-[11px]">{fmtNum(score)} pts</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+  return null;
+};


### PR DESCRIPTION
Compute the player's hall of fame score at 50 evenly spaced timestamps
between their creation and either now (active) or their deactivation by
projecting events into a fresh TennisTable snapshot at each timestamp.

Add a tab selector on the player page so users can switch between the
existing score breakdown ("Details") and the new line graph ("History").

https://claude.ai/code/session_01NLaFpEX6UtUW86A4NLdPfk