### PR TITLE
Keep deactivated players in Elo scoring so timelines stay stable

### DIFF
--- a/frontend/src/client/client-db/__tests__/tennis-table.test.ts
+++ b/frontend/src/client/client-db/__tests__/tennis-table.test.ts
@@ -249,6 +249,72 @@ describe("TennisTable Basic sanity tests", () => {
 
       expect(activePlayers).toHaveLength(2);
     });
+
+    it("should keep remaining players' Elo stable when another player is deactivated", () => {
+      const threePlayerEvents: EventType[] = [
+        { time: 1000, stream: "player-1", type: EventTypeEnum.PLAYER_CREATED, data: { name: "Alice" } },
+        { time: 1100, stream: "player-2", type: EventTypeEnum.PLAYER_CREATED, data: { name: "Bob" } },
+        { time: 1200, stream: "player-3", type: EventTypeEnum.PLAYER_CREATED, data: { name: "Carol" } },
+        {
+          time: 2000,
+          stream: "game-1",
+          type: EventTypeEnum.GAME_CREATED,
+          data: { playedAt: 2000, winner: "player-1", loser: "player-2" },
+        },
+        {
+          time: 2100,
+          stream: "game-2",
+          type: EventTypeEnum.GAME_CREATED,
+          data: { playedAt: 2100, winner: "player-1", loser: "player-3" },
+        },
+        {
+          time: 2200,
+          stream: "game-3",
+          type: EventTypeEnum.GAME_CREATED,
+          data: { playedAt: 2200, winner: "player-3", loser: "player-2" },
+        },
+      ];
+
+      const before = new TennisTable({ events: threePlayerEvents });
+      const aliceEloBefore = before.leaderboard.getPlayerSummary("player-1").elo;
+      const carolEloBefore = before.leaderboard.getPlayerSummary("player-3").elo;
+
+      const after = new TennisTable({
+        events: [
+          ...threePlayerEvents,
+          { time: 3000, stream: "player-2", type: EventTypeEnum.PLAYER_DEACTIVATED, data: null },
+        ],
+      });
+      const aliceEloAfter = after.leaderboard.getPlayerSummary("player-1").elo;
+      const carolEloAfter = after.leaderboard.getPlayerSummary("player-3").elo;
+
+      expect(aliceEloAfter).toBeCloseTo(aliceEloBefore, 6);
+      expect(carolEloAfter).toBeCloseTo(carolEloBefore, 6);
+    });
+
+    it("should hide deactivated players from the displayed leaderboard but keep their score history counting", () => {
+      const events: EventType[] = [
+        { time: 1000, stream: "player-1", type: EventTypeEnum.PLAYER_CREATED, data: { name: "Alice" } },
+        { time: 1100, stream: "player-2", type: EventTypeEnum.PLAYER_CREATED, data: { name: "Bob" } },
+        {
+          time: 2000,
+          stream: "game-1",
+          type: EventTypeEnum.GAME_CREATED,
+          data: { playedAt: 2000, winner: "player-1", loser: "player-2" },
+        },
+        { time: 3000, stream: "player-2", type: EventTypeEnum.PLAYER_DEACTIVATED, data: null },
+      ];
+
+      const tt = new TennisTable({ events });
+      const board = tt.leaderboard.getLeaderboard();
+
+      expect(board.rankedPlayers.find((p) => p.id === "player-2")).toBeUndefined();
+      expect(board.unrankedPlayers.find((p) => p.id === "player-2")).toBeUndefined();
+      // Bob's loss to Alice still counted against Bob's Elo in the map
+      const bobSummary = tt.leaderboard.getPlayerSummary("player-2");
+      expect(bobSummary.loss).toBe(1);
+      expect(bobSummary.elo).toBeLessThan(1000);
+    });
   });
 
   describe("Game Scores", () => {

--- a/frontend/src/client/client-db/future-elo.ts
+++ b/frontend/src/client/client-db/future-elo.ts
@@ -88,11 +88,16 @@ export class FutureElo {
       }
     }
 
-    // Create all ranked players pairings
+    // Create all ranked players pairings. Predicted/simulated games are only generated between
+    // currently active players, even though the historical games loop above keeps deactivated
+    // players in the map so their results still feed into win-fraction calculations.
     const rankedPlayeIds: string[] = [];
-    this.playersMap.forEach(
-      (player) => player.totalGames >= this.parent.client.gameLimitForRanked && rankedPlayeIds.push(player.id),
-    );
+    this.playersMap.forEach((player) => {
+      const isActive = this.parent.eventStore.playersProjector.getPlayer(player.id)?.active === true;
+      if (player.totalGames >= this.parent.client.gameLimitForRanked && isActive) {
+        rankedPlayeIds.push(player.id);
+      }
+    });
 
     // Create all unique permutations of player pairings
     for (let playerIndex = 0; playerIndex < rankedPlayeIds.length; playerIndex++) {

--- a/frontend/src/client/client-db/individual-points.ts
+++ b/frontend/src/client/client-db/individual-points.ts
@@ -33,12 +33,6 @@ export class IndividualPoints {
   #generatePlayerMap(transactionOrder: "FIFO" | "LIFO") {
     const map = new Map<string, PlayerWithIndividualPoints>();
     for (const game of this.parent.games) {
-      if (
-        !this.parent.eventStore.playersProjector.getPlayer(game.winner)?.active ||
-        !this.parent.eventStore.playersProjector.getPlayer(game.loser)?.active
-      ) {
-        continue; // Skip games with inactive players
-      }
       const winner = this.#getOrCreatePlayer(game.winner, map, game.playedAt);
       const loser = this.#getOrCreatePlayer(game.loser, map, game.playedAt);
       const { losersNewElo } = Elo.calculateELO(winner.totalPoints, loser.totalPoints);

--- a/frontend/src/client/client-db/leaderboard-changes.ts
+++ b/frontend/src/client/client-db/leaderboard-changes.ts
@@ -15,11 +15,13 @@ export class LeaderboardChanges {
     allChanges: { change: number; time: number }[];
   }[] {
     const oneWeekAgo = Date.now() - 1000 * 60 * 60 * 24 * 7;
+    const isActive = (playerId: string) =>
+      this.parent.eventStore.playersProjector.getPlayer(playerId)?.active === true;
 
     const scoreMaps: { time: number; map: Map<string, PlayerWithElo> }[] = [];
     let lastGamesMap: { time: number; map: Map<string, PlayerWithElo> } = { time: 0, map: new Map() };
 
-    Elo.eloCalculator(this.parent.games, this.parent.players, (map, game) => {
+    Elo.eloCalculator(this.parent.games, this.parent.allPlayers, (map, game) => {
       if (game.playedAt > oneWeekAgo) {
         scoreMaps.push({ time: game.playedAt, map: structuredClone(map) });
       } else {
@@ -35,6 +37,7 @@ export class LeaderboardChanges {
     {
       const leaderboard = Array.from(lastGamesMap.map)
         .filter(([, player]) => player.totalGames >= this.parent.client.gameLimitForRanked)
+        .filter(([id]) => isActive(id))
         .map(([, player]) => ({ id: player.id, score: player.elo }))
         .sort((a, b) => b.score - a.score);
       leaderboard.forEach((player, index) => {
@@ -50,6 +53,7 @@ export class LeaderboardChanges {
     scoreMaps.forEach(({ time, map }) => {
       const leaderboard = Array.from(map)
         .filter(([, player]) => player.totalGames >= this.parent.client.gameLimitForRanked)
+        .filter(([id]) => isActive(id))
         .map(([, player]) => ({ id: player.id, score: player.elo }))
         .sort((a, b) => b.score - a.score);
       leaderboard.forEach((player, index) => {

--- a/frontend/src/client/client-db/leaderboard.ts
+++ b/frontend/src/client/client-db/leaderboard.ts
@@ -30,9 +30,12 @@ export class Leaderboard {
 
   private _getLeaderboard(): LeaderboardDTO {
     const leaderboardMap = this.getCachedLeaderboardMap();
+    const isActive = (playerId: string) =>
+      this.parent.eventStore.playersProjector.getPlayer(playerId)?.active === true;
 
     const rankedPlayers: LeaderboardDTO["rankedPlayers"] = Array.from(leaderboardMap.values())
       .filter((player) => player.games.length >= this.parent.client.gameLimitForRanked)
+      .filter((player) => isActive(player.id))
       .sort((a, b) => b.elo - a.elo)
       .map((player, index) => ({
         ...player,
@@ -41,6 +44,7 @@ export class Leaderboard {
 
     const unrankedPlayers: LeaderboardDTO["unrankedPlayers"] = Array.from(leaderboardMap.values())
       .filter((player) => player.games.length < this.parent.client.gameLimitForRanked)
+      .filter((player) => isActive(player.id))
       .sort((a, b) => b.elo - a.elo);
 
     return {
@@ -103,10 +107,16 @@ export class Leaderboard {
 
     const playerIsRanked = player.games.length >= this.parent.client.gameLimitForRanked;
 
+    const isActive = (playerId: string) =>
+      this.parent.eventStore.playersProjector.getPlayer(playerId)?.active === true;
     const playersWithHigherElo = Array.from(leaderboardMap.values()).reduce(
       (acc, otherPlayer) =>
         (acc +=
-          otherPlayer.games.length >= this.parent.client.gameLimitForRanked && otherPlayer.elo > player.elo ? 1 : 0),
+          otherPlayer.games.length >= this.parent.client.gameLimitForRanked &&
+          otherPlayer.elo > player.elo &&
+          isActive(otherPlayer.id)
+            ? 1
+            : 0),
       0,
     );
 
@@ -165,7 +175,7 @@ export class Leaderboard {
     players.forEach((player) => (graphEntry[player] = Elo.INITIAL_ELO));
     graphData.push({ ...graphEntry });
 
-    Elo.eloCalculator(this.parent.games, this.parent.players, (map, game) => {
+    Elo.eloCalculator(this.parent.games, this.parent.allPlayers, (map, game) => {
       if (players.includes(game.winner) || players.includes(game.loser)) {
         if (players.includes(game.winner)) {
           const newElo = map.get(game.winner);
@@ -212,7 +222,7 @@ export class Leaderboard {
       return leaderboardMap.get(id)!;
     };
 
-    Elo.eloCalculator(this.parent.games, this.parent.players, (map, game, pointsWon) => {
+    Elo.eloCalculator(this.parent.games, this.parent.allPlayers, (map, game, pointsWon) => {
       const winner = getPlayer(game.winner);
       const loser = getPlayer(game.loser);
       const winnersNewElo = map.get(game.winner)!.elo;

--- a/frontend/src/client/client-db/playerOponentDistribution.ts
+++ b/frontend/src/client/client-db/playerOponentDistribution.ts
@@ -17,7 +17,7 @@ export class PlayerOponentDistribution {
     const playerDiffs: number[] = [];
     const allDiffs: number[] = [];
 
-    Elo.eloCalculator(this.parent.games, this.parent.players, (map, game) => {
+    Elo.eloCalculator(this.parent.games, this.parent.allPlayers, (map, game) => {
       const winnerElo = map.get(game.winner)!.elo;
       const loserElo = map.get(game.loser)!.elo;
       allDiffs.push(winnerElo - loserElo);

--- a/frontend/src/client/client-db/predictions-history.ts
+++ b/frontend/src/client/client-db/predictions-history.ts
@@ -60,6 +60,9 @@ export class PredictionsHistory {
         if (oponentId === playerId) {
           return;
         }
+        if (this.parent.eventStore.playersProjector.getPlayer(oponentId)?.active !== true) {
+          return;
+        }
         const fraction = this.parent.futureElo.getPredictedFractionForTwoPlayers(playerId, oponentId);
         if (!fraction) {
           return;

--- a/frontend/src/client/client-db/simulations.ts
+++ b/frontend/src/client/client-db/simulations.ts
@@ -37,19 +37,14 @@ export class Simulations {
     expected: { id: string; rank: number; score: number }[];
   } {
     const currentLeaderboard = this.parent.leaderboard.getLeaderboard();
-    const allGamesWithActivePlayers = this.parent.games.filter(
-      (game) =>
-        this.parent.eventStore.playersProjector.getPlayer(game.winner)?.active &&
-        this.parent.eventStore.playersProjector.getPlayer(game.loser)?.active,
-    );
-    const predictedGames = this.parent.futureElo.simulatedGamesForAGivenInputOfGames(allGamesWithActivePlayers);
+    const predictedGames = this.parent.futureElo.simulatedGamesForAGivenInputOfGames(this.parent.games);
 
     const simResultMap = new Map<string, number[]>();
 
     for (let i = 0; i < 5_000; i++) {
       this.shuffleArray(predictedGames);
       // Casting, but its only using winner and loser inside it anyway
-      const eloMap = Elo.eloCalculator(predictedGames as Game[], this.parent.players);
+      const eloMap = Elo.eloCalculator(predictedGames as Game[], this.parent.allPlayers);
       eloMap.forEach((player) => {
         if (simResultMap.has(player.id) === false) {
           simResultMap.set(player.id, []);
@@ -83,31 +78,27 @@ export class Simulations {
     const player = this.parent.eventStore.playersProjector.getPlayer(playerId);
     if (!player) return;
 
-    const allGamesWithActivePlayers = this.parent.games.filter(
-      (game) =>
-        this.parent.eventStore.playersProjector.getPlayer(game.winner)?.active &&
-        this.parent.eventStore.playersProjector.getPlayer(game.loser)?.active,
-    );
+    const allGames = this.parent.games;
 
     const playerGameTimes = new Set<number>();
-    for (let i = 0; i < allGamesWithActivePlayers.length; i++) {
-      const game = allGamesWithActivePlayers[i];
+    for (let i = 0; i < allGames.length; i++) {
+      const game = allGames[i];
       const isPlayedByPlayer = [game.winner, game.loser].includes(playerId);
       if (isPlayedByPlayer) {
         playerGameTimes.add(game.playedAt);
-        const gameBefore = allGamesWithActivePlayers[i - 1];
+        const gameBefore = allGames[i - 1];
         if (gameBefore) {
           playerGameTimes.add(gameBefore.playedAt);
         }
       }
     }
     // Add latest game
-    playerGameTimes.add(allGamesWithActivePlayers[allGamesWithActivePlayers.length - 1].playedAt);
+    playerGameTimes.add(allGames[allGames.length - 1].playedAt);
 
     const sortedPlayerGameTimes = Array.from(playerGameTimes).sort((a, b) => a - b); // Verify ascending
     const playerPlayedTheLastGame =
-      allGamesWithActivePlayers[allGamesWithActivePlayers.length - 1].winner === playerId ||
-      allGamesWithActivePlayers[allGamesWithActivePlayers.length - 1].loser === playerId;
+      allGames[allGames.length - 1].winner === playerId ||
+      allGames[allGames.length - 1].loser === playerId;
 
     const BATCH_SIZE = 1; // 5 seems reasonable but 1 works well on my beast mac and gives smooth frame rate
 
@@ -121,7 +112,7 @@ export class Simulations {
     let eloOverTime: { elo: number; time: number }[] = [];
 
     for (const gameTime of sortedPlayerGameTimes.toReversed()) {
-      const relevantGames = allGamesWithActivePlayers.filter((g) => g.playedAt <= gameTime);
+      const relevantGames = allGames.filter((g) => g.playedAt <= gameTime);
       const predictedGames = this.parent.futureElo.simulatedGamesForAGivenInputOfGames(relevantGames);
 
       const playerElos: number[] = [];
@@ -135,7 +126,7 @@ export class Simulations {
         this.shuffleArray(predictedGames);
         const eloMap = Elo.eloCalculator(
           predictedGames as Game[], // Casting, but its only using winner and loser inside it anyway
-          this.parent.players,
+          this.parent.allPlayers,
         );
         const playerElo = eloMap.get(playerId)?.elo;
         playerElo && playerElos.push(playerElo);

--- a/frontend/src/client/client-db/tennis-table.ts
+++ b/frontend/src/client/client-db/tennis-table.ts
@@ -69,6 +69,14 @@ export class TennisTable {
   get players() {
     return this.eventStore.playersProjector.activePlayers;
   }
+  /** Returns every player ever created, active and deactivated. Used for scoring
+   * so deactivating a player does not retroactively change anyone's Elo. */
+  get allPlayers() {
+    return [
+      ...this.eventStore.playersProjector.activePlayers,
+      ...this.eventStore.playersProjector.inactivePlayers,
+    ];
+  }
   get games() {
     return this.eventStore.gamesProjector.games;
   }

--- a/frontend/src/pages/player-network/player-network.tsx
+++ b/frontend/src/pages/player-network/player-network.tsx
@@ -38,13 +38,7 @@ export const PlayerNetwork: React.FC = () => {
   const { height } = useWindowSize();
   const svgRef = useRef<SVGSVGElement>(null);
   const [matches] = useState<Match[]>(
-    context.games
-      .filter(
-        (g) =>
-          context.eventStore.playersProjector.getPlayer(g.winner)?.active &&
-          context.eventStore.playersProjector.getPlayer(g.loser)?.active,
-      )
-      .map((g) => ({ player1: g.winner, player2: g.loser, winner: g.winner })),
+    context.games.map((g) => ({ player1: g.winner, player2: g.loser, winner: g.winner })),
   );
   const simulationRef = useRef<d3.Simulation<Node, Link> | null>(null);
 


### PR DESCRIPTION
Previously, deactivating a player silently dropped every game they
played from the Elo calculator, retroactively changing every other
player's score. Now scoring always uses the full roster (active +
inactive) so historical Elo is preserved; deactivation only hides the
player from the displayed leaderboard. Simulations still only predict
future games between active ranked players.