### PR TITLE
Clear client event cache via websocket when an event is edited or deleted

### DIFF
--- a/DenoServer/event-store/event-store.routes.ts
+++ b/DenoServer/event-store/event-store.routes.ts
@@ -87,8 +87,12 @@ export function registerEventStoreRoutes(api: Router) {
     // Assume frontend has validated business logic for the event // TODO: Do reducer business logic backend too
     // Run zod validation??
 
-    await updateEvent(eventPayload);
-    webSocketClientManager.broadcastRefetch();
+    const updated = await updateEvent(eventPayload);
+    if (updated === false) {
+      context.response.status = 409;
+      return;
+    }
+    webSocketClientManager.broadcastClearCache();
     context.response.status = 201;
   });
 
@@ -104,8 +108,12 @@ export function registerEventStoreRoutes(api: Router) {
     // Assume frontend has validated business logic for the event // TODO: Do reducer business logic backend too
     // Run zod validation??
 
-    await deleteEvent(eventTime);
-    webSocketClientManager.broadcastRefetch();
+    const deleted = await deleteEvent(eventTime);
+    if (deleted === false) {
+      context.response.status = 409;
+      return;
+    }
+    webSocketClientManager.broadcastClearCache();
     context.response.status = 201;
   });
 

--- a/DenoServer/integrations/gamebot/process-matches.ts
+++ b/DenoServer/integrations/gamebot/process-matches.ts
@@ -94,7 +94,7 @@ export async function processMatchesResponse(response: MatchesApiResponse) {
 
   console.log(`Compleded syncing ${matchesToSync.length} matches, resulting in ${eventsToWrite.length} events.`);
 
-  // webSocketClientManager.broadcastRefetch(); // Maybe too hars to do full refetch?
+  // webSocketClientManager.broadcastClearCache(); // Maybe too hars to do full refetch?
   webSocketClientManager.broadcastLatestEvent();
 }
 

--- a/DenoServer/web-socket/web-socket-client-manager.ts
+++ b/DenoServer/web-socket/web-socket-client-manager.ts
@@ -9,6 +9,7 @@ enum WS_MESSAGE {
   HEART_BEAT = "heart-beat",
   LATEST_EVENT = "latest-event",
   LIVE_GAME = "live-game",
+  CLEAR_CACHE = "clear-cache",
 }
 
 export class WebSocketClientManager {
@@ -142,10 +143,12 @@ export class WebSocketClientManager {
   }
 
   /**
-   * Only for event manipulation... dont use this if you can avoid it
+   * Tell all clients to clear their local storage event cache and refetch the
+   * full event history. Only for event manipulation (edit/delete), where
+   * already-cached events have changed... dont use this if you can avoid it
    */
-  broadcastRefetch() {
-    this.broadcastMessage(WS_MESSAGE.LATEST_EVENT + ":999999999999999");
+  broadcastClearCache() {
+    this.broadcastMessage(WS_MESSAGE.CLEAR_CACHE);
   }
 
   /**

--- a/frontend/src/hooks/use-web-socket.tsx
+++ b/frontend/src/hooks/use-web-socket.tsx
@@ -7,6 +7,7 @@ export enum WS_MESSAGE {
   HEART_BEAT = "heart-beat",
   LATEST_EVENT = "latest-event",
   LIVE_GAME = "live-game",
+  CLEAR_CACHE = "clear-cache",
 }
 
 export const useWebSocket = (

--- a/frontend/src/wrappers/event-db-context.tsx
+++ b/frontend/src/wrappers/event-db-context.tsx
@@ -6,12 +6,20 @@ import { EventType } from "../client/client-db/event-store/event-types";
 import { PingPongLoader } from "../common/ping-loader";
 import { useAutoSeedTournaments } from "../hooks/use-auto-seed-tournaments";
 
+export const EVENTS_LOCAL_STORAGE_KEY = "tennis-table-events";
+export const EVENTS_CACHE_TIMESTAMP_KEY = "tennis-table-events-cache-time";
+
+export function clearEventsLocalStorageCache() {
+  localStorage.removeItem(EVENTS_LOCAL_STORAGE_KEY);
+  localStorage.removeItem(EVENTS_CACHE_TIMESTAMP_KEY);
+}
+
 export function useEventDb() {
   return useQuery<EventType[]>({
     queryKey: ["event-db"],
     queryFn: async () => {
-      const LOCAL_STORAGE_KEY = "tennis-table-events";
-      const CACHE_TIMESTAMP_KEY = "tennis-table-events-cache-time";
+      const LOCAL_STORAGE_KEY = EVENTS_LOCAL_STORAGE_KEY;
+      const CACHE_TIMESTAMP_KEY = EVENTS_CACHE_TIMESTAMP_KEY;
       const TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
       const FORCE_INVALIDATE_BEFORE = new Date("2026-02-23T00:00:00").getTime();
 

--- a/frontend/src/wrappers/web-socket-refetcher.tsx
+++ b/frontend/src/wrappers/web-socket-refetcher.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useWebSocket, WS_MESSAGE } from "../hooks/use-web-socket";
 import { useEffect, useState, useRef } from "react";
-import { useEventDbContext } from "./event-db-context";
+import { clearEventsLocalStorageCache, useEventDbContext } from "./event-db-context";
 
 type Props = {
   children: React.ReactNode;
@@ -49,6 +49,13 @@ export const WebSocketRefetcher: React.FC<Props> = ({ children }) => {
     }
     if (message.startsWith(WS_MESSAGE.LIVE_GAME)) {
       queryClient.invalidateQueries({ queryKey: ["live-game"] });
+      return;
+    }
+    if (message.startsWith(WS_MESSAGE.CLEAR_CACHE)) {
+      // The event history itself was changed (edit/delete), so the cached
+      // events can no longer be trusted. Clear and refetch everything.
+      clearEventsLocalStorageCache();
+      queryClient.invalidateQueries();
       return;
     }
   }


### PR DESCRIPTION
Editing or deleting an event only triggered a fake latest-event broadcast,
and the client's refetch is incremental (only fetches events after the last
cached one), so the already-cached, now-stale event in localStorage was
never updated.

Add a dedicated clear-cache websocket message that the backend broadcasts
after a successful event update or delete. Clients respond by clearing the
localStorage event cache and invalidating queries, forcing a full refetch
of the event history. The update/delete routes now also return 409 instead
of 201 when the operation fails, and only broadcast on success.

https://claude.ai/code/session_012MiNFpEWVoeqCXsWZfXfd3