### PR TITLE
Add category filtering and sorting to Hall of Fame leaderboard

### DIFF
--- a/frontend/src/pages/hall-of-fame/hall-of-fame-leaderboard-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-leaderboard-page.tsx
@@ -129,10 +129,17 @@ export const HallOfFameLeaderboardPage: React.FC = () => {
                   <tr
                     key={entry.playerId}
                     onClick={() => navigate(`/hall-of-fame/${entry.playerId}`)}
-                    className="cursor-pointer hover:bg-secondary-background hover:text-secondary-text text-xl font-light"
+                    className="relative cursor-pointer hover:bg-secondary-background hover:text-secondary-text text-xl font-light"
                   >
-                    <td className="py-2 px-2 italic">{index + 1}</td>
-                    <td className="py-2 px-2 relative overflow-hidden">
+                    <td className="py-2 px-2 italic">
+                      {index + 1}
+                      {/* Bar spans the full row width; the row is the positioning context. */}
+                      <div
+                        className="absolute bottom-0 left-0 h-[2px] bg-current"
+                        style={{ width: `${relativePercent}%` }}
+                      />
+                    </td>
+                    <td className="py-2 px-2">
                       <div className="flex items-center gap-3 font-normal whitespace-nowrap">
                         <ProfilePicture playerId={entry.playerId} size={28} border={2} />
                         {entry.playerName}
@@ -142,10 +149,6 @@ export const HallOfFameLeaderboardPage: React.FC = () => {
                           </span>
                         )}
                       </div>
