### PR TITLE
Add Streak Ender and Group Stage Star achievements

### DIFF
--- a/frontend/src/client/client-db/__tests__/achievements/group-stage-star.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/group-stage-star.test.ts
@@ -1,0 +1,301 @@
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { TennisTable } from "../../tennis-table";
+
+describe("Group Stage Star Achievement", () => {
+  const players: EventType[] = [
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "alice", time: 1, data: { name: "Alice" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "bob", time: 2, data: { name: "Bob" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "carol", time: 3, data: { name: "Carol" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "dave", time: 4, data: { name: "Dave" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "eve", time: 5, data: { name: "Eve" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "frank", time: 6, data: { name: "Frank" } },
+  ];
+
+  const PAST_START = Date.now() - 30 * 24 * 60 * 60 * 1000;
+  const FUTURE_START = Date.now() + 30 * 24 * 60 * 60 * 1000;
+
+  function game(stream: string, time: number, winner: string, loser: string): EventType {
+    return {
+      type: EventTypeEnum.GAME_CREATED,
+      stream,
+      time,
+      data: { winner, loser, playedAt: time },
+    };
+  }
+
+  it("awards the player who went undefeated in a finished 4-player group", () => {
+    const events: EventType[] = [
+      ...players,
+      {
+        type: EventTypeEnum.TOURNAMENT_CREATED,
+        stream: "t1",
+        time: 1000,
+        data: { name: "Spring Cup", startDate: PAST_START, groupPlay: true },
+      },
+      {
+        type: EventTypeEnum.TOURNAMENT_SET_PLAYER_ORDER,
+        stream: "t1",
+        time: 1001,
+        data: { playerOrder: ["alice", "bob", "carol", "dave"] },
+      },
+      // Alice wins all 3 of her games.
+      game("g1", PAST_START + 100, "alice", "bob"),
+      game("g2", PAST_START + 200, "alice", "carol"),
+      game("g3", PAST_START + 300, "alice", "dave"),
+      // Remaining games to complete the group stage.
+      game("g4", PAST_START + 400, "bob", "carol"),
+      game("g5", PAST_START + 500, "bob", "dave"),
+      game("g6", PAST_START + 600, "carol", "dave"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const aliceAwards = tt.achievements.getAchievements("alice").filter((a) => a.type === "group-stage-star");
+    expect(aliceAwards).toHaveLength(1);
+    expect(aliceAwards[0]).toStrictEqual({
+      type: "group-stage-star",
+      earnedBy: "alice",
+      earnedAt: PAST_START + 600,
+      data: { tournamentId: "t1", wins: 3 },
+    });
+
+    expect(tt.achievements.getAchievements("bob").filter((a) => a.type === "group-stage-star")).toHaveLength(0);
+    expect(tt.achievements.getAchievements("carol").filter((a) => a.type === "group-stage-star")).toHaveLength(0);
+    expect(tt.achievements.getAchievements("dave").filter((a) => a.type === "group-stage-star")).toHaveLength(0);
+  });
+
+  it("does NOT award while the group stage is still in progress (some games pending)", () => {
+    const events: EventType[] = [
+      ...players,
+      {
+        type: EventTypeEnum.TOURNAMENT_CREATED,
+        stream: "t1",
+        time: 1000,
+        data: { name: "In-progress Cup", startDate: PAST_START, groupPlay: true },
+      },
+      {
+        type: EventTypeEnum.TOURNAMENT_SET_PLAYER_ORDER,
+        stream: "t1",
+        time: 1001,
+        data: { playerOrder: ["alice", "bob", "carol", "dave"] },
+      },
+      // Alice plays and wins all her games but the rest is incomplete.
+      game("g1", PAST_START + 100, "alice", "bob"),
+      game("g2", PAST_START + 200, "alice", "carol"),
+      game("g3", PAST_START + 300, "alice", "dave"),
+      game("g4", PAST_START + 400, "bob", "carol"),
+      // g5 (bob vs dave) and g6 (carol vs dave) missing → group play not ended.
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "group-stage-star")).toHaveLength(0);
+  });
+
+  it("does NOT award for tournaments without group play", () => {
+    const events: EventType[] = [
+      ...players,
+      {
+        type: EventTypeEnum.TOURNAMENT_CREATED,
+        stream: "t1",
+        time: 1000,
+        data: { name: "Knockout Only", startDate: PAST_START, groupPlay: false },
+      },
+      {
+        type: EventTypeEnum.TOURNAMENT_SET_PLAYER_ORDER,
+        stream: "t1",
+        time: 1001,
+        data: { playerOrder: ["alice", "bob", "carol", "dave"] },
+      },
+      game("g1", PAST_START + 100, "alice", "bob"),
+      game("g2", PAST_START + 200, "alice", "carol"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "group-stage-star")).toHaveLength(0);
+  });
+
+  it("does NOT award for a tournament that has not started yet", () => {
+    const events: EventType[] = [
+      ...players,
+      {
+        type: EventTypeEnum.TOURNAMENT_CREATED,
+        stream: "t1",
+        time: 1000,
+        data: { name: "Future Cup", startDate: FUTURE_START, groupPlay: true },
+      },
+      {
+        type: EventTypeEnum.TOURNAMENT_SET_PLAYER_ORDER,
+        stream: "t1",
+        time: 1001,
+        data: { playerOrder: ["alice", "bob", "carol", "dave"] },
+      },
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "group-stage-star")).toHaveLength(0);
+  });
+
+  it("awards one undefeated player per group when there are multiple groups", () => {
+    const events: EventType[] = [
+      ...players,
+      {
+        type: EventTypeEnum.TOURNAMENT_CREATED,
+        stream: "t1",
+        time: 1000,
+        data: { name: "Two Groups", startDate: PAST_START, groupPlay: true, overridePreferredGroupSize: 3 },
+      },
+      {
+        type: EventTypeEnum.TOURNAMENT_SET_PLAYER_ORDER,
+        stream: "t1",
+        time: 1001,
+        data: { playerOrder: ["alice", "bob", "carol", "dave", "eve", "frank"] },
+      },
+      // Group A (alice, dave, eve based on seeding) — wins for alice
+      // The exact group assignment uses the snake/seed algorithm; just play
+      // every cross pairing so whatever groups form, the right players have
+      // all their games done.
+      game("g1", PAST_START + 100, "alice", "bob"),
+      game("g2", PAST_START + 200, "alice", "carol"),
+      game("g3", PAST_START + 300, "alice", "dave"),
+      game("g4", PAST_START + 400, "alice", "eve"),
+      game("g5", PAST_START + 500, "alice", "frank"),
+      game("g6", PAST_START + 600, "bob", "carol"),
+      game("g7", PAST_START + 700, "bob", "dave"),
+      game("g8", PAST_START + 800, "bob", "eve"),
+      game("g9", PAST_START + 900, "bob", "frank"),
+      game("g10", PAST_START + 1000, "carol", "dave"),
+      game("g11", PAST_START + 1100, "carol", "eve"),
+      game("g12", PAST_START + 1200, "carol", "frank"),
+      game("g13", PAST_START + 1300, "dave", "eve"),
+      game("g14", PAST_START + 1400, "dave", "frank"),
+      game("g15", PAST_START + 1500, "eve", "frank"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    // Whatever groups form, alice beat everyone — so she's undefeated in her group.
+    expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "group-stage-star")).toHaveLength(1);
+
+    // Sanity: at most one undefeated player exists per group.
+    const totalAwards = ["alice", "bob", "carol", "dave", "eve", "frank"]
+      .map((p) => tt.achievements.getAchievements(p).filter((a) => a.type === "group-stage-star").length)
+      .reduce((sum, n) => sum + n, 0);
+    // 6 players / preferredGroupSize 3 => two groups; can be at most 2 undefeated awards.
+    expect(totalAwards).toBeLessThanOrEqual(2);
+    expect(totalAwards).toBeGreaterThanOrEqual(1);
+  });
+
+  it("treats opponent skips as free wins (still undefeated)", () => {
+    const events: EventType[] = [
+      ...players,
+      {
+        type: EventTypeEnum.TOURNAMENT_CREATED,
+        stream: "t1",
+        time: 1000,
+        data: { name: "Skip Cup", startDate: PAST_START, groupPlay: true },
+      },
+      {
+        type: EventTypeEnum.TOURNAMENT_SET_PLAYER_ORDER,
+        stream: "t1",
+        time: 1001,
+        data: { playerOrder: ["alice", "bob", "carol", "dave"] },
+      },
+      // Alice wins 2 real games + 1 by Dave skipping.
+      game("g1", PAST_START + 100, "alice", "bob"),
+      game("g2", PAST_START + 200, "alice", "carol"),
+      {
+        type: EventTypeEnum.TOURNAMENT_SKIP_GAME,
+        stream: "t1",
+        time: PAST_START + 300,
+        data: { skipId: "skip1", winner: "alice", loser: "dave" },
+      },
+      // Complete the rest.
+      game("g4", PAST_START + 400, "bob", "carol"),
+      game("g5", PAST_START + 500, "bob", "dave"),
+      game("g6", PAST_START + 600, "carol", "dave"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const aliceAwards = tt.achievements.getAchievements("alice").filter((a) => a.type === "group-stage-star");
+    expect(aliceAwards).toHaveLength(1);
+    expect(aliceAwards[0].data).toStrictEqual({ tournamentId: "t1", wins: 3 });
+  });
+
+  it("does NOT award when the player themselves skipped a game", () => {
+    const events: EventType[] = [
+      ...players,
+      {
+        type: EventTypeEnum.TOURNAMENT_CREATED,
+        stream: "t1",
+        time: 1000,
+        data: { name: "Self-Skip Cup", startDate: PAST_START, groupPlay: true },
+      },
+      {
+        type: EventTypeEnum.TOURNAMENT_SET_PLAYER_ORDER,
+        stream: "t1",
+        time: 1001,
+        data: { playerOrder: ["alice", "bob", "carol", "dave"] },
+      },
+      // Alice wins 2 real games; the 3rd is recorded as her skipping (Bob wins by default).
+      game("g1", PAST_START + 100, "alice", "carol"),
+      game("g2", PAST_START + 200, "alice", "dave"),
+      {
+        type: EventTypeEnum.TOURNAMENT_SKIP_GAME,
+        stream: "t1",
+        time: PAST_START + 300,
+        data: { skipId: "skip1", winner: "bob", loser: "alice" },
+      },
+      // Finish the group.
+      game("g4", PAST_START + 400, "bob", "carol"),
+      game("g5", PAST_START + 500, "bob", "dave"),
+      game("g6", PAST_START + 600, "carol", "dave"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "group-stage-star")).toHaveLength(0);
+    // Bob has 3 wins, 0 losses, 0 own-skips → he's undefeated.
+    expect(tt.achievements.getAchievements("bob").filter((a) => a.type === "group-stage-star")).toHaveLength(1);
+  });
+
+  it("progression counts earned achievements", () => {
+    const events: EventType[] = [
+      ...players,
+      {
+        type: EventTypeEnum.TOURNAMENT_CREATED,
+        stream: "t1",
+        time: 1000,
+        data: { name: "Cup", startDate: PAST_START, groupPlay: true },
+      },
+      {
+        type: EventTypeEnum.TOURNAMENT_SET_PLAYER_ORDER,
+        stream: "t1",
+        time: 1001,
+        data: { playerOrder: ["alice", "bob", "carol", "dave"] },
+      },
+      game("g1", PAST_START + 100, "alice", "bob"),
+      game("g2", PAST_START + 200, "alice", "carol"),
+      game("g3", PAST_START + 300, "alice", "dave"),
+      game("g4", PAST_START + 400, "bob", "carol"),
+      game("g5", PAST_START + 500, "bob", "dave"),
+      game("g6", PAST_START + 600, "carol", "dave"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getPlayerProgression("alice")["group-stage-star"]).toStrictEqual({ earned: 1 });
+    expect(tt.achievements.getPlayerProgression("bob")["group-stage-star"]).toStrictEqual({ earned: 0 });
+  });
+});

--- a/frontend/src/client/client-db/__tests__/achievements/streak-ender.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/streak-ender.test.ts
@@ -1,0 +1,157 @@
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { TennisTable } from "../../tennis-table";
+
+describe("Streak Ender Achievement", () => {
+  const players: EventType[] = [
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "alice", time: 1, data: { name: "Alice" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "bob", time: 2, data: { name: "Bob" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "carol", time: 3, data: { name: "Carol" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "dave", time: 4, data: { name: "Dave" } },
+  ];
+
+  function aliceWinsAgainst(opponents: string[], startTime = 1000, step = 10): EventType[] {
+    return opponents.map((opponent, i) => ({
+      type: EventTypeEnum.GAME_CREATED,
+      stream: `g-alice-${i + 1}`,
+      time: startTime + (i + 1) * step,
+      data: { winner: "alice", loser: opponent, playedAt: startTime + (i + 1) * step },
+    }));
+  }
+
+  it("awards the winner when the loser was on a 10+ game win streak", () => {
+    const aliceWins = aliceWinsAgainst(["bob", "carol", "dave", "bob", "carol", "dave", "bob", "carol", "dave", "bob"]);
+    const events: EventType[] = [
+      ...players,
+      ...aliceWins,
+      {
+        type: EventTypeEnum.GAME_CREATED,
+        stream: "ender",
+        time: 5000,
+        data: { winner: "carol", loser: "alice", playedAt: 5000 },
+      },
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const carolEnders = tt.achievements.getAchievements("carol").filter((a) => a.type === "streak-ender");
+    expect(carolEnders).toHaveLength(1);
+    expect(carolEnders[0]).toStrictEqual({
+      type: "streak-ender",
+      earnedBy: "carol",
+      earnedAt: 5000,
+      data: {
+        opponent: "alice",
+        gameId: "ender",
+        streakLength: 10,
+      },
+    });
+  });
+
+  it("does NOT award when the loser was on a 9-game streak", () => {
+    const aliceWins = aliceWinsAgainst(["bob", "carol", "dave", "bob", "carol", "dave", "bob", "carol", "dave"]);
+    const events: EventType[] = [
+      ...players,
+      ...aliceWins,
+      {
+        type: EventTypeEnum.GAME_CREATED,
+        stream: "no-ender",
+        time: 5000,
+        data: { winner: "bob", loser: "alice", playedAt: 5000 },
+      },
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("bob").filter((a) => a.type === "streak-ender")).toHaveLength(0);
+  });
+
+  it("records the actual streak length when the loser was on a long (15+) streak", () => {
+    const opponents = [
+      "bob", "carol", "dave", "bob", "carol",
+      "dave", "bob", "carol", "dave", "bob",
+      "carol", "dave", "bob", "carol", "dave",
+    ];
+    const aliceWins = aliceWinsAgainst(opponents);
+    const events: EventType[] = [
+      ...players,
+      ...aliceWins,
+      {
+        type: EventTypeEnum.GAME_CREATED,
+        stream: "ender",
+        time: 9000,
+        data: { winner: "dave", loser: "alice", playedAt: 9000 },
+      },
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const daveEnders = tt.achievements.getAchievements("dave").filter((a) => a.type === "streak-ender");
+    expect(daveEnders).toHaveLength(1);
+    expect(daveEnders[0].data).toStrictEqual({
+      opponent: "alice",
+      gameId: "ender",
+      streakLength: 15,
+    });
+  });
+
+  it("can be earned multiple times by the same player against different opponents", () => {
+    const aliceWins = aliceWinsAgainst(
+      ["bob", "carol", "dave", "bob", "carol", "dave", "bob", "carol", "dave", "bob"],
+      1000,
+    );
+    // Carol ends Alice's streak.
+    const carolEnds: EventType = {
+      type: EventTypeEnum.GAME_CREATED,
+      stream: "carol-ends",
+      time: 5000,
+      data: { winner: "carol", loser: "alice", playedAt: 5000 },
+    };
+    // Bob now goes on a 10+ streak (against Alice and Dave).
+    const bobOpponents = ["alice", "dave", "alice", "dave", "alice", "dave", "alice", "dave", "alice", "dave"];
+    const bobWins: EventType[] = bobOpponents.map((opp, i) => ({
+      type: EventTypeEnum.GAME_CREATED,
+      stream: `bob-w-${i + 1}`,
+      time: 6000 + (i + 1) * 10,
+      data: { winner: "bob", loser: opp, playedAt: 6000 + (i + 1) * 10 },
+    }));
+    // Carol ends Bob's streak too.
+    const carolEndsBob: EventType = {
+      type: EventTypeEnum.GAME_CREATED,
+      stream: "carol-ends-bob",
+      time: 9000,
+      data: { winner: "carol", loser: "bob", playedAt: 9000 },
+    };
+
+    const tt = new TennisTable({
+      events: [...players, ...aliceWins, carolEnds, ...bobWins, carolEndsBob],
+    });
+    tt.achievements.calculateAchievements();
+
+    const carolEnders = tt.achievements.getAchievements("carol").filter((a) => a.type === "streak-ender");
+    expect(carolEnders).toHaveLength(2);
+    expect(carolEnders.map((a) => a.data.opponent).sort()).toStrictEqual(["alice", "bob"]);
+  });
+
+  it("progression counts earned achievements", () => {
+    const aliceWins = aliceWinsAgainst(["bob", "carol", "dave", "bob", "carol", "dave", "bob", "carol", "dave", "bob"]);
+    const events: EventType[] = [
+      ...players,
+      ...aliceWins,
+      {
+        type: EventTypeEnum.GAME_CREATED,
+        stream: "ender",
+        time: 5000,
+        data: { winner: "dave", loser: "alice", playedAt: 5000 },
+      },
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getPlayerProgression("dave")["streak-ender"]).toStrictEqual({ earned: 1 });
+    expect(tt.achievements.getPlayerProgression("bob")["streak-ender"]).toStrictEqual({ earned: 0 });
+  });
+});

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -267,6 +267,19 @@ export class Achievements {
       }
       playerStreak.count++;
 
+      // Check for Streak Ender: winner just ended a 10+ game win streak.
+      // Must read loser.winStreakAll BEFORE it is reset below.
+      if (loser.winStreakAll >= 10) {
+        this.#addAchievement(
+          game.winner,
+          this.#createAchievement("streak-ender", game.winner, game.playedAt, {
+            opponent: game.loser,
+            gameId: game.id,
+            streakLength: loser.winStreakAll,
+          }),
+        );
+      }
+
       // Update loser stats
       loser.lastActiveAt = game.playedAt;
       loser.winStreakAll = 0;
@@ -1302,6 +1315,24 @@ export class Achievements {
           }),
         );
       }
+
+      // Check for Group Stage Star: a player who finished their group stage
+      // with zero losses and zero own-skips (opponent skips that gave them a
+      // free win still count). Awarded once per tournament group stage.
+      if (t.groupPlay && t.groupPlay.groupPlayEnded !== undefined) {
+        const endedAt = t.groupPlay.groupPlayEnded;
+        t.groupPlay.groupScores.forEach((score, playerId) => {
+          if (score.loss === 0 && score.skips === 0 && score.wins > 0) {
+            this.#addAchievement(
+              playerId,
+              this.#createAchievement("group-stage-star", playerId, endedAt, {
+                tournamentId,
+                wins: score.wins,
+              }),
+            );
+          }
+        });
+      }
     });
   }
 
