### PR TITLE
Add "Compared to all" view to hall of fame player page

### DIFF
--- a/frontend/src/client/client-db/hall-of-fame.ts
+++ b/frontend/src/client/client-db/hall-of-fame.ts
@@ -20,10 +20,33 @@ export type HallOfFameEntry = {
   score: HallOfFameScoreBreakdown;
 };
 
+export type HallOfFameFactorKey =
+  | "seasonPerformance"
+  | "achievementsEarned"
+  | "socialDiversity"
+  | "tournamentProgression"
+  | "longevity"
+  | "experience"
+  | "dataVolume";
+
+export type HallOfFameSectionStats = Record<HallOfFameFactorKey, { max: number; rank: number }>;
+
+const FACTOR_KEYS: HallOfFameFactorKey[] = [
+  "seasonPerformance",
+  "achievementsEarned",
+  "socialDiversity",
+  "tournamentProgression",
+  "longevity",
+  "experience",
+  "dataVolume",
+];
+
 export class HallOfFame {
   private parent: TennisTable;
   private cache: HallOfFameEntry[] | undefined;
   private playerCache = new Map<string, HallOfFameEntry>();
+  private sectionMaxes: Record<HallOfFameFactorKey, number> | undefined;
+  private sectionRanks: Record<HallOfFameFactorKey, Map<string, number>> | undefined;
 
   constructor(parent: TennisTable) {
     this.parent = parent;
@@ -51,9 +74,73 @@ export class HallOfFame {
     return entry;
   }
 
+  getSectionStats(playerId: string): HallOfFameSectionStats | undefined {
+    this.#ensureCrossPlayerStats();
+    if (!this.sectionMaxes || !this.sectionRanks) return undefined;
+    const stats = {} as HallOfFameSectionStats;
+    for (const key of FACTOR_KEYS) {
+      stats[key] = {
+        max: this.sectionMaxes[key],
+        rank: this.sectionRanks[key].get(playerId) ?? 0,
+      };
+    }
+    return stats;
+  }
+
   clearCache() {
     this.cache = undefined;
     this.playerCache.clear();
+    this.sectionMaxes = undefined;
+    this.sectionRanks = undefined;
+  }
+
+  #ensureCrossPlayerStats() {
+    if (this.sectionMaxes && this.sectionRanks) return;
+
+    const allPlayers = [
+      ...this.parent.eventStore.playersProjector.activePlayers,
+      ...this.parent.eventStore.playersProjector.inactivePlayers,
+    ];
+
+    const scoresByFactor: Record<HallOfFameFactorKey, { playerId: string; score: number }[]> = {
+      seasonPerformance: [],
+      achievementsEarned: [],
+      socialDiversity: [],
+      tournamentProgression: [],
+      longevity: [],
+      experience: [],
+      dataVolume: [],
+    };
+
+    for (const player of allPlayers) {
+      const breakdown = this.#calculatePlayerScore(player.id);
+      for (const key of FACTOR_KEYS) {
+        scoresByFactor[key].push({ playerId: player.id, score: breakdown[key].score });
+      }
+    }
+
+    const maxes = {} as Record<HallOfFameFactorKey, number>;
+    const ranks = {} as Record<HallOfFameFactorKey, Map<string, number>>;
+
+    for (const key of FACTOR_KEYS) {
+      const sorted = scoresByFactor[key].sort((a, b) => b.score - a.score);
+      maxes[key] = sorted[0]?.score ?? 0;
+
+      const rankMap = new Map<string, number>();
+      let currentRank = 0;
+      let lastScore = Number.POSITIVE_INFINITY;
+      for (let i = 0; i < sorted.length; i++) {
+        if (sorted[i].score !== lastScore) {
+          currentRank = i + 1;
+          lastScore = sorted[i].score;
+        }
+        rankMap.set(sorted[i].playerId, currentRank);
+      }
+      ranks[key] = rankMap;
+    }
+
+    this.sectionMaxes = maxes;
+    this.sectionRanks = ranks;
   }
 
   #calculateAll(): HallOfFameEntry[] {

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-page.tsx
@@ -16,7 +16,7 @@ export const HallOfFamePage: React.FC = () => {
       <div className="bg-primary-background rounded-lg w-full max-w-xl">
         <h1 className="text-2xl text-center text-primary-text mt-4 mb-1">Hall of Fame</h1>
         <p className="text-primary-text text-sm text-center mb-4">
-          Honoring the players who shaped our community through their dedication, competitive spirit, and lasting contributions to the table tennis community.
+          Honoring the retired players who shaped our community through their dedication, competitive spirit, and lasting contributions to the table tennis community.
         </p>
         {entries.length === 0 ? (
           <p className="text-secondary-background text-sm text-center pb-4">No retired players yet.</p>

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
@@ -312,7 +312,7 @@ export const HallOfFamePlayerPage: React.FC = () => {
                     )}
                     {fmtNum(segment.value)} pts
                     {viewMode === "compared" && (
-                      <span className="text-primary-text/70 ml-1.5">/ {fmtNum(segment.max)} max</span>
+                      <span className="text-primary-text/70 ml-1.5">/ {fmtNum(segment.max)}</span>
                     )}
                   </span>
                 </div>

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
@@ -5,6 +5,10 @@ import { ProfilePicture } from "../player/profile-picture";
 import { HallOfFameScoreBreakdown } from "../../client/client-db/hall-of-fame";
 import { fmtNum } from "../../common/number-utils";
 import { classNames } from "../../common/class-names";
+import { useLocalStorage } from "../../hooks/use-local-storage";
+
+type ViewMode = "total" | "compared";
+const VIEW_MODE_STORAGE_KEY = "hall-of-fame-player-view-mode";
 
 type FactorKey = keyof Omit<HallOfFameScoreBreakdown, "total">;
 
@@ -179,6 +183,8 @@ const FACTORS: { key: FactorKey; emoji: string; name: string }[] = [
 export const HallOfFamePlayerPage: React.FC = () => {
   const { playerId } = useParams<{ playerId: string }>();
   const context = useEventDbContext();
+  const [storedViewMode, setStoredViewMode] = useLocalStorage(VIEW_MODE_STORAGE_KEY, "total");
+  const viewMode: ViewMode = storedViewMode === "compared" ? "compared" : "total";
 
   if (!playerId) {
     return <div className="text-primary-text text-center p-8">Player not found</div>;
@@ -203,6 +209,10 @@ export const HallOfFamePlayerPage: React.FC = () => {
     );
   }
 
+  const sectionStats = viewMode === "compared"
+    ? context.hallOfFame.getSectionStats(playerId)
+    : undefined;
+
   const total = entry.score.total || 1;
 
   let cumulative = 0;
@@ -210,7 +220,24 @@ export const HallOfFamePlayerPage: React.FC = () => {
     const value = getFactorScore(entry.score, factor.key);
     const start = cumulative;
     cumulative += value;
-    return { ...factor, value, startPct: (start / total) * 100, widthPct: (value / total) * 100 };
+    const totalStartPct = (start / total) * 100;
+    const totalWidthPct = (value / total) * 100;
+
+    const stat = sectionStats?.[factor.key];
+    const max = stat?.max ?? 0;
+    const comparedWidthPct = max > 0 ? (value / max) * 100 : 0;
+
+    const startPct = viewMode === "compared" ? 0 : totalStartPct;
+    const widthPct = viewMode === "compared" ? comparedWidthPct : totalWidthPct;
+
+    return {
+      ...factor,
+      value,
+      startPct,
+      widthPct,
+      max,
+      rank: stat?.rank ?? 0,
+    };
   });
 
   return (
@@ -240,6 +267,38 @@ export const HallOfFamePlayerPage: React.FC = () => {
             A combined score of everything you accomplished during your career.
           </p>
 
+          <div
+            role="tablist"
+            aria-label="Score view mode"
+            className="inline-flex bg-secondary-background rounded-full p-1 mb-4"
+          >
+            {(
+              [
+                { value: "total" as const, label: "Section of total" },
+                { value: "compared" as const, label: "Compared to all" },
+              ]
+            ).map((option) => {
+              const isActiveOption = viewMode === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="tab"
+                  aria-selected={isActiveOption}
+                  onClick={() => setStoredViewMode(option.value)}
+                  className={classNames(
+                    "px-3 py-1 rounded-full text-xs font-medium transition-colors",
+                    isActiveOption
+                      ? "bg-tertiary-background text-tertiary-text shadow-sm"
+                      : "text-secondary-text hover:text-primary-text",
+                  )}
+                >
+                  {option.label}
+                </button>
+              );
+            })}
+          </div>
+
           <div className="space-y-6">
             {segments.map((segment) => (
               <div key={segment.key} className="ring-1 ring-secondary-background rounded-xl p-3">
@@ -248,7 +307,13 @@ export const HallOfFamePlayerPage: React.FC = () => {
                     {segment.emoji} {segment.name}
                   </span>
                   <span className="text-primary-text font-medium text-sm">
+                    {viewMode === "compared" && segment.rank > 0 && (
+                      <span className="text-primary-text/70 mr-1.5">#{segment.rank} ·</span>
+                    )}
                     {fmtNum(segment.value)} pts
+                    {viewMode === "compared" && (
+                      <span className="text-primary-text/70 ml-1.5">/ {fmtNum(segment.max)} max</span>
+                    )}
                   </span>
                 </div>
                 <div className="w-full bg-secondary-background rounded-full h-6 overflow-hidden">


### PR DESCRIPTION
New segmented toggle lets players see each score section as a bar
relative to the highest score for that section across all players
(active + inactive), with per-section rank and max value displayed.
View choice is persisted in localStorage.