-                      <div
-                        className="absolute bottom-0 left-0 h-[2px] bg-current"
-                        style={{ width: `${relativePercent}%` }}
-                      />
                     </td>
                     <td className="py-2 px-2 text-right">
                       {fmtNum(score)}

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-leaderboard-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-leaderboard-page.tsx
@@ -1,13 +1,44 @@
-import React from "react";
+import React, { useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { useEventDbContext } from "../../wrappers/event-db-context";
 import { ProfilePicture } from "../player/profile-picture";
 import { fmtNum } from "../../common/number-utils";
+import { classNames } from "../../common/class-names";
+import { HallOfFameEntry, HallOfFameFactorKey } from "../../client/client-db/hall-of-fame";
+import { FACTORS } from "./hall-of-fame-player-page";
+
+type CategoryOption = HallOfFameFactorKey | "all";
+type SortBy = "category" | "total";
 
 export const HallOfFameLeaderboardPage: React.FC = () => {
   const context = useEventDbContext();
   const navigate = useNavigate();
   const entries = context.hallOfFame.getFullHypotheticalLeaderboard();
+
+  const [selectedCategory, setSelectedCategory] = useState<CategoryOption>("all");
+  const [sortBy, setSortBy] = useState<SortBy>("category");
+
+  const isCategory = selectedCategory !== "all";
+  const selectedFactor = FACTORS.find((f) => f.key === selectedCategory);
+
+  const displayedScore = (entry: HallOfFameEntry): number =>
+    selectedCategory === "all" ? entry.score.total : entry.score[selectedCategory].score;
+
+  // getFullHypotheticalLeaderboard() already returns entries sorted by total score.
+  const sortedEntries = useMemo(() => {
+    if (selectedCategory === "all" || sortBy === "total") {
+      return entries;
+    }
+    return [...entries].sort((a, b) => b.score[selectedCategory].score - a.score[selectedCategory].score);
+  }, [entries, selectedCategory, sortBy]);
+
+  // Highest displayed score, used to size the relative bar on each row.
+  const maxScore = useMemo(() => {
+    return sortedEntries.reduce((max, entry) => {
+      const score = selectedCategory === "all" ? entry.score.total : entry.score[selectedCategory].score;
+      return Math.max(max, score);
+    }, 0);
+  }, [sortedEntries, selectedCategory]);
 
   return (
     <div className="w-full px-4 flex flex-col items-center">
@@ -22,7 +53,60 @@ export const HallOfFameLeaderboardPage: React.FC = () => {
           Hall of Fame scores for every player — both retired and currently active. Scores for active players are
           hypothetical and will keep changing as they keep playing.
         </p>
-        {entries.length === 0 ? (
+
+        {/* Category filter + sort toggle */}
+        <div className="flex flex-wrap items-center justify-center gap-3 px-4 mb-4">
+          <div className="flex items-center gap-2">
+            <label htmlFor="hof-category" className="text-primary-text text-sm">
+              Category:
+            </label>
+            <select
+              id="hof-category"
+              value={selectedCategory}
+              onChange={(e) => setSelectedCategory(e.target.value as CategoryOption)}
+              className="px-3 py-2 bg-secondary-background text-secondary-text border border-primary-text rounded text-sm min-w-[180px]"
+            >
+              <option value="all">🏅 Total score</option>
+              {FACTORS.map((factor) => (
+                <option key={factor.key} value={factor.key}>
+                  {factor.emoji} {factor.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {isCategory && (
+            <div role="tablist" aria-label="Sort by" className="inline-flex bg-secondary-background rounded-full p-1">
+              {(
+                [
+                  { value: "category" as const, label: `${selectedFactor?.name ?? "Category"} score` },
+                  { value: "total" as const, label: "Total score" },
+                ]
+              ).map((option) => {
+                const active = sortBy === option.value;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    role="tab"
+                    aria-selected={active}
+                    onClick={() => setSortBy(option.value)}
+                    className={classNames(
+                      "px-3 py-1 rounded-full text-xs font-medium transition-colors",
+                      active
+                        ? "bg-tertiary-background text-tertiary-text shadow-sm"
+                        : "text-secondary-text hover:text-primary-text",
+                    )}
+                  >
+                    {option.label}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {sortedEntries.length === 0 ? (
           <p className="text-secondary-background text-sm text-center pb-4">No players yet.</p>
         ) : (
           <table className="w-full text-primary-text">
@@ -30,13 +114,17 @@ export const HallOfFameLeaderboardPage: React.FC = () => {
               <tr className="text-base">
                 <th className="text-left py-2 px-2 font-normal w-8">#</th>
                 <th className="text-left py-2 px-2 font-normal">Name</th>
-                <th className="text-right py-2 px-2 font-normal whitespace-nowrap">Hall of Fame Score</th>
+                <th className="text-right py-2 px-2 font-normal whitespace-nowrap">
+                  {isCategory ? `${selectedFactor?.emoji ?? ""} ${selectedFactor?.name ?? "Score"}` : "Hall of Fame Score"}
+                </th>
               </tr>
             </thead>
             <tbody className="divide-y divide-primary-text/50">
-              {entries.map((entry, index) => {
+              {sortedEntries.map((entry, index) => {
                 const player = context.eventStore.playersProjector.getPlayer(entry.playerId);
                 const isActive = player?.active ?? false;
+                const score = displayedScore(entry);
+                const relativePercent = maxScore > 0 ? (score / maxScore) * 100 : 0;
                 return (
                   <tr
                     key={entry.playerId}
@@ -44,7 +132,7 @@ export const HallOfFameLeaderboardPage: React.FC = () => {
                     className="cursor-pointer hover:bg-secondary-background hover:text-secondary-text text-xl font-light"
                   >
                     <td className="py-2 px-2 italic">{index + 1}</td>
-                    <td className="py-2 px-2">
+                    <td className="py-2 px-2 relative overflow-hidden">
                       <div className="flex items-center gap-3 font-normal whitespace-nowrap">
                         <ProfilePicture playerId={entry.playerId} size={28} border={2} />
                         {entry.playerName}
@@ -54,8 +142,17 @@ export const HallOfFameLeaderboardPage: React.FC = () => {
                           </span>
                         )}
                       </div>
+                      <div
+                        className="absolute bottom-0 left-0 h-[2px] bg-current"
+                        style={{ width: `${relativePercent}%` }}
+                      />
                     </td>
-                    <td className="py-2 px-2 text-right">{fmtNum(entry.score.total)}</td>
+                    <td className="py-2 px-2 text-right">
+                      {fmtNum(score)}
+                      {isCategory && (
+                        <span className="text-primary-text/50 text-sm ml-1.5">/ {fmtNum(entry.score.total)} total</span>
+                      )}
+                    </td>
                   </tr>
                 );
               })}

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-leaderboard-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-leaderboard-page.tsx
@@ -135,7 +135,7 @@ export const HallOfFameLeaderboardPage: React.FC = () => {
                       {index + 1}
                       {/* Bar spans the full row width; the row is the positioning context. */}
                       <div
-                        className="absolute bottom-0 left-0 h-[2px] bg-current"
+                        className="absolute bottom-0 left-0 h-[3px] bg-current"
                         style={{ width: `${relativePercent}%` }}
                       />
                     </td>

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
@@ -224,7 +224,7 @@ function renderDetails(breakdown: HallOfFameScoreBreakdown, key: FactorKey): Rea
   }
 }
 
-const FACTORS: { key: FactorKey; emoji: string; name: string }[] = [
+export const FACTORS: { key: FactorKey; emoji: string; name: string }[] = [
   { key: "peakElo", emoji: "🔥", name: "All-Time High" },
   { key: "podiumTime", emoji: "🥉", name: "Podium Time" },
   { key: "experience", emoji: "🏓", name: "Experience" },


### PR DESCRIPTION
## Summary
Enhanced the Hall of Fame leaderboard page with filtering and sorting capabilities, allowing users to view scores by individual categories (e.g., Peak Elo, Podium Time, Experience) or total score, with dynamic sorting options.

## Key Changes
- **Category filtering:** Added a dropdown selector to filter the leaderboard by individual scoring factors or view all scores combined
- **Dynamic sorting:** When viewing a specific category, users can toggle between sorting by that category's score or by total score
- **Visual enhancements:** Added a relative score bar beneath player names to provide visual comparison of scores
- **Score display:** The score column now shows the relevant score (category or total) with context about total score when viewing a category
- **Exported FACTORS constant:** Made the `FACTORS` array exportable from `hall-of-fame-player-page.tsx` for reuse in the leaderboard page

## Implementation Details
- Used `useMemo` to optimize sorting and max score calculations based on selected category and sort preference
- The leaderboard respects the existing total score ordering from `getFullHypotheticalLeaderboard()` when viewing all scores
- Added accessible UI controls with proper ARIA labels for the sort toggle buttons
- The relative score bar width is calculated as a percentage of the maximum score in the current view

https://claude.ai/code/session_01CK9L5xacrmcvjEpCqEfbmr