### PR TITLE
Add Marathon Set achievement for league-wide deuce records

### DIFF
--- a/frontend/src/client/client-db/__tests__/achievements/marathon-set.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/marathon-set.test.ts
@@ -1,0 +1,287 @@
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { TennisTable } from "../../tennis-table";
+
+describe("Marathon Set Achievement", () => {
+  const baseEvents: EventType[] = [
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "alice", time: 1, data: { name: "Alice" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "bob", time: 2, data: { name: "Bob" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "carol", time: 3, data: { name: "Carol" } },
+  ];
+
+  it("awards the set winner with the previous record (11) when a deuce set is won at 12+", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      {
+        type: EventTypeEnum.GAME_CREATED,
+        stream: "g1",
+        time: 100,
+        data: { winner: "alice", loser: "bob", playedAt: 100 },
+      },
+      {
+        type: EventTypeEnum.GAME_SCORE,
+        stream: "g1",
+        time: 101,
+        data: {
+          setsWon: { gameWinner: 2, gameLoser: 0 },
+          setPoints: [
+            { gameWinner: 12, gameLoser: 10 },
+            { gameWinner: 11, gameLoser: 4 },
+          ],
+        },
+      },
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const aliceAwards = tt.achievements.getAchievements("alice").filter((a) => a.type === "marathon-set");
+    expect(aliceAwards).toHaveLength(1);
+    expect(aliceAwards[0]).toStrictEqual({
+      type: "marathon-set",
+      earnedBy: "alice",
+      earnedAt: 100,
+      data: {
+        gameId: "g1",
+        opponent: "bob",
+        setWinnerScore: 12,
+        setLoserScore: 10,
+        previousRecord: 11,
+      },
+    });
+    expect(tt.achievements.marathonSetRecord).toStrictEqual({ score: 12, holder: "alice" });
+  });
+
+  it("does NOT award when winning score is 11 or loser scored less than 10", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      {
+        type: EventTypeEnum.GAME_CREATED,
+        stream: "g1",
+        time: 100,
+        data: { winner: "alice", loser: "bob", playedAt: 100 },
+      },
+      {
+        type: EventTypeEnum.GAME_SCORE,
+        stream: "g1",
+        time: 101,
+        data: {
+          setsWon: { gameWinner: 2, gameLoser: 0 },
+          setPoints: [
+            { gameWinner: 11, gameLoser: 9 }, // not deuce
+            { gameWinner: 13, gameLoser: 9 }, // winner >= 12 but loser < 10
+          ],
+        },
+      },
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "marathon-set")).toHaveLength(0);
+    expect(tt.achievements.marathonSetRecord).toStrictEqual({ score: 11, holder: null });
+  });
+
+  it("ties do NOT award (strictly greater only)", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      {
+        type: EventTypeEnum.GAME_CREATED,
+        stream: "g1",
+        time: 100,
+        data: { winner: "alice", loser: "bob", playedAt: 100 },
+      },
+      {
+        type: EventTypeEnum.GAME_SCORE,
+        stream: "g1",
+        time: 101,
+        data: {
+          setsWon: { gameWinner: 2, gameLoser: 0 },
+          setPoints: [
+            { gameWinner: 15, gameLoser: 13 },
+            { gameWinner: 11, gameLoser: 0 },
+          ],
+        },
+      },
+      {
+        type: EventTypeEnum.GAME_CREATED,
+        stream: "g2",
+        time: 200,
+        data: { winner: "bob", loser: "carol", playedAt: 200 },
+      },
+      {
+        type: EventTypeEnum.GAME_SCORE,
+        stream: "g2",
+        time: 201,
+        data: {
+          setsWon: { gameWinner: 2, gameLoser: 0 },
+          setPoints: [
+            { gameWinner: 15, gameLoser: 13 }, // ties the record — should NOT award
+            { gameWinner: 11, gameLoser: 0 },
+          ],
+        },
+      },
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "marathon-set")).toHaveLength(1);
+    expect(tt.achievements.getAchievements("bob").filter((a) => a.type === "marathon-set")).toHaveLength(0);
+    expect(tt.achievements.marathonSetRecord).toStrictEqual({ score: 15, holder: "alice" });
+  });
+
+  it("awards the set winner even if they lost the overall game", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      // Alice wins the match 2-1; Bob wins the deuce set in the middle
+      {
+        type: EventTypeEnum.GAME_CREATED,
+        stream: "g1",
+        time: 100,
+        data: { winner: "alice", loser: "bob", playedAt: 100 },
+      },
+      {
+        type: EventTypeEnum.GAME_SCORE,
+        stream: "g1",
+        time: 101,
+        data: {
+          setsWon: { gameWinner: 2, gameLoser: 1 },
+          setPoints: [
+            { gameWinner: 11, gameLoser: 5 },
+            { gameWinner: 13, gameLoser: 15 }, // Bob (game loser) wins this deuce set 15-13
+            { gameWinner: 11, gameLoser: 6 },
+          ],
+        },
+      },
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const aliceAwards = tt.achievements.getAchievements("alice").filter((a) => a.type === "marathon-set");
+    const bobAwards = tt.achievements.getAchievements("bob").filter((a) => a.type === "marathon-set");
+    expect(aliceAwards).toHaveLength(0);
+    expect(bobAwards).toHaveLength(1);
+    expect(bobAwards[0].data).toStrictEqual({
+      gameId: "g1",
+      opponent: "alice",
+      setWinnerScore: 15,
+      setLoserScore: 13,
+      previousRecord: 11,
+    });
+  });
+
+  it("can award multiple times in one game when multiple sets each beat the running record", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      {
+        type: EventTypeEnum.GAME_CREATED,
+        stream: "g1",
+        time: 100,
+        data: { winner: "alice", loser: "bob", playedAt: 100 },
+      },
+      {
+        type: EventTypeEnum.GAME_SCORE,
+        stream: "g1",
+        time: 101,
+        data: {
+          setsWon: { gameWinner: 3, gameLoser: 0 },
+          setPoints: [
+            { gameWinner: 12, gameLoser: 10 }, // beats 11 -> award, record=12
+            { gameWinner: 14, gameLoser: 12 }, // beats 12 -> award, record=14
+            { gameWinner: 13, gameLoser: 11 }, // beats neither -> no award
+          ],
+        },
+      },
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const aliceAwards = tt.achievements
+      .getAchievements("alice")
+      .filter((a) => a.type === "marathon-set")
+      .sort((a, b) => (a.data!.setWinnerScore - b.data!.setWinnerScore));
+    expect(aliceAwards).toHaveLength(2);
+    expect(aliceAwards[0].data).toStrictEqual({
+      gameId: "g1",
+      opponent: "bob",
+      setWinnerScore: 12,
+      setLoserScore: 10,
+      previousRecord: 11,
+    });
+    expect(aliceAwards[1].data).toStrictEqual({
+      gameId: "g1",
+      opponent: "bob",
+      setWinnerScore: 14,
+      setLoserScore: 12,
+      previousRecord: 12,
+    });
+    expect(tt.achievements.marathonSetRecord).toStrictEqual({ score: 14, holder: "alice" });
+  });
+
+  it("progression shows player's personal best deuce-set winning score vs the league record", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      // Alice sets the record at 14
+      {
+        type: EventTypeEnum.GAME_CREATED,
+        stream: "g1",
+        time: 100,
+        data: { winner: "alice", loser: "bob", playedAt: 100 },
+      },
+      {
+        type: EventTypeEnum.GAME_SCORE,
+        stream: "g1",
+        time: 101,
+        data: {
+          setsWon: { gameWinner: 2, gameLoser: 0 },
+          setPoints: [
+            { gameWinner: 14, gameLoser: 12 },
+            { gameWinner: 11, gameLoser: 4 },
+          ],
+        },
+      },
+      // Bob wins a deuce set at 13 (below the record)
+      {
+        type: EventTypeEnum.GAME_CREATED,
+        stream: "g2",
+        time: 200,
+        data: { winner: "bob", loser: "carol", playedAt: 200 },
+      },
+      {
+        type: EventTypeEnum.GAME_SCORE,
+        stream: "g2",
+        time: 201,
+        data: {
+          setsWon: { gameWinner: 2, gameLoser: 0 },
+          setPoints: [
+            { gameWinner: 13, gameLoser: 11 },
+            { gameWinner: 11, gameLoser: 6 },
+          ],
+        },
+      },
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const aliceProg = tt.achievements.getPlayerProgression("alice")["marathon-set"];
+    expect(aliceProg.current).toBe(14);
+    expect(aliceProg.target).toBe(14);
+    expect(aliceProg.recordHolder).toBe("alice");
+    expect(aliceProg.earned).toBe(1);
+
+    const bobProg = tt.achievements.getPlayerProgression("bob")["marathon-set"];
+    expect(bobProg.current).toBe(13);
+    expect(bobProg.target).toBe(14);
+    expect(bobProg.recordHolder).toBe("alice");
+    expect(bobProg.earned).toBe(0);
+
+    const carolProg = tt.achievements.getPlayerProgression("carol")["marathon-set"];
+    expect(carolProg.current).toBe(0);
+    expect(carolProg.target).toBe(14);
+    expect(carolProg.recordHolder).toBe("alice");
+    expect(carolProg.earned).toBe(0);
+  });
+});

