### PR TITLE
Fix Hall of Fame peak ELO calculation for unranked players

### DIFF
--- a/frontend/src/client/client-db/hall-of-fame.ts
+++ b/frontend/src/client/client-db/hall-of-fame.ts
@@ -350,12 +350,14 @@ export class HallOfFame {
     if (this.peakEloCache) return this.peakEloCache;
     const peaks = new Map<string, number>();
     const gameLimitForRanked = this.parent.client.gameLimitForRanked;
+    const trackPeak = (player: { id: string; elo: number; totalGames: number } | undefined) => {
+      if (!player || player.totalGames < gameLimitForRanked) return;
+      const current = peaks.get(player.id);
+      if (current === undefined || player.elo > current) peaks.set(player.id, player.elo);
+    };
     Elo.eloCalculator(this.parent.games, this.parent.allPlayers, (map, game) => {
-      const winner = map.get(game.winner);
-      if (winner && winner.totalGames >= gameLimitForRanked) {
-        const current = peaks.get(winner.id) ?? Elo.INITIAL_ELO;
-        if (winner.elo > current) peaks.set(winner.id, winner.elo);
-      }
+      trackPeak(map.get(game.winner));
+      trackPeak(map.get(game.loser));
     });
     this.peakEloCache = peaks;
     return peaks;

--- a/frontend/src/client/client-db/hall-of-fame.ts
+++ b/frontend/src/client/client-db/hall-of-fame.ts
@@ -337,6 +337,10 @@ export class HallOfFame {
   }
 
   #calcPeakElo(playerId: string): HallOfFameScoreBreakdown["peakElo"] {
+    const summary = this.parent.leaderboard.getPlayerSummary(playerId);
+    if (!summary.isRanked) {
+      return { score: 0, peakElo: 0 };
+    }
     const peakElo = this.#getPeakElos().get(playerId) ?? Elo.INITIAL_ELO;
     const score = Math.max(0, peakElo - Elo.INITIAL_ELO);
     return { score, peakElo };

--- a/frontend/src/client/client-db/hall-of-fame.ts
+++ b/frontend/src/client/client-db/hall-of-fame.ts
@@ -345,9 +345,10 @@ export class HallOfFame {
   #getPeakElos(): Map<string, number> {
     if (this.peakEloCache) return this.peakEloCache;
     const peaks = new Map<string, number>();
+    const gameLimitForRanked = this.parent.client.gameLimitForRanked;
     Elo.eloCalculator(this.parent.games, this.parent.allPlayers, (map, game) => {
       const winner = map.get(game.winner);
-      if (winner) {
+      if (winner && winner.totalGames >= gameLimitForRanked) {
         const current = peaks.get(winner.id) ?? Elo.INITIAL_ELO;
         if (winner.elo > current) peaks.set(winner.id, winner.elo);
       }


### PR DESCRIPTION
## Summary
Fixed the peak ELO calculation in the Hall of Fame to properly handle unranked players and enforce the minimum game requirement for ranked status.

## Key Changes
- Added a check in `#calcPeakElo()` to return zero scores for unranked players before calculating peak ELO
- Modified `#getPeakElos()` to only track peak ELO for players who have met the minimum game requirement (`gameLimitForRanked`)
- Extracted `gameLimitForRanked` as a variable for clarity and consistency

## Implementation Details
The changes ensure that:
1. Players without ranked status are excluded from peak ELO scoring in the Hall of Fame
2. Peak ELO is only calculated for players who have played at least the minimum number of games required for ranked status
3. The ranking threshold is consistently applied across both the score calculation and peak ELO tracking logic

https://claude.ai/code/session_01TKFbs93EqT4qfRZm74L8aT