### PR TITLE
Add All-Time High Elo factor to Hall of Fame score

### DIFF
--- a/frontend/src/client/client-db/hall-of-fame.ts
+++ b/frontend/src/client/client-db/hall-of-fame.ts
@@ -1,3 +1,4 @@
+import { Elo } from "./elo";
 import { TennisTable } from "./tennis-table";
 
 export type SeasonDetail = { rank: number; points: number };
@@ -11,6 +12,7 @@ export type HallOfFameScoreBreakdown = {
   longevity: { score: number; activeDays: number };
   experience: { score: number; games: number };
   dataVolume: { score: number; gamesWithSets: number; gamesWithPoints: number };
+  peakElo: { score: number; peakElo: number };
   total: number;
 };
 
@@ -27,7 +29,8 @@ export type HallOfFameFactorKey =
   | "tournamentProgression"
   | "longevity"
   | "experience"
-  | "dataVolume";
+  | "dataVolume"
+  | "peakElo";
 
 export type HallOfFameSectionStats = Record<HallOfFameFactorKey, { max: number; rank: number }>;
 
@@ -39,6 +42,7 @@ const FACTOR_KEYS: HallOfFameFactorKey[] = [
   "longevity",
   "experience",
   "dataVolume",
+  "peakElo",
 ];
 
 export class HallOfFame {
@@ -47,6 +51,7 @@ export class HallOfFame {
   private playerCache = new Map<string, HallOfFameEntry>();
   private sectionMaxes: Record<HallOfFameFactorKey, number> | undefined;
   private sectionRanks: Record<HallOfFameFactorKey, Map<string, number>> | undefined;
+  private peakEloCache: Map<string, number> | undefined;
 
   constructor(parent: TennisTable) {
     this.parent = parent;
@@ -92,6 +97,7 @@ export class HallOfFame {
     this.playerCache.clear();
     this.sectionMaxes = undefined;
     this.sectionRanks = undefined;
+    this.peakEloCache = undefined;
   }
 
   #ensureCrossPlayerStats() {
@@ -110,6 +116,7 @@ export class HallOfFame {
       longevity: [],
       experience: [],
       dataVolume: [],
+      peakElo: [],
     };
 
     for (const player of allPlayers) {
@@ -166,10 +173,12 @@ export class HallOfFame {
     const longevity = this.#calcLongevity(playerId);
     const experience = this.#calcExperience(playerId);
     const dataVolume = this.#calcDataVolume(playerId);
+    const peakElo = this.#calcPeakElo(playerId);
 
     const total =
       seasonPerformance.score + achievementsEarned.score + socialDiversity.score +
-      tournamentProgression.score + longevity.score + experience.score + dataVolume.score;
+      tournamentProgression.score + longevity.score + experience.score + dataVolume.score +
+      peakElo.score;
 
     return {
       seasonPerformance,
@@ -179,6 +188,7 @@ export class HallOfFame {
       longevity,
       experience,
       dataVolume,
+      peakElo,
       total: Math.round(total),
     };
   }
@@ -324,5 +334,25 @@ export class HallOfFame {
     }
 
     return { score: gamesWithSets + gamesWithPoints, gamesWithSets, gamesWithPoints };
+  }
+
+  #calcPeakElo(playerId: string): HallOfFameScoreBreakdown["peakElo"] {
+    const peakElo = this.#getPeakElos().get(playerId) ?? Elo.INITIAL_ELO;
+    const score = Math.max(0, peakElo - Elo.INITIAL_ELO);
+    return { score, peakElo };
+  }
+
+  #getPeakElos(): Map<string, number> {
+    if (this.peakEloCache) return this.peakEloCache;
+    const peaks = new Map<string, number>();
+    Elo.eloCalculator(this.parent.games, this.parent.allPlayers, (map, game) => {
+      const winner = map.get(game.winner);
+      if (winner) {
+        const current = peaks.get(winner.id) ?? Elo.INITIAL_ELO;
+        if (winner.elo > current) peaks.set(winner.id, winner.elo);
+      }
+    });
+    this.peakEloCache = peaks;
+    return peaks;
   }
 }

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
@@ -163,6 +163,21 @@ function renderDetails(breakdown: HallOfFameScoreBreakdown, key: FactorKey): Rea
         </div>
       );
     }
+    case "peakElo": {
+      const d = data as HallOfFameScoreBreakdown["peakElo"];
+      return (
+        <div className="text-primary-text text-xs space-y-1.5">
+          <div className="flex flex-wrap gap-1.5">
+            <span className="bg-secondary-background text-secondary-text px-2 py-0.5 rounded text-xs inline-flex items-center gap-1.5">
+              Peak ELO
+              <span className="bg-tertiary-background text-tertiary-text h-5 min-w-5 px-1 rounded-full inline-flex items-center justify-center text-xs font-bold">
+                {fmtNum(d.peakElo)}
+              </span>
+            </span>
+          </div>
+        </div>
+      );
+    }
     default: {
       const _exhaustive: never = key;
       return _exhaustive;
@@ -178,6 +193,7 @@ const FACTORS: { key: FactorKey; emoji: string; name: string }[] = [
   { key: "tournamentProgression", emoji: "🏆", name: "Tournament Performance" },
   { key: "socialDiversity", emoji: "👥", name: "Social Diversity" },
   { key: "achievementsEarned", emoji: "🎖️", name: "Achievements Earned" },
+  { key: "peakElo", emoji: "🔥", name: "All-Time High" },
 ];
 
 export const HallOfFamePlayerPage: React.FC = () => {

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
@@ -186,6 +186,7 @@ function renderDetails(breakdown: HallOfFameScoreBreakdown, key: FactorKey): Rea
 }
 
 const FACTORS: { key: FactorKey; emoji: string; name: string }[] = [
+  { key: "peakElo", emoji: "🔥", name: "All-Time High" },
   { key: "experience", emoji: "🏓", name: "Experience" },
   { key: "dataVolume", emoji: "📊", name: "Data Volume" },
   { key: "longevity", emoji: "📅", name: "Activity" },
@@ -193,7 +194,6 @@ const FACTORS: { key: FactorKey; emoji: string; name: string }[] = [
   { key: "tournamentProgression", emoji: "🏆", name: "Tournament Performance" },
   { key: "socialDiversity", emoji: "👥", name: "Social Diversity" },
   { key: "achievementsEarned", emoji: "🎖️", name: "Achievements Earned" },
-  { key: "peakElo", emoji: "🔥", name: "All-Time High" },
 ];
 
 export const HallOfFamePlayerPage: React.FC = () => {


### PR DESCRIPTION
Adds an 8th factor "peakElo" to the Hall of Fame score breakdown,
scoring 1 point per Elo point a player's peak ever rose above the
starting Elo of 1000. Peaks at or below 1000 contribute 0.