### PR TITLE
Split Hall of Fame experience into games won/lost sub-scores

### DIFF
--- a/frontend/src/client/client-db/hall-of-fame.ts
+++ b/frontend/src/client/client-db/hall-of-fame.ts
@@ -11,7 +11,7 @@ export type HallOfFameScoreBreakdown = {
   socialDiversity: { score: number; uniqueOpponents: number };
   tournamentProgression: { score: number; tournaments: TournamentDetail[] };
   longevity: { score: number; activeDays: number };
-  experience: { score: number; games: number };
+  experience: { score: number; gamesWon: number; gamesLost: number };
   dataVolume: { score: number; gamesWithSets: number; gamesWithPoints: number };
   peakElo: { score: number; peakElo: number };
   podiumTime: { score: number; rank1Days: number; rank2Days: number; rank3Days: number };
@@ -359,10 +359,13 @@ export class HallOfFame {
   }
 
   #calcExperience(playerId: string): HallOfFameScoreBreakdown["experience"] {
-    const games = this.parent.games.filter(
-      (g) => g.winner === playerId || g.loser === playerId,
-    ).length;
-    return { score: games * 3, games };
+    let gamesWon = 0;
+    let gamesLost = 0;
+    for (const game of this.parent.games) {
+      if (game.winner === playerId) gamesWon++;
+      else if (game.loser === playerId) gamesLost++;
+    }
+    return { score: gamesWon * 3 + gamesLost * 1, gamesWon, gamesLost };
   }
 
   #calcDataVolume(playerId: string): HallOfFameScoreBreakdown["dataVolume"] {

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
@@ -133,9 +133,15 @@ function renderDetails(breakdown: HallOfFameScoreBreakdown, key: FactorKey): Rea
         <div className="text-primary-text text-xs space-y-1.5">
           <div className="flex flex-wrap gap-1.5">
             <span className="bg-secondary-background text-secondary-text px-2 py-0.5 rounded text-xs inline-flex items-center gap-1.5">
-              Games played: 3 pts
+              Games won: 3 pts
               <span className="bg-tertiary-background text-tertiary-text h-5 min-w-5 px-1 rounded-full inline-flex items-center justify-center text-xs font-bold">
-                {fmtNum(d.games)}x
+                {fmtNum(d.gamesWon)}x
+              </span>
+            </span>
+            <span className="bg-secondary-background text-secondary-text px-2 py-0.5 rounded text-xs inline-flex items-center gap-1.5">
+              Games lost: 1 pt
+              <span className="bg-tertiary-background text-tertiary-text h-5 min-w-5 px-1 rounded-full inline-flex items-center justify-center text-xs font-bold">
+                {fmtNum(d.gamesLost)}x
               </span>
             </span>
           </div>


### PR DESCRIPTION
Experience now awards 3 pts per game won and 1 pt per game lost,
displayed as two separate badges in the score breakdown.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Gx3eRn47di2JXmMpvBWa6A