### PR TITLE
Add opponent info to leap-frog achievement

### DIFF
--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -875,6 +875,7 @@ export class Achievements {
         this.#addAchievement(
           game.winner,
           this.#createAchievement("leap-frog", game.winner, game.playedAt, {
+            opponent: game.loser,
             gameId: game.id,
             ranksJumped: winnerRankBefore - winnerRankAfter,
             fromRank: winnerRankBefore,
@@ -1808,6 +1809,7 @@ type AchievementDefinitions = {
     opponentElo: number;
   };
   "leap-frog": {
+    opponent: string;
     gameId: string;
     ranksJumped: number;
     fromRank: number;

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -457,6 +457,7 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
 
                 {achievement.type === "leap-frog" && achievement.data && (
                   <div className="text-xs text-secondary-text/70 mt-2 space-y-1">
+                    <p>Beat {context.playerName(achievement.data.opponent)}</p>
                     <p>
                       Jumped {achievement.data.ranksJumped} rank
                       {achievement.data.ranksJumped !== 1 ? "s" : ""}: #{achievement.data.fromRank} → #


### PR DESCRIPTION
## Summary
Enhanced the leap-frog achievement to display the opponent's name alongside the rank jump information, providing better context for the achievement.

## Changes
- **Achievement Data Model:** Added `opponent` field to the `leap-frog` achievement definition to store the loser's player ID
- **Achievement Creation:** Updated the leap-frog achievement instantiation to capture `game.loser` as the opponent
- **UI Display:** Added opponent name display in the achievements tab using the existing `context.playerName()` helper to resolve the player ID to a readable name

## Implementation Details
The opponent information is now captured at achievement creation time from the game data and displayed in the player achievements view, making it clearer who was defeated in the rank-jumping victory.

https://claude.ai/code/session_01BjVig74Ek1uKSwJmb75eF7