--- a/frontend/src/client/client-db/__tests__/achievements/marathon-set.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/marathon-set.test.ts
@@ -8,7 +8,7 @@ describe("Marathon Set Achievement", () => {
     { type: EventTypeEnum.PLAYER_CREATED, stream: "carol", time: 3, data: { name: "Carol" } },
   ];
 
-  it("awards the set winner with the previous record (11) when a deuce set is won at 12+", () => {
+  it("awards the set winner with undefined previousRecord when first establishing the league record", () => {
     const events: EventType[] = [
       ...baseEvents,
       {
@@ -45,7 +45,7 @@ describe("Marathon Set Achievement", () => {
         opponent: "bob",
         setWinnerScore: 12,
         setLoserScore: 10,
-        previousRecord: 11,
+        previousRecord: undefined,
       },
     });
     expect(tt.achievements.marathonSetRecord).toStrictEqual({ score: 12, holder: "alice" });
@@ -78,7 +78,7 @@ describe("Marathon Set Achievement", () => {
     tt.achievements.calculateAchievements();
 
     expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "marathon-set")).toHaveLength(0);
-    expect(tt.achievements.marathonSetRecord).toStrictEqual({ score: 11, holder: null });
+    expect(tt.achievements.marathonSetRecord).toStrictEqual({ score: undefined, holder: undefined });
   });
 
   it("ties do NOT award (strictly greater only)", () => {
@@ -167,7 +167,7 @@ describe("Marathon Set Achievement", () => {
       opponent: "alice",
       setWinnerScore: 15,
       setLoserScore: 13,
-      previousRecord: 11,
+      previousRecord: undefined,
     });
   });
 
@@ -208,7 +208,7 @@ describe("Marathon Set Achievement", () => {
       opponent: "bob",
       setWinnerScore: 12,
       setLoserScore: 10,
-      previousRecord: 11,
+      previousRecord: undefined,
     });
     expect(aliceAwards[1].data).toStrictEqual({
       gameId: "g1",
@@ -218,6 +218,39 @@ describe("Marathon Set Achievement", () => {
       previousRecord: 12,
     });
     expect(tt.achievements.marathonSetRecord).toStrictEqual({ score: 14, holder: "alice" });
+  });
+
+  it("progression target and recordHolder are undefined when no record has been set", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      {
+        type: EventTypeEnum.GAME_CREATED,
+        stream: "g1",
+        time: 100,
+        data: { winner: "alice", loser: "bob", playedAt: 100 },
+      },
+      {
+        type: EventTypeEnum.GAME_SCORE,
+        stream: "g1",
+        time: 101,
+        data: {
+          setsWon: { gameWinner: 2, gameLoser: 0 },
+          setPoints: [
+            { gameWinner: 11, gameLoser: 9 },
+            { gameWinner: 11, gameLoser: 7 },
+          ],
+        },
+      },
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const aliceProg = tt.achievements.getPlayerProgression("alice")["marathon-set"];
+    expect(aliceProg.current).toBe(0);
+    expect(aliceProg.target).toBeUndefined();
+    expect(aliceProg.recordHolder).toBeUndefined();
+    expect(aliceProg.earned).toBe(0);
   });
 
   it("progression shows player's personal best deuce-set winning score vs the league record", () => {

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -19,6 +19,12 @@ export class Achievements {
   // Climber achievement and progression. `time` is when that low was
   // set — needed so the awarded achievement can report the "from" date.
   climberAllTimeLow: Map<string, { elo: number; time: number }> = new Map();
+  // League-wide running record for the Marathon Set achievement: the
+  // highest winning set score from a true-deuce set (winner ≥ 12,
+  // loser ≥ 10). Starts at 11 so the first qualifying set strictly
+  // exceeds it. Used by the progression view so players can see what
+  // they need to beat.
+  marathonSetRecord: { score: number; holder: string | null } = { score: 11, holder: null };
 
   constructor(parent: TennisTable) {
     this.parent = parent;
@@ -33,6 +39,7 @@ export class Achievements {
     this.bestDavidGain.clear();
     this.worstGoliathLoss.clear();
     this.climberAllTimeLow.clear();
+    this.marathonSetRecord = { score: 11, holder: null };
 
     const playerTracker = new Map<
       string,
@@ -283,6 +290,18 @@ export class Achievements {
           this.#createAchievement("never-give-up", game.loser, game.playedAt, {
             startedAt: loser.loseStreakAllStartedAt,
           }),
+        );
+      }
+
+      // Check for marathon-set achievements (each set evaluated in
+      // order against the running league-wide record).
+      if (game.score?.setPoints) {
+        this.#checkMarathonSetAchievements(
+          game.winner,
+          game.loser,
+          game.id,
+          game.score.setPoints,
+          game.playedAt,
         );
       }
 
@@ -926,6 +945,43 @@ export class Achievements {
     }
   }
 
+  // Awards "Marathon Set" to the set winner for every set in this
+  // game (evaluated in order) whose winning score strictly exceeds
+  // the league-wide running record AND that was a true-deuce set
+  // (winner ≥ 12, loser ≥ 10). Multiple awards from one game are
+  // possible if successive sets each beat the running record.
+  #checkMarathonSetAchievements(
+    gameWinner: string,
+    gameLoser: string,
+    gameId: string,
+    setPoints: { gameWinner: number; gameLoser: number }[],
+    playedAt: number,
+  ) {
+    setPoints.forEach((set) => {
+      if (set.gameWinner === set.gameLoser) return;
+      const setWinnerScore = Math.max(set.gameWinner, set.gameLoser);
+      const setLoserScore = Math.min(set.gameWinner, set.gameLoser);
+      if (setWinnerScore < 12 || setLoserScore < 10) return;
+      if (setWinnerScore <= this.marathonSetRecord.score) return;
+
+      const setWinnerId = set.gameWinner > set.gameLoser ? gameWinner : gameLoser;
+      const setLoserId = setWinnerId === gameWinner ? gameLoser : gameWinner;
+
+      this.#addAchievement(
+        setWinnerId,
+        this.#createAchievement("marathon-set", setWinnerId, playedAt, {
+          gameId,
+          opponent: setLoserId,
+          setWinnerScore,
+          setLoserScore,
+          previousRecord: this.marathonSetRecord.score,
+        }),
+      );
+
+      this.marathonSetRecord = { score: setWinnerScore, holder: setWinnerId };
+    });
+  }
+
   #checkDonutAchievements(
     winner: string,
     loser: string,
