### PR TITLE
Improve confidence curve with half-life and exponent parameters

### DIFF
--- a/frontend/src/client/client-db/__tests__/future-elo.test.ts
+++ b/frontend/src/client/client-db/__tests__/future-elo.test.ts
@@ -1,4 +1,10 @@
-import { ConfidenceConfig, Fraction, GAME_CONFIDENCE_CONFIG } from "../future-elo";
+import {
+  ConfidenceConfig,
+  Fraction,
+  GAME_CONFIDENCE_CONFIG,
+  POINT_CONFIDENCE_CONFIG,
+  SET_CONFIDENCE_CONFIG,
+} from "../future-elo";
 import { TennisTable } from "../tennis-table";
 
 // Narrow view of FutureElo's private confidence calculation for testing
@@ -55,6 +61,17 @@ describe("FutureElo confidence curve", () => {
     const lopsided = confidenceOf(10, 0, GAME_CONFIDENCE_CONFIG);
 
     expect(balanced).toBeGreaterThan(lopsided);
+  });
+
+  it.each([
+    ["games", GAME_CONFIDENCE_CONFIG, 12],
+    ["sets", SET_CONFIDENCE_CONFIG, 25],
+    ["points", POINT_CONFIDENCE_CONFIG, 420],
+  ])("reaches ~90%% confidence at the calibration anchor for %s", (_, config, perPlayer) => {
+    const confidence = confidenceOf(perPlayer, perPlayer, config);
+
+    expect(confidence).toBeGreaterThan(0.89);
+    expect(confidence).toBeLessThan(0.91);
   });
 
   it("gives zero confidence with no data", () => {

--- a/frontend/src/client/client-db/__tests__/future-elo.test.ts
+++ b/frontend/src/client/client-db/__tests__/future-elo.test.ts
@@ -26,7 +26,7 @@ describe("FutureElo confidence curve", () => {
     futureElo.getWinFractionWithConfidence({ wins, loss, probabilityLookup, confidenceConfig }).confidence;
 
   // 10 points per game, no product term: confidence points are linear in game count
-  const linearConfig: ConfidenceConfig = { additions: 10, products: 0, halfLifePoints: 50 };
+  const linearConfig: ConfidenceConfig = { additions: 10, products: 0, halfLifePoints: 50, curveExponent: 1 };
 
   it("reaches 50% confidence at halfLifePoints", () => {
     expect(confidenceOf(5, 0, linearConfig)).toBeCloseTo(0.5, 10);
@@ -74,12 +74,19 @@ describe("FutureElo confidence curve", () => {
     expect(confidence).toBeLessThan(0.91);
   });
 
+  it("rises faster early for points: ~40% confidence already at 60:60", () => {
+    const confidence = confidenceOf(60, 60, POINT_CONFIDENCE_CONFIG);
+
+    expect(confidence).toBeGreaterThan(0.38);
+    expect(confidence).toBeLessThan(0.44);
+  });
+
   it("gives zero confidence with no data", () => {
     const result = futureElo.getWinFractionWithConfidence({
       wins: 1,
       loss: 1,
       probabilityLookup,
-      confidenceConfig: { additions: 0, products: 0, halfLifePoints: 50 },
+      confidenceConfig: { additions: 0, products: 0, halfLifePoints: 50, curveExponent: 1 },
     });
 
     expect(result.confidence).toBe(0);

--- a/frontend/src/client/client-db/__tests__/future-elo.test.ts
+++ b/frontend/src/client/client-db/__tests__/future-elo.test.ts
@@ -1,0 +1,70 @@
+import { ConfidenceConfig, Fraction, GAME_CONFIDENCE_CONFIG } from "../future-elo";
+import { TennisTable } from "../tennis-table";
+
+// Narrow view of FutureElo's private confidence calculation for testing
+type FutureEloInternal = {
+  getWinFractionWithConfidence(input: {
+    wins: number;
+    loss: number;
+    probabilityLookup: number[];
+    confidenceConfig: ConfidenceConfig;
+  }): Fraction;
+};
+
+describe("FutureElo confidence curve", () => {
+  const probabilityLookup = Array.from({ length: 101 }, (_, i) => i / 100);
+
+  const futureElo = new TennisTable({ events: [] }).futureElo as unknown as FutureEloInternal;
+
+  const confidenceOf = (wins: number, loss: number, confidenceConfig: ConfidenceConfig): number =>
+    futureElo.getWinFractionWithConfidence({ wins, loss, probabilityLookup, confidenceConfig }).confidence;
+
+  // 10 points per game, no product term: confidence points are linear in game count
+  const linearConfig: ConfidenceConfig = { additions: 10, products: 0, halfLifePoints: 50 };
+
+  it("reaches 50% confidence at halfLifePoints", () => {
+    expect(confidenceOf(5, 0, linearConfig)).toBeCloseTo(0.5, 10);
+  });
+
+  it("gives diminishing returns: doubling the data yields less than double the confidence", () => {
+    const confidence5 = confidenceOf(3, 2, linearConfig);
+    const confidence10 = confidenceOf(6, 4, linearConfig);
+
+    expect(confidence10).toBeGreaterThan(confidence5);
+    expect(confidence10).toBeLessThan(2 * confidence5);
+  });
+
+  it("lets each successive batch of games fill a fixed fraction of the remaining uncertainty", () => {
+    // With a linear points formula, remaining uncertainty after 2n games
+    // is the square of the remaining uncertainty after n games
+    const remainingAfter5 = 1 - confidenceOf(3, 2, linearConfig);
+    const remainingAfter10 = 1 - confidenceOf(6, 4, linearConfig);
+
+    expect(remainingAfter10).toBeCloseTo(remainingAfter5 * remainingAfter5, 10);
+  });
+
+  it("approaches but never reaches 100% confidence", () => {
+    const confidence = confidenceOf(25, 25, linearConfig);
+
+    expect(confidence).toBeGreaterThan(0.99);
+    expect(confidence).toBeLessThan(1);
+  });
+
+  it("requires more data for uneven win/loss ratios to gain the same confidence", () => {
+    const balanced = confidenceOf(5, 5, GAME_CONFIDENCE_CONFIG);
+    const lopsided = confidenceOf(10, 0, GAME_CONFIDENCE_CONFIG);
+
+    expect(balanced).toBeGreaterThan(lopsided);
+  });
+
+  it("gives zero confidence with no data", () => {
+    const result = futureElo.getWinFractionWithConfidence({
+      wins: 1,
+      loss: 1,
+      probabilityLookup,
+      confidenceConfig: { additions: 0, products: 0, halfLifePoints: 50 },
+    });
+
+    expect(result.confidence).toBe(0);
+  });
+});

--- a/frontend/src/client/client-db/future-elo.ts
+++ b/frontend/src/client/client-db/future-elo.ts
@@ -14,19 +14,19 @@ export type ConfidenceConfig = {
 export const GAME_CONFIDENCE_CONFIG: ConfidenceConfig = {
   additions: 3,
   products: 0.15,
-  halfLifePoints: 50,
+  halfLifePoints: 28, // ~90% confidence at 12:12 games
 };
 
 export const SET_CONFIDENCE_CONFIG: ConfidenceConfig = {
   additions: 1.6,
   products: 0.02,
-  halfLifePoints: 50,
+  halfLifePoints: 28, // ~90% confidence at 25:25 sets
 };
 
 export const POINT_CONFIDENCE_CONFIG: ConfidenceConfig = {
   additions: 0.2,
   products: 0,
-  halfLifePoints: 50,
+  halfLifePoints: 50, // ~90% confidence at 420:420 points
 };
 
 export class FutureElo {

--- a/frontend/src/client/client-db/future-elo.ts
+++ b/frontend/src/client/client-db/future-elo.ts
@@ -8,25 +8,29 @@ export type Fraction = { fraction: number; confidence: number };
 export type ConfidenceConfig = {
   additions: number;
   products: number;
-  halfLifePoints: number; // Confidence points needed to reach 50% confidence
+  halfLifePoints: number; // Confidence points needed to reach 50% confidence (at curveExponent 1)
+  curveExponent: number; // Below 1 the curve rises faster early and flattens out sooner
 };
 
 export const GAME_CONFIDENCE_CONFIG: ConfidenceConfig = {
   additions: 3,
   products: 0.15,
   halfLifePoints: 28, // ~90% confidence at 12:12 games
+  curveExponent: 1,
 };
 
 export const SET_CONFIDENCE_CONFIG: ConfidenceConfig = {
   additions: 1.6,
   products: 0.02,
   halfLifePoints: 28, // ~90% confidence at 25:25 sets
+  curveExponent: 1,
 };
 
 export const POINT_CONFIDENCE_CONFIG: ConfidenceConfig = {
   additions: 0.2,
   products: 0,
-  halfLifePoints: 50, // ~90% confidence at 420:420 points
+  halfLifePoints: 34, // ~90% confidence at 420:420 points, ~40% at 60:60
+  curveExponent: 0.75,
 };
 
 export class FutureElo {
@@ -505,7 +509,7 @@ export class FutureElo {
       wins,
       loss,
       probabilityLookup,
-      confidenceConfig: { additions, products, halfLifePoints },
+      confidenceConfig: { additions, products, halfLifePoints, curveExponent },
     } = input;
 
     // Calculate raw win fraction (0 to 1)
@@ -542,7 +546,8 @@ export class FutureElo {
 
     // Saturating curve: each confidence point fills a fixed fraction of the remaining
     // uncertainty, so early data counts more and confidence approaches 1 asymptotically.
-    const confidence = 1 - Math.pow(2, -confidencePoints / halfLifePoints);
+    // A curveExponent below 1 stretches the curve, boosting the early rise further.
+    const confidence = 1 - Math.pow(2, -Math.pow(confidencePoints / halfLifePoints, curveExponent));
 
     return {
       fraction: expectedWinProbability,

--- a/frontend/src/client/client-db/future-elo.ts
+++ b/frontend/src/client/client-db/future-elo.ts
@@ -8,21 +8,25 @@ export type Fraction = { fraction: number; confidence: number };
 export type ConfidenceConfig = {
   additions: number;
   products: number;
+  halfLifePoints: number; // Confidence points needed to reach 50% confidence
 };
 
 export const GAME_CONFIDENCE_CONFIG: ConfidenceConfig = {
   additions: 3,
   products: 0.15,
+  halfLifePoints: 50,
 };
 
 export const SET_CONFIDENCE_CONFIG: ConfidenceConfig = {
   additions: 1.6,
   products: 0.02,
+  halfLifePoints: 50,
 };
 
 export const POINT_CONFIDENCE_CONFIG: ConfidenceConfig = {
   additions: 0.2,
   products: 0,
+  halfLifePoints: 50,
 };
 
 export class FutureElo {
@@ -501,7 +505,7 @@ export class FutureElo {
       wins,
       loss,
       probabilityLookup,
-      confidenceConfig: { additions, products },
+      confidenceConfig: { additions, products, halfLifePoints },
     } = input;
 
     // Calculate raw win fraction (0 to 1)
@@ -530,11 +534,15 @@ export class FutureElo {
       expectedWinProbability = lowerValue + (upperValue - lowerValue) * fraction;
     }
 
-    // Calculate confidence based on sample size
+    // Calculate confidence based on sample size.
+    // The product term makes uneven win/loss ratios require more data to gain confidence.
     const addition = wins + loss;
     const product = wins * loss;
     const confidencePoints = addition * additions + product * products;
-    const confidence = Math.min(confidencePoints, 100) / 100;
+
+    // Saturating curve: each confidence point fills a fixed fraction of the remaining
+    // uncertainty, so early data counts more and confidence approaches 1 asymptotically.
+    const confidence = 1 - Math.pow(2, -confidencePoints / halfLifePoints);
 
     return {
       fraction: expectedWinProbability,


### PR DESCRIPTION
## Summary
Enhanced the confidence calculation in FutureElo to use a more sophisticated saturating curve model that better represents how confidence should grow with sample size. The new model uses a half-life parameter and curve exponent to create asymptotic confidence growth, where early data counts more and confidence approaches 100% but never reaches it.

## Key Changes
- **Updated `ConfidenceConfig` type** to include `halfLifePoints` and `curveExponent` parameters
  - `halfLifePoints`: The number of confidence points needed to reach 50% confidence (at exponent 1)
  - `curveExponent`: Controls curve shape; values below 1 boost early confidence rise
  
- **Calibrated confidence configs** for all three data types:
  - Games: ~90% confidence at 12:12 games
  - Sets: ~90% confidence at 25:25 sets
  - Points: ~90% confidence at 420:420 points with faster early rise (exponent 0.75)

- **Replaced linear confidence formula** with saturating curve: `1 - 2^(-(confidencePoints/halfLifePoints)^curveExponent)`
  - Provides diminishing returns: doubling data yields less than double confidence
  - Each batch of games fills a fixed fraction of remaining uncertainty
  - Asymptotically approaches but never reaches 100% confidence

- **Added comprehensive test suite** (`future-elo.test.ts`) validating:
  - Half-life calibration
  - Diminishing returns behavior
  - Asymptotic confidence growth
  - Uneven win/loss ratios requiring more data
  - Config-specific calibration anchors
  - Edge cases (zero data)

## Implementation Details
The new confidence curve uses a logarithmic saturation model where confidence points are transformed through a power function before being applied to the exponential saturation curve. This allows fine-tuning of how quickly confidence rises early (via `curveExponent`) while maintaining the property that confidence approaches 1 asymptotically.

https://claude.ai/code/session_01DtsGf34GeDCEQFxZyVpgKA