@@ -1406,6 +1437,8 @@ export class Achievements {
         target: this.marathonSetRecord.score,
         recordHolder: this.marathonSetRecord.holder,
       },
+      "streak-ender": { earned: 0 },
+      "group-stage-star": { earned: 0 },
     };
 
     let firstActiveAt: number | null = null;
@@ -1794,6 +1827,8 @@ type AchievementDefinitions = {
     // Undefined when this set is the first to establish the league record.
     previousRecord?: number;
   };
+  "streak-ender": { opponent: string; gameId: string; streakLength: number };
+  "group-stage-star": { tournamentId: string; wins: number };
 };
 
 type AchievementType = keyof AchievementDefinitions;
@@ -1894,4 +1929,6 @@ export type AchievementProgression = {
   "goliath": ProgressionWithTarget;
   "climber": ProgressionWithTarget;
   "marathon-set": MarathonSetProgression;
+  "streak-ender": BaseProgression;
+  "group-stage-star": BaseProgression;
 };

--- a/frontend/src/pages/achievements/achievements-list.tsx
+++ b/frontend/src/pages/achievements/achievements-list.tsx
@@ -206,6 +206,17 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                       {fmtNum(achievement.data.netScoreGained, { digits: 0, signedPositive: true })} Score)
                     </span>
                   )}