@@ -1340,6 +1396,12 @@ export class Achievements {
       "david": { current: 0, target: 30, earned: 0 },
       "goliath": { current: 0, target: 30, earned: 0 },
       "climber": { current: 0, target: 300, earned: 0 },
+      "marathon-set": {
+        earned: 0,
+        current: 0,
+        target: this.marathonSetRecord.score,
+        recordHolder: this.marathonSetRecord.holder ?? undefined,
+      },
     };
 
     let firstActiveAt: number | null = null;
@@ -1350,6 +1412,7 @@ export class Achievements {
     let closeCallsCount = 0;
     let edgeLordCount = 0;
     let consistencyCount = 0;
+    let bestDeuceSetWon = 0;
     const streaksPerOpponent = new Map<string, number>();
     const opponentsPlayed = new Set<string>();
     const gamesPerOpponent = new Map<string, { count: number; firstGame: number; lastGame: number }>();
@@ -1448,6 +1511,24 @@ export class Achievements {
       if (game.score?.setPoints && this.#checkConsistentGame(game.score.setPoints)) {
         consistencyCount++;
       }
+
+      // Track highest deuce-set winning score this player has won
+      // (regardless of overall game outcome — the achievement is
+      // awarded to set winners).
+      if (game.score?.setPoints) {
+        game.score.setPoints.forEach((set) => {
+          if (set.gameWinner === set.gameLoser) return;
+          const setWinnerScore = Math.max(set.gameWinner, set.gameLoser);
+          const setLoserScore = Math.min(set.gameWinner, set.gameLoser);
+          if (setWinnerScore < 12 || setLoserScore < 10) return;
+          const setWinnerIsGameWinner = set.gameWinner > set.gameLoser;
+          const playerWonSet =
+            (isWinner && setWinnerIsGameWinner) || (isLoser && !setWinnerIsGameWinner);
+          if (playerWonSet && setWinnerScore > bestDeuceSetWon) {
+            bestDeuceSetWon = setWinnerScore;
+          }
+        });
+      }
     });
 
     // Update progression with current stats
