### PR TITLE
Add Podium Time factor to Hall of Fame score

### DIFF
--- a/frontend/src/client/client-db/__tests__/hall-of-fame/podium-time.test.ts
+++ b/frontend/src/client/client-db/__tests__/hall-of-fame/podium-time.test.ts
@@ -67,12 +67,14 @@ describe("Hall of Fame podium time", () => {
     const d = tt.hallOfFame.getScoreForAnyPlayer("d")?.score.podiumTime;
     const e = tt.hallOfFame.getScoreForAnyPlayer("e")?.score.podiumTime;
 
-    expect(a?.rank1Days).toBe(10);
-    expect(a?.score).toBe(10);
-    expect(b?.rank2Days).toBe(10);
-    expect(b?.score).toBe(5);
-    expect(c?.rank3Days).toBe(10);
-    expect(c?.score).toBe(5);
+    // The podium activates at t=113 (when E becomes ranked, all in day 0)
+    // and runs until the ping at day 10 + tiny offset, so days [0..10] = 11.
+    expect(a?.rank1Days).toBe(11);
+    expect(a?.score).toBe(11);
+    expect(b?.rank2Days).toBe(11);
+    expect(b?.score).toBe(5.5);
+    expect(c?.rank3Days).toBe(11);
+    expect(c?.score).toBe(5.5);
     expect(d?.score).toBe(0);
     expect(e?.score).toBe(0);
   });
@@ -97,13 +99,14 @@ describe("Hall of Fame podium time", () => {
     const c = tt.hallOfFame.getScoreForAnyPlayer("c")?.score.podiumTime;
     const d = tt.hallOfFame.getScoreForAnyPlayer("d")?.score.podiumTime;
 
-    // A, B, C each get 5 days (before C's retirement drops it below 5 ranked).
-    expect(a?.rank1Days).toBe(5);
-    expect(a?.score).toBe(5);
-    expect(b?.rank2Days).toBe(5);
-    expect(b?.score).toBe(2.5);
-    expect(c?.rank3Days).toBe(5);
-    expect(c?.score).toBe(2.5);
+    // Podium runs from t=113 (day 0) until C's retirement at day 5 + tiny,
+    // so days [0..5] = 6 calendar days each at their respective ranks.
+    expect(a?.rank1Days).toBe(6);
+    expect(a?.score).toBe(6);
+    expect(b?.rank2Days).toBe(6);
+    expect(b?.score).toBe(3);
+    expect(c?.rank3Days).toBe(6);
+    expect(c?.score).toBe(3);
     // D never earns podium time — the ranked count drops to 4 the moment
     // C retires.
     expect(d?.score).toBe(0);
@@ -163,8 +166,38 @@ describe("Hall of Fame podium time", () => {
 
     const tt = new TennisTable({ events });
     const a = tt.hallOfFame.getScoreForAnyPlayer("a")?.score.podiumTime;
-    // A should only have ~10 days of podium time (after E got ranked).
-    // Not the 10-day idle stretch where only 4 players were ranked.
-    expect(a?.rank1Days).toBe(10);
+    // Podium starts at day 10 (when E becomes ranked) and runs to day 20
+    // + tiny (the ping) = days [10..20] = 11 calendar days at rank 1.
+    // No credit for the 10-day idle stretch where only 4 players ranked.
+    expect(a?.rank1Days).toBe(11);
+  });
+
+  it("re-opens the podium when a deactivated player is brought back", () => {
+    // After the 5-player setup, all 5 are ranked and A,B,C are on the podium.
+    // C retires after 5 days, dropping the ranked count to 4 and freezing
+    // the podium. 5 days later C is reactivated, restoring 5 ranked players
+    // and re-opening the podium. Another 5 days pass before a ping.
+    const setup = fivePlayerSetup();
+    const lastSetupTime = 119;
+    const retireTime = lastSetupTime + 5 * ONE_DAY;
+    const reactivateTime = lastSetupTime + 10 * ONE_DAY;
+    const futureTime = lastSetupTime + 15 * ONE_DAY;
+    const events: EventType[] = [
+      ...setup,
+      { time: retireTime, stream: "c", type: EventTypeEnum.PLAYER_DEACTIVATED, data: null },
+      { time: reactivateTime, stream: "c", type: EventTypeEnum.PLAYER_REACTIVATED, data: null },
+      game("ping", futureTime, "a", "d"),
+    ];
+
+    const tt = new TennisTable({ events });
+    const a = tt.hallOfFame.getScoreForAnyPlayer("a")?.score.podiumTime;
+    const c = tt.hallOfFame.getScoreForAnyPlayer("c")?.score.podiumTime;
+
+    // A is on the podium across days [0..5] (before retire) and
+    // [10..15] (after reactivate) = 12 unique days.
+    expect(a?.rank1Days).toBe(12);
+    // C is back at #3 across days [10..15] after reactivation = 6 days,
+    // plus the 6 days [0..5] before retirement = 12 unique days.
+    expect(c?.rank3Days).toBe(12);
   });
 });

