### PR TITLE
Raise Optio ranked limit to 30; show gated predictions for unranked players

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2364,6 +2364,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
       "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2375,6 +2376,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
       "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2385,6 +2387,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
       "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3207,6 +3210,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
       "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3941,6 +3945,7 @@
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
       "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4946,6 +4951,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4959,6 +4965,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4972,6 +4979,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4985,6 +4993,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4998,6 +5007,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5011,6 +5021,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5024,6 +5035,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5037,9 +5049,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5053,9 +5063,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5069,9 +5077,7 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5085,9 +5091,7 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5101,9 +5105,7 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5117,9 +5119,7 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5133,9 +5133,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5149,9 +5147,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5165,6 +5161,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5178,6 +5175,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5196,6 +5194,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5209,6 +5208,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5222,6 +5222,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -20284,8 +20285,9 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "extraneous": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/frontend/src/client/client-config/clients/optio-client.tsx
+++ b/frontend/src/client/client-config/clients/optio-client.tsx
@@ -75,5 +75,5 @@ export class OptioClient implements ClientConfig {
   snow = false;
   title = new GuestClient().title;
   favicon = new GuestClient().favicon;
-  gameLimitForRanked = 12;
+  gameLimitForRanked = 30;
 }

--- a/frontend/src/client/client-db/future-elo.ts
+++ b/frontend/src/client/client-db/future-elo.ts
@@ -47,14 +47,14 @@ export class FutureElo {
   predictedGamesTemp: { winner: string; loser: string }[][] = [];
   predictedGames: Game[] = [];
 
-  calculatePlayerFractionsForToday(overrideTime?: number, focusPlayerId?: string) {
+  calculatePlayerFractionsForToday(opts?: { overrideTime?: number; focusPlayerId?: string }) {
     this.reset();
-    this.setup(undefined, focusPlayerId);
+    this.setup(undefined, opts?.focusPlayerId);
     // Calculate win fraction for all player pairings
     for (const { p1, p2 } of this.playerPairings) {
-      this.getDirectFraction(p1, p2, overrideTime || Date.now());
-      this.getOneLayerFraction(p1, p2, overrideTime || Date.now());
-      this.getTwoLayerFraction(p1, p2, overrideTime || Date.now());
+      this.getDirectFraction(p1, p2, opts?.overrideTime || Date.now());
+      this.getOneLayerFraction(p1, p2, opts?.overrideTime || Date.now());
+      this.getTwoLayerFraction(p1, p2, opts?.overrideTime || Date.now());
     }
   }
 

--- a/frontend/src/client/client-db/future-elo.ts
+++ b/frontend/src/client/client-db/future-elo.ts
@@ -47,9 +47,9 @@ export class FutureElo {
   predictedGamesTemp: { winner: string; loser: string }[][] = [];
   predictedGames: Game[] = [];
 
-  calculatePlayerFractionsForToday(overrideTime?: number) {
+  calculatePlayerFractionsForToday(overrideTime?: number, focusPlayerId?: string) {
     this.reset();
-    this.setup();
+    this.setup(undefined, focusPlayerId);
     // Calculate win fraction for all player pairings
     for (const { p1, p2 } of this.playerPairings) {
       this.getDirectFraction(p1, p2, overrideTime || Date.now());
@@ -90,7 +90,7 @@ export class FutureElo {
     this.predictedGames = [];
   }
 
-  private setup(games?: Game[]) {
+  private setup(games?: Game[], focusPlayerId?: string) {
     // Add all existing games
     for (const game of games ?? this.parent.games) {
       const { winner, loser } = game;
@@ -131,6 +131,16 @@ export class FutureElo {
     for (let playerIndex = 0; playerIndex < rankedPlayeIds.length; playerIndex++) {
       for (let oponentIndex = playerIndex + 1; oponentIndex < rankedPlayeIds.length; oponentIndex++) {
         this.playerPairings.push({ p1: rankedPlayeIds[playerIndex], p2: rankedPlayeIds[oponentIndex] });
+      }
+    }
+
+    // When an unranked player is in focus (e.g. viewing their predictions page) pair them against
+    // every ranked player so their direct and intermediary fractions get computed like a ranked
+    // player's, even though they don't qualify for the ranked pairing grid above. Ranked focus
+    // players are already covered by the permutations above.
+    if (focusPlayerId && this.playersMap.has(focusPlayerId) && rankedPlayeIds.includes(focusPlayerId) === false) {
+      for (const rankedId of rankedPlayeIds) {
+        this.playerPairings.push({ p1: focusPlayerId, p2: rankedId });
       }
     }
 

--- a/frontend/src/client/client-db/tournaments/prediction.ts
+++ b/frontend/src/client/client-db/tournaments/prediction.ts
@@ -93,7 +93,7 @@ export class TournamentPrediction {
     });
 
     const stateAtTime = new TennisTable({ events: eventsUpToTime }); // TODO Performance test impact of this performance.now before and after
-    stateAtTime.futureElo.calculatePlayerFractionsForToday(simulationTime); // TODO Performance test impact of this performance.now before and after
+    stateAtTime.futureElo.calculatePlayerFractionsForToday({ overrideTime: simulationTime }); // TODO Performance test impact of this performance.now before and after
 
     const tournamentAtTime = stateAtTime.tournaments.getTournament(tournamentId);
     if (!tournamentAtTime) {

--- a/frontend/src/pages/player/player-page.tsx
+++ b/frontend/src/pages/player/player-page.tsx
@@ -132,7 +132,8 @@ export const PlayerPage: React.FC = () => {
                 case "statistics":
                   return summary.games.length > 0;
                 case "predictions":
-                  return summary.isRanked && isActive;
+                  // Unranked players still get the tab (gated behind a warning); retired players don't.
+                  return isActive;
                 case "season":
                   // Show tab if player has participated in any season
                   return hasParticipatedInAnySeason;
@@ -367,7 +368,9 @@ export const PlayerPage: React.FC = () => {
           </div>
         )}
         {activeTab === "achievements" && playerId && <PlayerAchievements playerId={playerId} />}
-        {activeTab === "predictions" && playerId && <PlayerPredictionsPage playerId={playerId} />}
+        {activeTab === "predictions" && playerId && (
+          <PlayerPredictionsPage playerId={playerId} isRanked={summary.isRanked} />
+        )}
         {activeTab === "season" && playerId && <PlayerSeasonStats playerId={playerId} />}
       </div>
     </div>

--- a/frontend/src/pages/player/player-page.tsx
+++ b/frontend/src/pages/player/player-page.tsx
@@ -265,7 +265,7 @@ export const PlayerPage: React.FC = () => {
           <div className="overflow-x-auto bg-primary-background text-primary-text rounded-xl px-1">
             <table className="w-full min-w-[450px]">
               <thead>
-                <tr className="border-b border-gray-200 text-xs md:text-sm">
+                <tr className="border-b border-gray-200 text-xs md:text-sm lg:text-base xl:text-lg">
                   <th className="text-left py-2 md:py-3 px-1 md:px-4 font-medium">Opponent</th>
                   <th className="text-left py-2 md:py-3 px-1 font-medium"></th>
                   <th className="text-left py-2 md:py-3 px-1 font-medium">Pts</th>
@@ -274,7 +274,7 @@ export const PlayerPage: React.FC = () => {
                   <th className="text-left py-2 md:py-3 px-1 md:px-4 font-medium">Actions</th>
                 </tr>
               </thead>
-              <tbody className="text-xs md:text-sm">
+              <tbody className="text-xs md:text-sm lg:text-base xl:text-lg">
                 {summary.games
                   .toReversed()
                   .slice(0, isAdmin ? undefined : 10)
@@ -286,7 +286,7 @@ export const PlayerPage: React.FC = () => {
                         </Link>
                       </td>
                       <td className="py-1 px-1">
-                        <span className="text-base md:text-2xl">{game.result === "win" ? "🏆" : "💔"}</span>
+                        <span className="text-base md:text-2xl lg:text-3xl">{game.result === "win" ? "🏆" : "💔"}</span>
                       </td>
                       <td className="py-1 px-1">
                         <span className="font-medium">
@@ -303,7 +303,7 @@ export const PlayerPage: React.FC = () => {
                           </div>
                         )}
                         {game.score?.setPoints && (
-                          <div className="font-light italic text-xs whitespace-nowrap">
+                          <div className="font-light italic text-xs lg:text-sm whitespace-nowrap">
                             {game.result === "win"
                               ? game.score.setPoints.map((set) => `${set.gameWinner}-${set.gameLoser}`).join(", ")
                               : game.score.setPoints.map((set) => `${set.gameLoser}-${set.gameWinner}`).join(", ")}

--- a/frontend/src/pages/player/player-predictions-list.tsx
+++ b/frontend/src/pages/player/player-predictions-list.tsx
@@ -27,7 +27,7 @@ export const PlayerPredictionsList = ({ playerId }: Props) => {
   const context = useEventDbContext();
   // Pass the focus player so unranked players still get paired against every ranked player and
   // receive direct + intermediary fractions, just like a ranked player.
-  context.futureElo.calculatePlayerFractionsForToday(undefined, playerId);
+  context.futureElo.calculatePlayerFractionsForToday({ focusPlayerId: playerId });
 
   const leaderboard = context.leaderboard.getLeaderboard();
 

--- a/frontend/src/pages/player/player-predictions-list.tsx
+++ b/frontend/src/pages/player/player-predictions-list.tsx
@@ -25,22 +25,19 @@ export const PlayerPredictionsList = ({ playerId }: Props) => {
   };
 
   const context = useEventDbContext();
-  context.futureElo.calculatePlayerFractionsForToday();
+  // Pass the focus player so unranked players still get paired against every ranked player and
+  // receive direct + intermediary fractions, just like a ranked player.
+  context.futureElo.calculatePlayerFractionsForToday(undefined, playerId);
 
   const leaderboard = context.leaderboard.getLeaderboard();
 
   const playersData = context.futureElo.playersMap.get(playerId)!;
 
-  const opponents = Array.from(playersData.oponentsMap.entries())
-    .filter((o) => leaderboard.rankedPlayers.find((r) => r.id === o[0]))
-    .sort((a, b) => {
-      const aRankedIndex = leaderboard.rankedPlayers.findIndex((r) => r.id === a[0]);
-      const bRankedIndex = leaderboard.rankedPlayers.findIndex((r) => r.id === b[0]);
-      return (
-        (leaderboard.rankedPlayers[aRankedIndex]?.rank || Infinity) -
-        (leaderboard.rankedPlayers[bRankedIndex]?.rank || Infinity)
-      );
-    });
+  // List every currently ranked player as an opponent (ordered by rank), regardless of whether the
+  // focus player has played them, so the breakdown matches what a ranked player sees.
+  const opponents = leaderboard.rankedPlayers
+    .filter((r) => r.id !== playerId && playersData.oponentsMap.has(r.id))
+    .map((r) => [r.id, playersData.oponentsMap.get(r.id)!] as const);
 
   return (
     <div className="space-y-2">

--- a/frontend/src/pages/player/player-predictions-page.tsx
+++ b/frontend/src/pages/player/player-predictions-page.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { PlayerPredictionsList } from "./player-predictions-list";
 import { PlayerPredictionsHistory } from "./players-predictions-history";
 import { classNames } from "../../common/class-names";
@@ -11,11 +12,17 @@ const tabs: { id: TabType; label: string }[] = [
 
 type Props = {
   playerId: string;
+  isRanked: boolean;
 };
 
-export const PlayerPredictionsPage = ({ playerId }: Props) => {
+export const PlayerPredictionsPage = ({ playerId, isRanked }: Props) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const activeTab = (searchParams.get("predictionTab") as TabType) || "history";
+
+  // Unranked players are gated behind a warning. They can choose to reveal the
+  // predictions anyway, after which a persistent banner keeps reminding them the
+  // data is insufficient.
+  const [revealed, setRevealed] = useState(false);
 
   const setActiveTab = (tab: TabType) => {
     setSearchParams((prev) => {
@@ -25,8 +32,34 @@ export const PlayerPredictionsPage = ({ playerId }: Props) => {
     });
   };
 
+  if (!isRanked && !revealed) {
+    return (
+      <div className="flex flex-col h-full sm:-mt-4 md:-mt-8">
+        <div className="mx-auto my-8 max-w-md rounded-xl border border-yellow-500/40 bg-yellow-500/10 p-6 text-center text-secondary-text">
+          <div className="text-3xl mb-2">⚠️</div>
+          <p className="text-lg font-semibold mb-1">This player is not ranked</p>
+          <p className="text-sm text-secondary-text/80 mb-4">
+            Predictions are based on insufficient data and may be unreliable.
+          </p>
+          <button
+            onClick={() => setRevealed(true)}
+            className="rounded-md bg-tertiary-background px-4 py-2 text-sm font-medium text-tertiary-text hover:bg-tertiary-background/70 transition-colors"
+          >
+            Show predictions anyway
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex flex-col h-full sm:-mt-4 md:-mt-8">
+      {!isRanked && (
+        <div className="mb-4 flex items-center gap-2 rounded-lg border border-yellow-500/40 bg-yellow-500/10 px-4 py-2 text-sm text-secondary-text">
+          <span>⚠️</span>
+          <span>This player is not ranked — predictions are based on insufficient data and may be unreliable.</span>
+        </div>
+      )}
       {/* Tabs */}
       <div className="bg-secondary-background  px-0 mb-4">
         <div className="flex space-x-2 overflow-auto">


### PR DESCRIPTION
- Bump Optio gameLimitForRanked from 12 to 30
- Show the Predictions tab for active unranked players (previously hidden)
- Gate unranked predictions behind a warning with a 'Show anyway' button,
  and keep a persistent insufficient-data banner once revealed

https://claude.ai/code/session_01CJnahn3BqREKZe43DyvVqN