@@ -1457,6 +1538,7 @@ export class Achievements {
     progression["close-calls"].current = closeCallsCount;
     progression["edge-lord"].current = edgeLordCount;
     progression["consistency-is-key"].current = consistencyCount;
+    progression["marathon-set"].current = bestDeuceSetWon;
     progression["variety-player"].current = opponentsPlayed.size;
     progression["variety-player"].opponents = opponentsPlayed;
     progression["global-player"].current = opponentsPlayed.size;
@@ -1700,6 +1782,13 @@ type AchievementDefinitions = {
   "david": { opponent: string; gameId: string; eloGain: number };
   "goliath": { opponent: string; gameId: string; eloLoss: number };
   "climber": { fromElo: number; toElo: number; fromDate: number; toDate: number };
+  "marathon-set": {
+    gameId: string;
+    opponent: string;
+    setWinnerScore: number;
+    setLoserScore: number;
+    previousRecord: number;
+  };
 };
 
 type AchievementType = keyof AchievementDefinitions;
@@ -1747,6 +1836,18 @@ type WelcomeCommitteeProgression = ProgressionWithTarget & {
   newPlayers?: Set<string>; // List of new players this person was first opponent for
 };
 
+type MarathonSetProgression = BaseProgression & {
+  // Player's own highest winning set score from a true-deuce set
+  // they won (winner ≥ 12, loser ≥ 10). 0 if they have none.
+  current: number;
+  // The league-wide record — the winning score this player must
+  // strictly exceed to earn the next Marathon Set award. Starts at
+  // 11 if no one has set a record yet.
+  target: number;
+  // Player who currently holds the league record, if any.
+  recordHolder?: string;
+};
+
 export type AchievementProgression = {
   "donut-1": ProgressionWithTarget;
   "donut-5": ProgressionWithTarget;
@@ -1786,4 +1887,5 @@ export type AchievementProgression = {
   "david": ProgressionWithTarget;
   "goliath": ProgressionWithTarget;
   "climber": ProgressionWithTarget;
+  "marathon-set": MarathonSetProgression;
 };

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -21,10 +21,13 @@ export class Achievements {
   climberAllTimeLow: Map<string, { elo: number; time: number }> = new Map();
   // League-wide running record for the Marathon Set achievement: the
   // highest winning set score from a true-deuce set (winner ≥ 12,
-  // loser ≥ 10). Starts at 11 so the first qualifying set strictly
-  // exceeds it. Used by the progression view so players can see what
+  // loser ≥ 10). Undefined until the first qualifying set establishes
+  // the record. Used by the progression view so players can see what
   // they need to beat.
-  marathonSetRecord: { score: number; holder: string | null } = { score: 11, holder: null };
+  marathonSetRecord: { score: number | undefined; holder: string | undefined } = {
+    score: undefined,
+    holder: undefined,
+  };
 
   constructor(parent: TennisTable) {
     this.parent = parent;
@@ -39,7 +42,7 @@ export class Achievements {
     this.bestDavidGain.clear();
     this.worstGoliathLoss.clear();
     this.climberAllTimeLow.clear();
-    this.marathonSetRecord = { score: 11, holder: null };
+    this.marathonSetRecord = { score: undefined, holder: undefined };
 
     const playerTracker = new Map<
       string,
@@ -962,7 +965,8 @@ export class Achievements {
       const setWinnerScore = Math.max(set.gameWinner, set.gameLoser);
       const setLoserScore = Math.min(set.gameWinner, set.gameLoser);
       if (setWinnerScore < 12 || setLoserScore < 10) return;
-      if (setWinnerScore <= this.marathonSetRecord.score) return;
+      const currentRecord = this.marathonSetRecord.score;
+      if (currentRecord !== undefined && setWinnerScore <= currentRecord) return;
 
       const setWinnerId = set.gameWinner > set.gameLoser ? gameWinner : gameLoser;
       const setLoserId = setWinnerId === gameWinner ? gameLoser : gameWinner;
@@ -974,7 +978,7 @@ export class Achievements {
           opponent: setLoserId,
           setWinnerScore,
           setLoserScore,
-          previousRecord: this.marathonSetRecord.score,
+          previousRecord: currentRecord,
         }),
       );
 
@@ -1400,7 +1404,7 @@ export class Achievements {
         earned: 0,
         current: 0,
         target: this.marathonSetRecord.score,
-        recordHolder: this.marathonSetRecord.holder ?? undefined,
+        recordHolder: this.marathonSetRecord.holder,
       },
     };
 
@@ -1787,7 +1791,8 @@ type AchievementDefinitions = {
     opponent: string;
     setWinnerScore: number;
     setLoserScore: number;
-    previousRecord: number;
+    // Undefined when this set is the first to establish the league record.
+    previousRecord?: number;
   };
 };
 
@@ -1841,9 +1846,10 @@ type MarathonSetProgression = BaseProgression & {
   // they won (winner ≥ 12, loser ≥ 10). 0 if they have none.
   current: number;
   // The league-wide record — the winning score this player must
-  // strictly exceed to earn the next Marathon Set award. Starts at
-  // 11 if no one has set a record yet.
-  target: number;
+  // strictly exceed to earn the next Marathon Set award. Undefined
+  // when no one has set a record yet (next qualifying deuce set wins
+  // it outright).
+  target?: number;
   // Player who currently holds the league record, if any.
   recordHolder?: string;
 };

--- a/frontend/src/pages/achievements/achievements-list.tsx
+++ b/frontend/src/pages/achievements/achievements-list.tsx
@@ -194,8 +194,10 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                   )}
                   {achievement.type === "marathon-set" && achievement.data && (
                     <span className="text-[11px] opacity-80">
-                      {achievement.data.setWinnerScore}–{achievement.data.setLoserScore} (prev record{" "}
-                      {achievement.data.previousRecord})
+                      {achievement.data.setWinnerScore}–{achievement.data.setLoserScore}
+                      {achievement.data.previousRecord !== undefined
+                        ? ` (prev record ${achievement.data.previousRecord})`
+                        : " (first league record!)"}
                     </span>
                   )}
                   {achievement.type === "king-maker" && achievement.data && (

--- a/frontend/src/pages/achievements/achievements-list.tsx
+++ b/frontend/src/pages/achievements/achievements-list.tsx
@@ -192,6 +192,12 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                       {achievement.data.playerPoints} pts vs {achievement.data.opponentPoints} pts
                     </span>
                   )}