--- a/frontend/src/client/client-db/__tests__/hall-of-fame/podium-time.test.ts
+++ b/frontend/src/client/client-db/__tests__/hall-of-fame/podium-time.test.ts
@@ -77,10 +77,12 @@ describe("Hall of Fame podium time", () => {
     expect(e?.score).toBe(0);
   });
 
-  it("stops accumulating podium time after a top-3 player is deactivated", () => {
+  it("freezes the podium clock when a deactivation drops the ranked count below 5", () => {
     const setup = fivePlayerSetup();
     const lastSetupTime = 119;
-    // C retires 5 days after setup ends. Next game is 15 days after setup.
+    // C retires 5 days after setup ends. After C is gone only 4 players
+    // are ranked, so the podium clock should stop until the count is back
+    // up to 5 (which never happens in this test).
     const retireTime = lastSetupTime + 5 * ONE_DAY;
     const futureTime = lastSetupTime + 15 * ONE_DAY;
     const events: EventType[] = [
@@ -95,24 +97,21 @@ describe("Hall of Fame podium time", () => {
     const c = tt.hallOfFame.getScoreForAnyPlayer("c")?.score.podiumTime;
     const d = tt.hallOfFame.getScoreForAnyPlayer("d")?.score.podiumTime;
 
-    // A stays at #1 the whole time: 15 days.
-    expect(a?.rank1Days).toBe(15);
-    expect(a?.score).toBe(15);
-    // B stays at #2 the whole time: 15 days at 0.5 = 7.5.
-    expect(b?.rank2Days).toBe(15);
-    expect(b?.score).toBe(7.5);
-    // C is at #3 for 5 days before retiring.
+    // A, B, C each get 5 days (before C's retirement drops it below 5 ranked).
+    expect(a?.rank1Days).toBe(5);
+    expect(a?.score).toBe(5);
+    expect(b?.rank2Days).toBe(5);
+    expect(b?.score).toBe(2.5);
     expect(c?.rank3Days).toBe(5);
     expect(c?.score).toBe(2.5);
-    // D gets promoted to #3 by C's retirement and holds it for 10 days.
-    expect(d?.rank3Days).toBe(10);
-    expect(d?.score).toBe(5);
+    // D never earns podium time — the ranked count drops to 4 the moment
+    // C retires.
+    expect(d?.score).toBe(0);
   });
 
-  it("treats top 3 by position regardless of how many players are ranked", () => {
-    // Only A and B ever play, A always wins. After 5 games both are ranked.
-    // They are the entire podium (A at #1, B at #2). After 10 days a ping
-    // game ticks the clock.
+  it("does not accumulate podium time until 5 players are ranked", () => {
+    // Only A and B ever play. They cross the rank threshold but the league
+    // has fewer than 5 ranked players, so no podium time is earned.
     const events: EventType[] = [
       { time: 1, stream: "a", type: EventTypeEnum.PLAYER_CREATED, data: { name: "A" } },
       { time: 2, stream: "b", type: EventTypeEnum.PLAYER_CREATED, data: { name: "B" } },
@@ -124,12 +123,48 @@ describe("Hall of Fame podium time", () => {
     events.push(game("ping", lastTime + 10 * ONE_DAY, "a", "b"));
 
     const tt = new TennisTable({ events });
-    const a = tt.hallOfFame.getScoreForAnyPlayer("a")?.score.podiumTime;
-    const b = tt.hallOfFame.getScoreForAnyPlayer("b")?.score.podiumTime;
+    expect(tt.hallOfFame.getScoreForAnyPlayer("a")?.score.podiumTime.score).toBe(0);
+    expect(tt.hallOfFame.getScoreForAnyPlayer("b")?.score.podiumTime.score).toBe(0);
+  });
 
+  it("does not credit podium time earned before the 5th player became ranked", () => {
+    // A, B, C, D play a round-robin that ranks all 4 of them. Then a 10-day
+    // gap with no games. E joins late and needs 5 games to become ranked.
+    // Only after E is ranked (i.e. after game 5 of A-vs-E) should the
+    // podium clock start.
+    const events: EventType[] = [
+      { time: 1, stream: "a", type: EventTypeEnum.PLAYER_CREATED, data: { name: "A" } },
+      { time: 2, stream: "b", type: EventTypeEnum.PLAYER_CREATED, data: { name: "B" } },
+      { time: 3, stream: "c", type: EventTypeEnum.PLAYER_CREATED, data: { name: "C" } },
+      { time: 4, stream: "d", type: EventTypeEnum.PLAYER_CREATED, data: { name: "D" } },
+      { time: 5, stream: "e", type: EventTypeEnum.PLAYER_CREATED, data: { name: "E" } },
+    ];
+    const pairs: [string, string][] = [
+      ["a", "b"], ["a", "c"], ["a", "d"],
+      ["b", "c"], ["b", "d"],
+      ["c", "d"],
+    ];
+    let t = 100;
+    for (let round = 0; round < 2; round++) {
+      for (const [winner, loser] of pairs) {
+        events.push(game(`rr-${round}-${winner}-${loser}`, t++, winner, loser));
+      }
+    }
+    // A 10-day idle stretch: A, B, C, D are all ranked but only 4 of them,
+    // so no podium time should accrue.
+    const idleGap = 10 * ONE_DAY;
+    let tE = t + idleGap;
+    // E plays 5 games against A to become ranked.
+    for (let i = 0; i < 5; i++) {
+      events.push(game(`e-${i}`, tE++, "a", "e"));
+    }
+    // Ping the clock 10 days after E is ranked.
+    events.push(game("ping", tE + 10 * ONE_DAY, "a", "b"));
+
+    const tt = new TennisTable({ events });
+    const a = tt.hallOfFame.getScoreForAnyPlayer("a")?.score.podiumTime;
+    // A should only have ~10 days of podium time (after E got ranked).
+    // Not the 10-day idle stretch where only 4 players were ranked.
     expect(a?.rank1Days).toBe(10);
-    expect(a?.score).toBe(10);
-    expect(b?.rank2Days).toBe(10);
-    expect(b?.score).toBe(5);
   });
 });

--- a/frontend/src/client/client-db/__tests__/hall-of-fame/podium-time.test.ts
+++ b/frontend/src/client/client-db/__tests__/hall-of-fame/podium-time.test.ts
@@ -1,0 +1,135 @@
+import { TennisTable } from "../../tennis-table";
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+
+const ONE_DAY = 24 * 60 * 60 * 1000;
+
+describe("Hall of Fame podium time", () => {
+  const game = (id: string, time: number, winner: string, loser: string): EventType => ({
+    time,
+    stream: id,
+    type: EventTypeEnum.GAME_CREATED,
+    data: { playedAt: time, winner, loser },
+  });
+
+  // 5-player double round-robin (20 games). Times 100..119. All 5 ranked
+  // (gameLimitForRanked = 5) with final standings A=1, B=2, C=3, D=4, E=5.
+  const fivePlayerSetup = (): EventType[] => {
+    const events: EventType[] = [
+      { time: 1, stream: "a", type: EventTypeEnum.PLAYER_CREATED, data: { name: "A" } },
+      { time: 2, stream: "b", type: EventTypeEnum.PLAYER_CREATED, data: { name: "B" } },
+      { time: 3, stream: "c", type: EventTypeEnum.PLAYER_CREATED, data: { name: "C" } },
+      { time: 4, stream: "d", type: EventTypeEnum.PLAYER_CREATED, data: { name: "D" } },
+      { time: 5, stream: "e", type: EventTypeEnum.PLAYER_CREATED, data: { name: "E" } },
+    ];
+    const pairs: [string, string][] = [
+      ["a", "b"], ["a", "c"], ["a", "d"], ["a", "e"],
+      ["b", "c"], ["b", "d"], ["b", "e"],
+      ["c", "d"], ["c", "e"],
+      ["d", "e"],
+    ];
+    let t = 100;
+    for (let round = 0; round < 2; round++) {
+      for (const [winner, loser] of pairs) {
+        events.push(game(`g-${round}-${winner}-${loser}`, t++, winner, loser));
+      }
+    }
+    return events;
+  };
+
+  it("gives no podium time when no player is yet ranked", () => {
+    const events: EventType[] = [
+      { time: 1, stream: "a", type: EventTypeEnum.PLAYER_CREATED, data: { name: "A" } },
+      { time: 2, stream: "b", type: EventTypeEnum.PLAYER_CREATED, data: { name: "B" } },
+      game("g1", 100, "a", "b"),
+      game("g2", 100 + 30 * ONE_DAY, "a", "b"),
+    ];
+
+    const tt = new TennisTable({ events });
+    const a = tt.hallOfFame.getScoreForAnyPlayer("a")?.score.podiumTime;
+    expect(a?.score).toBe(0);
+    expect(a?.rank1Days).toBe(0);
+    expect(a?.rank2Days).toBe(0);
+    expect(a?.rank3Days).toBe(0);
+  });
+
+  it("scores 1 pt per day at #1, 0.5 pt per day at #2 and #3", () => {
+    const setup = fivePlayerSetup();
+    const lastSetupTime = 119; // last game time in the round-robin
+    const futureTime = lastSetupTime + 10 * ONE_DAY;
+    // A pings-the-clock game between D and E far in the future. This
+    // doesn't change the top 3 (A, B, C) but advances time by 10 days.
+    const events = [...setup, game("ping", futureTime, "d", "e")];
+
+    const tt = new TennisTable({ events });
+    const a = tt.hallOfFame.getScoreForAnyPlayer("a")?.score.podiumTime;
+    const b = tt.hallOfFame.getScoreForAnyPlayer("b")?.score.podiumTime;
+    const c = tt.hallOfFame.getScoreForAnyPlayer("c")?.score.podiumTime;
+    const d = tt.hallOfFame.getScoreForAnyPlayer("d")?.score.podiumTime;
+    const e = tt.hallOfFame.getScoreForAnyPlayer("e")?.score.podiumTime;
+
+    expect(a?.rank1Days).toBe(10);
+    expect(a?.score).toBe(10);
+    expect(b?.rank2Days).toBe(10);
+    expect(b?.score).toBe(5);
+    expect(c?.rank3Days).toBe(10);
+    expect(c?.score).toBe(5);
+    expect(d?.score).toBe(0);
+    expect(e?.score).toBe(0);
+  });
+
+  it("stops accumulating podium time after a top-3 player is deactivated", () => {
+    const setup = fivePlayerSetup();
+    const lastSetupTime = 119;
+    // C retires 5 days after setup ends. Next game is 15 days after setup.
+    const retireTime = lastSetupTime + 5 * ONE_DAY;
+    const futureTime = lastSetupTime + 15 * ONE_DAY;
+    const events: EventType[] = [
+      ...setup,
+      { time: retireTime, stream: "c", type: EventTypeEnum.PLAYER_DEACTIVATED, data: null },
+      game("ping", futureTime, "a", "d"),
+    ];
+
+    const tt = new TennisTable({ events });
+    const a = tt.hallOfFame.getScoreForAnyPlayer("a")?.score.podiumTime;
+    const b = tt.hallOfFame.getScoreForAnyPlayer("b")?.score.podiumTime;
+    const c = tt.hallOfFame.getScoreForAnyPlayer("c")?.score.podiumTime;
+    const d = tt.hallOfFame.getScoreForAnyPlayer("d")?.score.podiumTime;
+
+    // A stays at #1 the whole time: 15 days.
+    expect(a?.rank1Days).toBe(15);
+    expect(a?.score).toBe(15);
+    // B stays at #2 the whole time: 15 days at 0.5 = 7.5.
+    expect(b?.rank2Days).toBe(15);
+    expect(b?.score).toBe(7.5);
+    // C is at #3 for 5 days before retiring.
+    expect(c?.rank3Days).toBe(5);
+    expect(c?.score).toBe(2.5);
+    // D gets promoted to #3 by C's retirement and holds it for 10 days.
+    expect(d?.rank3Days).toBe(10);
+    expect(d?.score).toBe(5);
+  });
+
+  it("treats top 3 by position regardless of how many players are ranked", () => {
+    // Only A and B ever play, A always wins. After 5 games both are ranked.
+    // They are the entire podium (A at #1, B at #2). After 10 days a ping
+    // game ticks the clock.
+    const events: EventType[] = [
+      { time: 1, stream: "a", type: EventTypeEnum.PLAYER_CREATED, data: { name: "A" } },
+      { time: 2, stream: "b", type: EventTypeEnum.PLAYER_CREATED, data: { name: "B" } },
+    ];
+    for (let i = 0; i < 5; i++) {
+      events.push(game(`g${i}`, 100 + i, "a", "b"));
+    }
+    const lastTime = 104;
+    events.push(game("ping", lastTime + 10 * ONE_DAY, "a", "b"));
+
+    const tt = new TennisTable({ events });
+    const a = tt.hallOfFame.getScoreForAnyPlayer("a")?.score.podiumTime;
+    const b = tt.hallOfFame.getScoreForAnyPlayer("b")?.score.podiumTime;
+
+    expect(a?.rank1Days).toBe(10);
+    expect(a?.score).toBe(10);
+    expect(b?.rank2Days).toBe(10);
+    expect(b?.score).toBe(5);
+  });
+});

--- a/frontend/src/client/client-db/hall-of-fame.ts
+++ b/frontend/src/client/client-db/hall-of-fame.ts
@@ -56,7 +56,7 @@ export class HallOfFame {
   private sectionMaxes: Record<HallOfFameFactorKey, number> | undefined;
   private sectionRanks: Record<HallOfFameFactorKey, Map<string, number>> | undefined;
   private peakEloCache: Map<string, number> | undefined;
-  private podiumMsCache: Map<string, { rank1: number; rank2: number; rank3: number }> | undefined;
+  private podiumMsCache: Map<string, { rank1Days: number; rank2Days: number; rank3Days: number }> | undefined;
 
   constructor(parent: TennisTable) {
     this.parent = parent;
@@ -373,19 +373,19 @@ export class HallOfFame {
   }
 
   #calcPodiumTime(playerId: string): HallOfFameScoreBreakdown["podiumTime"] {
-    const ONE_DAY = 24 * 60 * 60 * 1000;
-    const ms = this.#getPodiumMsByPlayer().get(playerId);
-    const rank1Days = Math.floor((ms?.rank1 ?? 0) / ONE_DAY);
-    const rank2Days = Math.floor((ms?.rank2 ?? 0) / ONE_DAY);
-    const rank3Days = Math.floor((ms?.rank3 ?? 0) / ONE_DAY);
+    const days = this.#getPodiumDaysByPlayer().get(playerId);
+    const rank1Days = days?.rank1Days ?? 0;
+    const rank2Days = days?.rank2Days ?? 0;
+    const rank3Days = days?.rank3Days ?? 0;
     const score = rank1Days + rank2Days * 0.5 + rank3Days * 0.5;
     return { score, rank1Days, rank2Days, rank3Days };
   }
 
-  #getPodiumMsByPlayer(): Map<string, { rank1: number; rank2: number; rank3: number }> {
+  #getPodiumDaysByPlayer(): Map<string, { rank1Days: number; rank2Days: number; rank3Days: number }> {
     if (this.podiumMsCache) return this.podiumMsCache;
-    const result = new Map<string, { rank1: number; rank2: number; rank3: number }>();
+    const ONE_DAY = 24 * 60 * 60 * 1000;
     const gameLimitForRanked = this.parent.client.gameLimitForRanked;
+    const MIN_RANKED_FOR_PODIUM = 5;
 
     type Timeline = { kind: "game"; time: number; winner: string; loser: string }
       | { kind: "activity"; time: number; playerId: string; active: boolean };
@@ -413,7 +413,6 @@ export class HallOfFame {
     const playerState = new Map<string, State>();
     let currentTop3: string[] = [];
     let lastTime: number | undefined;
-    const MIN_RANKED_FOR_PODIUM = 5;
 
     const recomputeTop3 = (): string[] => {
       const ranked = Array.from(playerState.entries())
@@ -425,22 +424,29 @@ export class HallOfFame {
         .map(([id]) => id);
     };
 
-    const creditAt = (playerId: string, rank: 1 | 2 | 3, elapsed: number) => {
-      const existing = result.get(playerId) ?? { rank1: 0, rank2: 0, rank3: 0 };
-      if (rank === 1) existing.rank1 += elapsed;
-      else if (rank === 2) existing.rank2 += elapsed;
-      else existing.rank3 += elapsed;
-      result.set(playerId, existing);
+    // Per player: day index -> best (lowest) rank held on that day.
+    const dayBestRank = new Map<string, Map<number, 1 | 2 | 3>>();
+
+    const recordInterval = (playerId: string, rank: 1 | 2 | 3, tStart: number, tEnd: number) => {
+      if (tEnd <= tStart) return;
+      const dStart = Math.floor(tStart / ONE_DAY);
+      const dEnd = Math.ceil(tEnd / ONE_DAY) - 1;
+      let map = dayBestRank.get(playerId);
+      if (!map) {
+        map = new Map();
+        dayBestRank.set(playerId, map);
+      }
+      for (let d = dStart; d <= dEnd; d++) {
+        const existing = map.get(d);
+        if (existing === undefined || rank < existing) map.set(d, rank);
+      }
     };
 
     for (const entry of timeline) {
       if (lastTime !== undefined && currentTop3.length > 0) {
-        const elapsed = entry.time - lastTime;
-        if (elapsed > 0) {
-          for (let i = 0; i < currentTop3.length; i++) {
-            const rank = (i + 1) as 1 | 2 | 3;
-            creditAt(currentTop3[i], rank, elapsed);
-          }
+        for (let i = 0; i < currentTop3.length; i++) {
+          const rank = (i + 1) as 1 | 2 | 3;
+          recordInterval(currentTop3[i], rank, lastTime, entry.time);
         }
       }
 
@@ -470,6 +476,19 @@ export class HallOfFame {
 
       currentTop3 = recomputeTop3();
       lastTime = entry.time;
+    }
+
+    const result = new Map<string, { rank1Days: number; rank2Days: number; rank3Days: number }>();
+    for (const [playerId, dayMap] of dayBestRank) {
+      let rank1Days = 0;
+      let rank2Days = 0;
+      let rank3Days = 0;
+      for (const rank of dayMap.values()) {
+        if (rank === 1) rank1Days++;
+        else if (rank === 2) rank2Days++;
+        else rank3Days++;
+      }
+      result.set(playerId, { rank1Days, rank2Days, rank3Days });
     }
 
     this.podiumMsCache = result;

--- a/frontend/src/client/client-db/hall-of-fame.ts
+++ b/frontend/src/client/client-db/hall-of-fame.ts
@@ -1,4 +1,5 @@
 import { Elo } from "./elo";
+import { EventTypeEnum } from "./event-store/event-types";
 import { TennisTable } from "./tennis-table";
 
 export type SeasonDetail = { rank: number; points: number };
@@ -13,6 +14,7 @@ export type HallOfFameScoreBreakdown = {
   experience: { score: number; games: number };
   dataVolume: { score: number; gamesWithSets: number; gamesWithPoints: number };
   peakElo: { score: number; peakElo: number };
+  podiumTime: { score: number; rank1Days: number; rank2Days: number; rank3Days: number };
   total: number;
 };
 
@@ -30,7 +32,8 @@ export type HallOfFameFactorKey =
   | "longevity"
   | "experience"
   | "dataVolume"
-  | "peakElo";
+  | "peakElo"
+  | "podiumTime";
 
 export type HallOfFameSectionStats = Record<HallOfFameFactorKey, { max: number; rank: number }>;
 
@@ -43,6 +46,7 @@ const FACTOR_KEYS: HallOfFameFactorKey[] = [
   "experience",
   "dataVolume",
   "peakElo",
+  "podiumTime",
 ];
 
 export class HallOfFame {
@@ -52,6 +56,7 @@ export class HallOfFame {
   private sectionMaxes: Record<HallOfFameFactorKey, number> | undefined;
   private sectionRanks: Record<HallOfFameFactorKey, Map<string, number>> | undefined;
   private peakEloCache: Map<string, number> | undefined;
+  private podiumMsCache: Map<string, { rank1: number; rank2: number; rank3: number }> | undefined;
 
   constructor(parent: TennisTable) {
     this.parent = parent;
@@ -98,6 +103,7 @@ export class HallOfFame {
     this.sectionMaxes = undefined;
     this.sectionRanks = undefined;
     this.peakEloCache = undefined;
+    this.podiumMsCache = undefined;
   }
 
   #ensureCrossPlayerStats() {
@@ -117,6 +123,7 @@ export class HallOfFame {
       experience: [],
       dataVolume: [],
       peakElo: [],
+      podiumTime: [],
     };
 
     for (const player of allPlayers) {
@@ -174,11 +181,12 @@ export class HallOfFame {
     const experience = this.#calcExperience(playerId);
     const dataVolume = this.#calcDataVolume(playerId);
     const peakElo = this.#calcPeakElo(playerId);
+    const podiumTime = this.#calcPodiumTime(playerId);
 
     const total =
       seasonPerformance.score + achievementsEarned.score + socialDiversity.score +
       tournamentProgression.score + longevity.score + experience.score + dataVolume.score +
-      peakElo.score;
+      peakElo.score + podiumTime.score;
 
     return {
       seasonPerformance,
@@ -189,6 +197,7 @@ export class HallOfFame {
       experience,
       dataVolume,
       peakElo,
+      podiumTime,
       total: Math.round(total),
     };
   }
@@ -361,5 +370,105 @@ export class HallOfFame {
     });
     this.peakEloCache = peaks;
     return peaks;
+  }
+
+  #calcPodiumTime(playerId: string): HallOfFameScoreBreakdown["podiumTime"] {
+    const ONE_DAY = 24 * 60 * 60 * 1000;
+    const ms = this.#getPodiumMsByPlayer().get(playerId);
+    const rank1Days = Math.floor((ms?.rank1 ?? 0) / ONE_DAY);
+    const rank2Days = Math.floor((ms?.rank2 ?? 0) / ONE_DAY);
+    const rank3Days = Math.floor((ms?.rank3 ?? 0) / ONE_DAY);
+    const score = rank1Days + rank2Days * 0.5 + rank3Days * 0.5;
+    return { score, rank1Days, rank2Days, rank3Days };
+  }
+
+  #getPodiumMsByPlayer(): Map<string, { rank1: number; rank2: number; rank3: number }> {
+    if (this.podiumMsCache) return this.podiumMsCache;
+    const result = new Map<string, { rank1: number; rank2: number; rank3: number }>();
+    const gameLimitForRanked = this.parent.client.gameLimitForRanked;
+
+    type Timeline = { kind: "game"; time: number; winner: string; loser: string }
+      | { kind: "activity"; time: number; playerId: string; active: boolean };
+
+    const timeline: Timeline[] = [];
+    for (const event of this.parent.events) {
+      switch (event.type) {
+        case EventTypeEnum.PLAYER_CREATED:
+          timeline.push({ kind: "activity", time: event.time, playerId: event.stream, active: true });
+          break;
+        case EventTypeEnum.PLAYER_DEACTIVATED:
+          timeline.push({ kind: "activity", time: event.time, playerId: event.stream, active: false });
+          break;
+        case EventTypeEnum.PLAYER_REACTIVATED:
+          timeline.push({ kind: "activity", time: event.time, playerId: event.stream, active: true });
+          break;
+      }
+    }
+    for (const game of this.parent.games) {
+      timeline.push({ kind: "game", time: game.playedAt, winner: game.winner, loser: game.loser });
+    }
+    timeline.sort((a, b) => a.time - b.time);
+
+    type State = { elo: number; totalGames: number; active: boolean };
+    const playerState = new Map<string, State>();
+    let currentTop3: string[] = [];
+    let lastTime: number | undefined;
+
+    const recomputeTop3 = (): string[] =>
+      Array.from(playerState.entries())
+        .filter(([, s]) => s.active && s.totalGames >= gameLimitForRanked)
+        .sort((a, b) => b[1].elo - a[1].elo)
+        .slice(0, 3)
+        .map(([id]) => id);
+
+    const creditAt = (playerId: string, rank: 1 | 2 | 3, elapsed: number) => {
+      const existing = result.get(playerId) ?? { rank1: 0, rank2: 0, rank3: 0 };
+      if (rank === 1) existing.rank1 += elapsed;
+      else if (rank === 2) existing.rank2 += elapsed;
+      else existing.rank3 += elapsed;
+      result.set(playerId, existing);
+    };
+
+    for (const entry of timeline) {
+      if (lastTime !== undefined && currentTop3.length > 0) {
+        const elapsed = entry.time - lastTime;
+        if (elapsed > 0) {
+          for (let i = 0; i < currentTop3.length; i++) {
+            const rank = (i + 1) as 1 | 2 | 3;
+            creditAt(currentTop3[i], rank, elapsed);
+          }
+        }
+      }
+
+      if (entry.kind === "game") {
+        const winner = playerState.get(entry.winner);
+        const loser = playerState.get(entry.loser);
+        if (winner && loser) {
+          winner.totalGames++;
+          loser.totalGames++;
+          const { winnersNewElo, losersNewElo } = Elo.calculateELO(
+            winner.elo,
+            loser.elo,
+            winner.totalGames,
+            loser.totalGames,
+          );
+          winner.elo = winnersNewElo;
+          loser.elo = losersNewElo;
+        }
+      } else {
+        const existing = playerState.get(entry.playerId);
+        if (existing) {
+          existing.active = entry.active;
+        } else {
+          playerState.set(entry.playerId, { elo: Elo.INITIAL_ELO, totalGames: 0, active: entry.active });
+        }
+      }
+
+      currentTop3 = recomputeTop3();
+      lastTime = entry.time;
+    }
+
+    this.podiumMsCache = result;
+    return result;
   }
 }

--- a/frontend/src/client/client-db/hall-of-fame.ts
+++ b/frontend/src/client/client-db/hall-of-fame.ts
@@ -413,13 +413,17 @@ export class HallOfFame {
     const playerState = new Map<string, State>();
     let currentTop3: string[] = [];
     let lastTime: number | undefined;
+    const MIN_RANKED_FOR_PODIUM = 5;
 
-    const recomputeTop3 = (): string[] =>
-      Array.from(playerState.entries())
-        .filter(([, s]) => s.active && s.totalGames >= gameLimitForRanked)
+    const recomputeTop3 = (): string[] => {
+      const ranked = Array.from(playerState.entries())
+        .filter(([, s]) => s.active && s.totalGames >= gameLimitForRanked);
+      if (ranked.length < MIN_RANKED_FOR_PODIUM) return [];
+      return ranked
         .sort((a, b) => b[1].elo - a[1].elo)
         .slice(0, 3)
         .map(([id]) => id);
+    };
 
     const creditAt = (playerId: string, rank: 1 | 2 | 3, elapsed: number) => {
       const existing = result.get(playerId) ?? { rank1: 0, rank2: 0, rank3: 0 };

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
@@ -187,7 +187,7 @@ function renderDetails(breakdown: HallOfFameScoreBreakdown, key: FactorKey): Rea
       ];
       return (
         <div className="text-primary-text text-xs space-y-1.5">
-          <p className="italic">Days spent in the top 3 of the ranked leaderboard</p>
+          <p className="italic">Days spent in the top 3 of the ranked leaderboard. Only counts while at least 5 players are ranked.</p>
           <div className="flex flex-wrap gap-1.5">
             {podiumTiers.map((tier) => (
               <span

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
@@ -178,6 +178,39 @@ function renderDetails(breakdown: HallOfFameScoreBreakdown, key: FactorKey): Rea
         </div>
       );
     }
+    case "podiumTime": {
+      const d = data as HallOfFameScoreBreakdown["podiumTime"];
+      const podiumTiers = [
+        { label: "🥇 Day at #1", pts: 1, count: d.rank1Days },
+        { label: "🥈 Day at #2", pts: 0.5, count: d.rank2Days },
+        { label: "🥉 Day at #3", pts: 0.5, count: d.rank3Days },
+      ];
+      return (
+        <div className="text-primary-text text-xs space-y-1.5">
+          <p className="italic">Days spent in the top 3 of the ranked leaderboard</p>
+          <div className="flex flex-wrap gap-1.5">
+            {podiumTiers.map((tier) => (
+              <span
+                key={tier.label}
+                className={classNames(
+                  "px-2 py-0.5 rounded text-xs inline-flex items-center gap-1.5",
+                  tier.count === 0
+                    ? "bg-secondary-background/50 text-secondary-text/75"
+                    : "bg-secondary-background text-secondary-text",
+                )}
+              >
+                {tier.label}: {tier.pts} pts
+                {tier.count > 0 && (
+                  <span className="bg-tertiary-background text-tertiary-text h-5 min-w-5 px-1 rounded-full inline-flex items-center justify-center text-xs font-bold">
+                    {fmtNum(tier.count)}x
+                  </span>
+                )}
+              </span>
+            ))}
+          </div>
+        </div>
+      );
+    }
     default: {
       const _exhaustive: never = key;
       return _exhaustive;
@@ -187,6 +220,7 @@ function renderDetails(breakdown: HallOfFameScoreBreakdown, key: FactorKey): Rea
 
 const FACTORS: { key: FactorKey; emoji: string; name: string }[] = [
   { key: "peakElo", emoji: "🔥", name: "All-Time High" },
+  { key: "podiumTime", emoji: "🥉", name: "Podium Time" },
   { key: "experience", emoji: "🏓", name: "Experience" },
   { key: "dataVolume", emoji: "📊", name: "Data Volume" },
   { key: "longevity", emoji: "📅", name: "Activity" },


### PR DESCRIPTION
Tracks the time each player spent on the ranked top 3 by replaying all
events chronologically (games + activity changes) so retirements and
reactivations correctly shift the podium. Scores 1 pt per day at #1 and
0.5 pt per day at #2 or #3, regardless of how many players are ranked.