+                  {achievement.type === "streak-ender" && achievement.data && (
+                    <span className="text-[11px] opacity-80">
+                      Ended {achievement.data.streakLength}-game streak
+                    </span>
+                  )}
+                  {achievement.type === "group-stage-star" && achievement.data && (
+                    <span className="text-[11px] opacity-80">
+                      Undefeated ({achievement.data.wins} win
+                      {achievement.data.wins !== 1 ? "s" : ""})
+                    </span>
+                  )}
                   {achievement.type === "leap-frog" && achievement.data && (
                     <span className="text-[11px] opacity-80">
                       #{achievement.data.fromRank} → #{achievement.data.toRank} (

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -206,6 +206,16 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
     description: "Win a deuce set with the highest winning score in league history",
     icon: "🏓",
   },
+  "streak-ender": {
+    title: "Streak Ender",
+    description: "Beat a player who was on an active 10+ game win streak",
+    icon: "🛑",
+  },
+  "group-stage-star": {
+    title: "Group Stage Star",
+    description: "Go undefeated in a tournament group stage",
+    icon: "⭐",
+  },
 };
 
 type TabType = "earned" | "progress";
@@ -430,6 +440,18 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
                   <p className="text-xs text-secondary-text/70 mt-2">
                     Score {fmtNum(achievement.data.elo)} in{" "}
                     {daysBetween(achievement.data.firstGameAt, achievement.earnedAt)} days
+                  </p>
+                )}
+
+                {achievement.type === "streak-ender" && achievement.data && (
+                  <p className="text-xs text-secondary-text/70 mt-2">
+                    Ended {context.playerName(achievement.data.opponent)}'s {achievement.data.streakLength}-game win streak
+                  </p>
+                )}
+
+                {achievement.type === "group-stage-star" && achievement.data && (
+                  <p className="text-xs text-secondary-text/70 mt-2">
+                    Undefeated with {achievement.data.wins} win{achievement.data.wins !== 1 ? "s" : ""}
                   </p>
                 )}
 


### PR DESCRIPTION
Streak Ender awards the winner whenever they beat a player whose
all-games win streak was 10 or more — repeatable per qualifying win.

Group Stage Star awards each player who finishes a tournament group
stage with no losses and no own-skips (free wins from opponent skips
still count). Earned once per qualifying group stage.