### PR TITLE
Add Hall of Fame full hypothetical leaderboard page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -47,6 +47,7 @@ import { SeasonPlayerPage } from "./pages/seasons/season-player-page";
 import { RecentGamesPage } from "./pages/recent-games/recent-games-page";
 import { HallOfFamePage } from "./pages/hall-of-fame/hall-of-fame-page";
 import { HallOfFamePlayerPage } from "./pages/hall-of-fame/hall-of-fame-player-page";
+import { HallOfFameLeaderboardPage } from "./pages/hall-of-fame/hall-of-fame-leaderboard-page";
 import { LiveGamePage } from "./pages/live-game/live-game-page";
 import { LiveGameAdminPage } from "./pages/live-game/live-game-admin-page";
 import { LiveGameOverlay } from "./pages/live-game/live-game-overlay";
@@ -111,6 +112,7 @@ function App() {
                         <Route path="/achievements" element={<AchievementsPage />} />
                         <Route path="/hall-of-fame">
                           <Route index element={<HallOfFamePage />} />
+                          <Route path="leaderboard" element={<HallOfFameLeaderboardPage />} />
                           <Route path=":playerId" element={<HallOfFamePlayerPage />} />
                         </Route>
                         <Route path="/simulations">

--- a/frontend/src/client/client-db/hall-of-fame.ts
+++ b/frontend/src/client/client-db/hall-of-fame.ts
@@ -116,6 +116,11 @@ export class HallOfFame {
     return this.totalRanks?.get(playerId) ?? 0;
   }
 
+  getRankedPlayerCount(): number {
+    this.#ensureCrossPlayerStats();
+    return this.totalRanks?.size ?? 0;
+  }
+
   clearCache() {
     this.cache = undefined;
     this.playerCache.clear();

--- a/frontend/src/client/client-db/hall-of-fame.ts
+++ b/frontend/src/client/client-db/hall-of-fame.ts
@@ -74,6 +74,19 @@ export class HallOfFame {
     return this.getHallOfFame().find((e) => e.playerId === playerId);
   }
 
+  getFullHypotheticalLeaderboard(): HallOfFameEntry[] {
+    const allPlayers = [
+      ...this.parent.eventStore.playersProjector.activePlayers,
+      ...this.parent.eventStore.playersProjector.inactivePlayers,
+    ];
+    const entries: HallOfFameEntry[] = [];
+    for (const player of allPlayers) {
+      const entry = this.getScoreForAnyPlayer(player.id);
+      if (entry) entries.push(entry);
+    }
+    return entries.sort((a, b) => b.score.total - a.score.total);
+  }
+
   getScoreForAnyPlayer(playerId: string): HallOfFameEntry | undefined {
     const cached = this.playerCache.get(playerId);
     if (cached) return cached;

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-leaderboard-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-leaderboard-page.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useEventDbContext } from "../../wrappers/event-db-context";
+import { ProfilePicture } from "../player/profile-picture";
+import { fmtNum } from "../../common/number-utils";
+
+export const HallOfFameLeaderboardPage: React.FC = () => {
+  const context = useEventDbContext();
+  const navigate = useNavigate();
+  const entries = context.hallOfFame.getFullHypotheticalLeaderboard();
+
+  return (
+    <div className="w-full px-4 flex flex-col items-center">
+      <div className="bg-primary-background rounded-lg w-full max-w-xl">
+        <div className="flex items-center gap-4 px-4 pt-4">
+          <Link to="/hall-of-fame" className="text-primary-text hover:underline text-sm">
+            &larr; Back
+          </Link>
+        </div>
+        <h1 className="text-2xl text-center text-primary-text mt-2 mb-1">Full Hypothetical Leaderboard</h1>
+        <p className="text-primary-text text-sm text-center mb-4 px-4">
+          Hall of Fame scores for every player — both retired and currently active. Scores for active players are
+          hypothetical and will keep changing as they keep playing.
+        </p>
+        {entries.length === 0 ? (
+          <p className="text-secondary-background text-sm text-center pb-4">No players yet.</p>
+        ) : (
+          <table className="w-full text-primary-text">
+            <thead>
+              <tr className="text-base">
+                <th className="text-left py-2 px-2 font-normal w-8">#</th>
+                <th className="text-left py-2 px-2 font-normal">Name</th>
+                <th className="text-right py-2 px-2 font-normal whitespace-nowrap">Hall of Fame Score</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-primary-text/50">
+              {entries.map((entry, index) => {
+                const player = context.eventStore.playersProjector.getPlayer(entry.playerId);
+                const isActive = player?.active ?? false;
+                return (
+                  <tr
+                    key={entry.playerId}
+                    onClick={() => navigate(`/hall-of-fame/${entry.playerId}`)}
+                    className="cursor-pointer hover:bg-secondary-background hover:text-secondary-text text-xl font-light"
+                  >
+                    <td className="py-2 px-2 italic">{index + 1}</td>
+                    <td className="py-2 px-2">
+                      <div className="flex items-center gap-3 font-normal whitespace-nowrap">
+                        <ProfilePicture playerId={entry.playerId} size={28} border={2} />
+                        {entry.playerName}
+                        {!isActive && (
+                          <span className="bg-secondary-background text-secondary-text text-xs px-2 py-0.5 rounded-full font-normal">
+                            Retired
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="py-2 px-2 text-right">{fmtNum(entry.score.total)}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
@@ -264,6 +264,7 @@ export const HallOfFamePlayerPage: React.FC = () => {
     ? context.hallOfFame.getSectionStats(playerId)
     : undefined;
   const totalRank = viewMode === "compared" ? context.hallOfFame.getTotalRank(playerId) : 0;
+  const playerCount = viewMode === "compared" ? context.hallOfFame.getRankedPlayerCount() : 0;
 
   const total = entry.score.total || 1;
 
@@ -315,7 +316,7 @@ export const HallOfFamePlayerPage: React.FC = () => {
             <h2 className="text-xl text-primary-text font-semibold">Hall of Fame Score Breakdown</h2>
             <span className="text-primary-text font-bold text-2xl">
               {viewMode === "compared" && totalRank > 0 && (
-                <span className="text-primary-text/70 mr-1.5 text-lg font-medium">#{totalRank} ·</span>
+                <span className="text-primary-text/70 mr-1.5 text-lg font-medium">#{totalRank} of {playerCount} ·</span>
               )}
               {fmtNum(entry.score.total)} pts
             </span>
@@ -377,7 +378,7 @@ export const HallOfFamePlayerPage: React.FC = () => {
                   </span>
                   <span className="text-primary-text font-medium text-sm">
                     {viewMode === "compared" && segment.rank > 0 && (
-                      <span className="text-primary-text/70 mr-1.5">#{segment.rank} ·</span>
+                      <span className="text-primary-text/70 mr-1.5">#{segment.rank} of {playerCount} ·</span>
                     )}
                     {fmtNum(segment.value)} pts
                     {viewMode === "compared" && (
@@ -408,7 +409,7 @@ export const HallOfFamePlayerPage: React.FC = () => {
             </span>
             <span className="text-primary-text font-bold text-2xl">
               {viewMode === "compared" && totalRank > 0 && (
-                <span className="text-primary-text/70 mr-1.5 text-lg font-medium">#{totalRank} ·</span>
+                <span className="text-primary-text/70 mr-1.5 text-lg font-medium">#{totalRank} of {playerCount} ·</span>
               )}
               {fmtNum(entry.score.total)} pts
             </span>

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { useEventDbContext } from "../../wrappers/event-db-context";
 import { ProfilePicture } from "../player/profile-picture";
 import { HallOfFameScoreBreakdown } from "../../client/client-db/hall-of-fame";
@@ -232,6 +232,7 @@ const FACTORS: { key: FactorKey; emoji: string; name: string }[] = [
 
 export const HallOfFamePlayerPage: React.FC = () => {
   const { playerId } = useParams<{ playerId: string }>();
+  const navigate = useNavigate();
   const context = useEventDbContext();
   const [storedViewMode, setStoredViewMode] = useLocalStorage(VIEW_MODE_STORAGE_KEY, "total");
   const viewMode: ViewMode = storedViewMode === "compared" ? "compared" : "total";
@@ -353,6 +354,18 @@ export const HallOfFamePlayerPage: React.FC = () => {
                 </button>
               );
             })}
+            <button
+              type="button"
+              role="tab"
+              aria-selected={false}
+              onClick={() => navigate("/hall-of-fame/leaderboard")}
+              className={classNames(
+                "px-3 py-1 rounded-full text-xs font-medium transition-colors",
+                "text-secondary-text hover:text-primary-text",
+              )}
+            >
+              Full hypothetical leaderboard
+            </button>
           </div>
 
           <div className="space-y-6">


### PR DESCRIPTION
## Summary
Adds a new full hypothetical leaderboard page for the Hall of Fame that displays scores for all players (both active and retired) in a single ranked view.

## Key Changes
- **New page component** (`HallOfFameLeaderboardPage`): Displays a complete ranked leaderboard of all players' Hall of Fame scores, with visual distinction for retired players
- **New leaderboard method** (`getFullHypotheticalLeaderboard`): Combines active and inactive players, calculates their Hall of Fame scores, and returns them sorted by total score
- **Navigation integration**: Added a "Full hypothetical leaderboard" button to the Hall of Fame player page that links to the new leaderboard view
- **Route configuration**: Added the new route `/hall-of-fame/leaderboard` to the app routing

## Implementation Details
- The leaderboard displays rank, player name with profile picture, and Hall of Fame score
- Retired players are marked with a "Retired" badge
- Rows are clickable to navigate to individual player Hall of Fame pages
- The page includes explanatory text clarifying that active player scores are hypothetical and subject to change
- Uses existing styling patterns and components (ProfilePicture, responsive layout, hover states)

https://claude.ai/code/session_01HYjZZSEZJE6MFoUUmtgYJe