### PR TITLE
Flip orientation of Points Exchanged bars

### DIFF
--- a/frontend/src/pages/player/player-points-distribution.tsx
+++ b/frontend/src/pages/player/player-points-distribution.tsx
@@ -24,7 +24,7 @@ export const PlayerPointsDistrubution: React.FC<Props> = ({ playerId }) => {
               <div
                 className={classNames(
                   "absolute h-6 group-hover:opacity-75 top-0 transition-all duration-300",
-                  points > 0 ? "right-1/2 rounded-l-md" : "left-1/2  rounded-r-md",
+                  points > 0 ? "left-1/2 rounded-r-md" : "right-1/2 rounded-l-md",
                 )}
                 style={{ width: `${(Math.abs(fraction) / 2) * 100}%`, backgroundColor: stringToColor(oponentId) }}
               />
@@ -32,7 +32,7 @@ export const PlayerPointsDistrubution: React.FC<Props> = ({ playerId }) => {
               <div
                 className={classNames(
                   "absolute top-0 text-primary-text",
-                  points > 0 ? "right-1/2 pr-2" : "left-1/2 pl-2",
+                  points > 0 ? "left-1/2 pl-2" : "right-1/2 pr-2",
                 )}
               >
                 {points?.toLocaleString("no-NO", { maximumFractionDigits: 0 })}


### PR DESCRIPTION
Mirror the positive/negative direction so positive net points extend
left and negative extend right, with the numeric labels following so
they remain inside each bar.