+                  {achievement.type === "marathon-set" && achievement.data && (
+                    <span className="text-[11px] opacity-80">
+                      {achievement.data.setWinnerScore}–{achievement.data.setLoserScore} (prev record{" "}
+                      {achievement.data.previousRecord})
+                    </span>
+                  )}
                   {achievement.type === "king-maker" && achievement.data && (
                     <span className="text-[11px] opacity-80">
                       New king: {context.playerName(achievement.data.newKing)} (

--- a/frontend/src/pages/achievements/progress-list.tsx
+++ b/frontend/src/pages/achievements/progress-list.tsx
@@ -97,7 +97,6 @@ export const ProgressList: React.FC<ProgressListProps> = ({ selectedType }) => {
           </div>
 
             {playersProgress.map(({ player, current, target, percent, earned }, index) => {
-              const isComplete = percent >= 100;
               const hasEarned = earned > 0;
 
               return (
@@ -110,13 +109,15 @@ export const ProgressList: React.FC<ProgressListProps> = ({ selectedType }) => {
                       : "bg-background-secondary",
                   )}
                 >
-                  {/* Progress Background */}
+                  {/* Progress Background. The bar only turns green
+                      once the achievement has actually been earned —
+                      hitting 100% progress alone is not enough. */}
                   {(target > 1 || current > 0) && (
                     <div className="absolute inset-0 pointer-events-none">
                       <div
                         className={classNames(
                           "h-full transition-all duration-300",
-                          isComplete
+                          hasEarned
                             ? "bg-gradient-to-b from-green-400 via-green-500 to-green-600"
                             : "bg-gradient-to-b from-blue-400 via-blue-500 to-blue-600",
                         )}

--- a/frontend/src/pages/achievements/progress-list.tsx
+++ b/frontend/src/pages/achievements/progress-list.tsx
@@ -109,18 +109,14 @@ export const ProgressList: React.FC<ProgressListProps> = ({ selectedType }) => {
                       : "bg-background-secondary",
                   )}
                 >
-                  {/* Progress Background. The bar only turns green
-                      once the achievement has actually been earned —
-                      hitting 100% progress alone is not enough. */}
+                  {/* Progress Background. The bar itself is always
+                      blue; the green earned-row background shows
+                      through behind it so an earned-but-progressing
+                      achievement reads as "blue bar over green bg". */}
                   {(target > 1 || current > 0) && (
                     <div className="absolute inset-0 pointer-events-none">
                       <div
-                        className={classNames(
-                          "h-full transition-all duration-300",
-                          hasEarned
-                            ? "bg-gradient-to-b from-green-400 via-green-500 to-green-600"
-                            : "bg-gradient-to-b from-blue-400 via-blue-500 to-blue-600",
-                        )}
+                        className="h-full transition-all duration-300 bg-gradient-to-b from-blue-400 via-blue-500 to-blue-600"
                         style={{ width: `${percent}%` }}
                       />
                     </div>

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -201,6 +201,11 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
     description: "Climb 300 Score from your all-time low (recorded from when you first became ranked)",
     icon: "🧗",
   },
+  "marathon-set": {
+    title: "Marathon Set",
+    description: "Win a deuce set with the highest winning score in league history",
+    icon: "🏓",
+  },
 };
 
 type TabType = "earned" | "progress";
@@ -390,6 +395,13 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
                 {achievement.type === "less-is-more" && achievement.data && (
                   <p className="text-xs text-secondary-text/70 mt-2">
                     {achievement.data.playerPoints} pts vs {achievement.data.opponentPoints} pts
+                  </p>
+                )}
+
+                {achievement.type === "marathon-set" && achievement.data && (
+                  <p className="text-xs text-secondary-text/70 mt-2">
+                    Set score: {achievement.data.setWinnerScore}–{achievement.data.setLoserScore}{" "}
+                    (previous record: {achievement.data.previousRecord})
                   </p>
                 )}
 
@@ -668,6 +680,25 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                             </div>
                           </div>
                         )}
+
+                      {/* Record holder for marathon-set */}
+                      {type === "marathon-set" && "recordHolder" in data && (
+                        <div className="mt-2 text-xs text-secondary-text/70">
+                          {data.recordHolder ? (
+                            <>
+                              League record held by{" "}
+                              <Link to={"/player/" + data.recordHolder}>
+                                <span className="text-secondary-text underline">
+                                  {context.playerName(data.recordHolder)}
+                                </span>
+                              </Link>
+                              . Beat {data.target} to take it.
+                            </>
+                          ) : (
+                            <>No record set yet — win a deuce set above 11 to start the record.</>
+                          )}
+                        </div>
+                      )}
                     </>
                   ) : (
                     // Fallback for achievements without targets (like tournament achievements)

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -400,8 +400,10 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
 
                 {achievement.type === "marathon-set" && achievement.data && (
                   <p className="text-xs text-secondary-text/70 mt-2">
-                    Set score: {achievement.data.setWinnerScore}–{achievement.data.setLoserScore}{" "}
-                    (previous record: {achievement.data.previousRecord})
+                    Set score: {achievement.data.setWinnerScore}–{achievement.data.setLoserScore}
+                    {achievement.data.previousRecord !== undefined
+                      ? ` (previous record: ${achievement.data.previousRecord})`
+                      : " (first league record!)"}
                   </p>
                 )}
 
@@ -700,6 +702,10 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                         </div>
                       )}
                     </>
+                  ) : type === "marathon-set" ? (
+                    <div className="mt-2 text-xs text-secondary-text/70">
+                      No league record yet — win a deuce set with the winning score at 12 or above to set the first record.
+                    </div>
                   ) : (
                     // Fallback for achievements without targets (like tournament achievements)
                     <div className="mt-2 text-xs text-secondary-text/70">

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -510,21 +510,16 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
             )}
           >
             {/* Progress bar background.
-                The row's container has a green gradient when the
-                achievement has been earned, so a fully-filled blue bar
-                over it reads as "blue bar over green bg". The bar only
-                turns green itself once the achievement has actually
-                been earned — hitting 100% progress alone is not enough
-                (e.g. matching a record without exceeding it). */}
+                The bar itself is always blue and represents current
+                progress. The row's container has a green gradient
+                when the achievement has been earned, which shows
+                through to the right of the blue bar — so an earned
+                achievement that's currently 94% progressed reads as
+                "94% blue over green bg, with a 6% green sliver". */}
             {hasTarget && (
               <div className="absolute inset-0 pointer-events-none">
                 <div
-                  className={classNames(
-                    "h-full transition-all duration-300",
-                    hasEarned
-                      ? "bg-gradient-to-b from-green-400 via-green-500 to-green-600"
-                      : "bg-gradient-to-b from-blue-400 via-blue-500 to-blue-600",
-                  )}
+                  className="h-full transition-all duration-300 bg-gradient-to-b from-blue-400 via-blue-500 to-blue-600"
                   style={{ width: `${percentage}%` }}
                 />
               </div>

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -498,7 +498,6 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
       {progressItems.map(({ type, label, data }) => {
         const hasTarget = "target" in data && !!data.target;
         const hasCurrent = "current" in data && !!data.current;
-        const isComplete = hasTarget && hasCurrent && data.current! >= data.target!;
         const percentage = hasTarget && hasCurrent ? Math.min((data.current! / data.target!) * 100, 100) : 0;
         const hasEarned = data.earned > 0;
 
@@ -512,16 +511,17 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
           >
             {/* Progress bar background.
                 The row's container has a green gradient when the
-                achievement has been earned — this shows through behind
-                the blue progressing bar so an earned-but-currently-
-                progressing achievement reads as "blue bar over green
-                bg". When progress hits 100%, the bar fills with green. */}
+                achievement has been earned, so a fully-filled blue bar
+                over it reads as "blue bar over green bg". The bar only
+                turns green itself once the achievement has actually
+                been earned — hitting 100% progress alone is not enough
+                (e.g. matching a record without exceeding it). */}
             {hasTarget && (
               <div className="absolute inset-0 pointer-events-none">
                 <div
                   className={classNames(
                     "h-full transition-all duration-300",
-                    isComplete
+                    hasEarned
                       ? "bg-gradient-to-b from-green-400 via-green-500 to-green-600"
                       : "bg-gradient-to-b from-blue-400 via-blue-500 to-blue-600",
                   )}


### PR DESCRIPTION
Awards the set winner each time a true-deuce set (winner >= 12, loser >= 10)
is won with a winning score strictly higher than the league's running record.
Multiple awards per game are possible if successive sets each beat the
running record. Progression shows the player's personal best deuce-set
winning score vs the current league record and its holder.

https://claude.ai/code/session_016xdra36voJTH6AmPVyQVau