### PR TITLE
Fix Anniversary achievement window to use calendar dates

### DIFF
--- a/frontend/src/client/client-db/__tests__/achievements/anniversary.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/anniversary.test.ts
@@ -55,6 +55,39 @@ describe("TennisTable", () => {
       expect(anniversariesFor(events, "alice")).toHaveLength(0);
     });
 
+    // The window is by calendar date (day before / day of / day after), not a
+    // strict ±24h band around the anniversary instant.
+    const at = (y: number, mo: number, d: number, h = 12) => new Date(y, mo, d, h, 0, 0, 0).getTime();
+
+    it("awards a game late on the day-after date even though it is more than 24h past the anniversary instant", () => {
+      const firstGame = at(2021, 0, 15, 8); // first game in the morning
+      // Day after the Jan-15-2022 anniversary, at night: ~39h after the instant.
+      const game1 = at(2022, 0, 16, 23);
+      expect(game1 - (firstGame + ONE_YEAR)).toBeGreaterThan(ONE_DAY); // outside the old ±24h band
+
+      const events = [...baseEvents(), game("g0", firstGame), game("g1", game1)];
+      const earned = anniversariesFor(events, "alice");
+      expect(earned).toHaveLength(1);
+      expect(earned[0].data).toStrictEqual({ firstGameAt: firstGame, year: 1 });
+    });
+
+    it("awards a game early on the day-before date even though it is more than 24h before the anniversary instant", () => {
+      const firstGame = at(2021, 0, 15, 20); // first game in the evening
+      const game1 = at(2022, 0, 14, 1); // day before the anniversary, just after midnight
+      expect(firstGame + ONE_YEAR - game1).toBeGreaterThan(ONE_DAY); // outside the old ±24h band
+
+      const events = [...baseEvents(), game("g0", firstGame), game("g1", game1)];
+      const earned = anniversariesFor(events, "alice");
+      expect(earned).toHaveLength(1);
+      expect(earned[0].data).toStrictEqual({ firstGameAt: firstGame, year: 1 });
+    });
+
+    it("does not award a game two calendar days after the anniversary date", () => {
+      const firstGame = at(2021, 0, 15, 8);
+      const events = [...baseEvents(), game("g0", firstGame), game("g1", at(2022, 0, 17, 0))];
+      expect(anniversariesFor(events, "alice")).toHaveLength(0);
+    });
+
     it("does not award for games well short of one year", () => {
       const sixMonths = 6 * 30 * ONE_DAY;
       const events = [...baseEvents(), game("g0", T0), game("g1", T0 + sixMonths)];

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -227,8 +227,8 @@ export class Achievements {
       this.#checkBackAfterAchievement(game.winner, winner.lastActiveAt, game.playedAt);
       this.#checkBackAfterAchievement(game.loser, loser.lastActiveAt, game.playedAt);
 
-      // Check for "Anniversary": a game played within ±1 day of the one-year
-      // mark of the player's first ever game.
+      // Check for "Anniversary": a game played on the day before, the day of,
+      // or the day after a yearly mark of the player's first ever game.
       this.#checkAnniversaryAchievement(game.winner, winner.firstActiveAt, game.playedAt);
       this.#checkAnniversaryAchievement(game.loser, loser.firstActiveAt, game.playedAt);
 
@@ -1211,21 +1211,43 @@ export class Achievements {
     }
   }
 
-  // Awards "Anniversary" when a player plays a game within ±1 day of a yearly
-  // mark of their first ever game (1 year, 2 years, ...). Earnable once per
+  // The calendar date of a player's `year`-th anniversary: the same month and
+  // day as their first ever game, `year` years later. Returned at local
+  // midnight (matching the seasons logic, which also works in local time).
+  #anniversaryDate(firstActiveAt: number, year: number): Date {
+    const date = new Date(firstActiveAt);
+    date.setHours(0, 0, 0, 0);
+    date.setFullYear(date.getFullYear() + year);
+    return date;
+  }
+
+  // Whole calendar days between two instants (local time). Both are floored to
+  // local midnight first; Math.round absorbs DST days that are 23 or 25 hours.
+  #calendarDayDiff(aMs: number, bMs: number): number {
+    const ONE_DAY = 24 * 60 * 60 * 1000;
+    const a = new Date(aMs);
+    a.setHours(0, 0, 0, 0);
+    const b = new Date(bMs);
+    b.setHours(0, 0, 0, 0);
+    return Math.round((a.getTime() - b.getTime()) / ONE_DAY);
+  }
+
+  // Awards "Anniversary" when a player plays a game around a yearly mark of
+  // their first ever game (1 year, 2 years, ...). The game qualifies as long as
+  // it lands on the calendar date before the anniversary, on the anniversary
+  // date itself, or the date after — at any time of day. Earnable once per
   // year mark.
   #checkAnniversaryAchievement(playerId: string, firstActiveAt: number, currentGameAt: number) {
     const ONE_YEAR = 365 * 24 * 60 * 60 * 1000;
-    const ONE_DAY = 24 * 60 * 60 * 1000;
 
-    // Nearest whole-year anniversary to this game. ONE_DAY ≪ half a year, so
-    // rounding unambiguously identifies which anniversary a window game hits.
+    // Which whole-year anniversary is this game closest to? A few days of
+    // leap-year drift stays far below half a year, so rounding is unambiguous.
     const year = Math.round((currentGameAt - firstActiveAt) / ONE_YEAR);
     if (year < 1) {
       return;
     }
-    const anniversaryAt = firstActiveAt + year * ONE_YEAR;
-    if (Math.abs(currentGameAt - anniversaryAt) > ONE_DAY) {
+    const anniversaryDate = this.#anniversaryDate(firstActiveAt, year);
+    if (Math.abs(this.#calendarDayDiff(currentGameAt, anniversaryDate.getTime())) > 1) {
       return;
     }
 
@@ -1428,7 +1450,6 @@ export class Achievements {
     const SIX_MONTHS = 6 * 30 * 24 * 60 * 60 * 1000;
     const ONE_YEAR = 365 * 24 * 60 * 60 * 1000;
     const TWO_YEARS = 2 * ONE_YEAR;
-    const ONE_DAY = 24 * 60 * 60 * 1000;
 
     const progression: AchievementProgression = {
       "donut-1": { current: 0, target: 1, earned: 0 },
@@ -1448,7 +1469,8 @@ export class Achievements {
       "active-2-years": { current: 0, target: TWO_YEARS, earned: 0 },
       // Target is the one-year mark of the first game; current is how much of
       // that year has elapsed. When current reaches target the player is at
-      // their anniversary and playing a game awards it (within a ±1 day window).
+      // their anniversary and playing a game awards it (on the day before, day
+      // of, or day after the anniversary date).
       "anniversary": { current: 0, target: ONE_YEAR, earned: 0 },
       "tournament-participated": { earned: 0 },
       "tournament-winner": { earned: 0 },
@@ -1745,9 +1767,10 @@ export class Achievements {
 
     // Anniversary progress counts toward the next anniversary the player can
     // still earn, and resets to 0 each year. The "target year" is the earliest
-    // whole year that has neither been earned nor had its ±1 day window pass
-    // (now > anniversary + 1 day). Progress is the time elapsed since the start
-    // of that year's cycle (the previous anniversary, or the first game).
+    // whole year that has neither been earned nor had its window pass (now is
+    // more than one calendar day after the anniversary date). Progress is the
+    // time elapsed since the start of that year's cycle (the previous
+    // anniversary, or the first game).
     if (firstActiveAt !== null) {
       const now = Date.now();
       const earnedYears = new Set<number>();
@@ -1758,7 +1781,10 @@ export class Achievements {
       }
 
       let targetYear = 1;
-      while (earnedYears.has(targetYear) || now > firstActiveAt + targetYear * ONE_YEAR + ONE_DAY) {
+      while (
+        earnedYears.has(targetYear) ||
+        this.#calendarDayDiff(now, this.#anniversaryDate(firstActiveAt, targetYear).getTime()) > 1
+      ) {
         targetYear++;
       }
 


### PR DESCRIPTION
## Summary
Changes the Anniversary achievement logic to use calendar dates (day before / day of / day after) instead of a strict ±24 hour window around the anniversary instant. This fixes edge cases where games played late on the day-after or early on the day-before would fall outside the old time-based window.

## Key Changes
- **New helper methods:**
  - `#anniversaryDate()`: Calculates the calendar date of a yearly anniversary (same month/day as first game, N years later)
  - `#calendarDayDiff()`: Computes the difference in whole calendar days between two instants in local time, accounting for DST

- **Updated `#checkAnniversaryAchievement()`:**
  - Replaced instant-based comparison (`Math.abs(currentGameAt - anniversaryAt) > ONE_DAY`) with calendar-date-based comparison
  - Now checks if the game falls within ±1 calendar day of the anniversary date, regardless of time of day

- **Updated progress calculation in `getProgression()`:**
  - Uses the new `#calendarDayDiff()` method to determine if an anniversary window has passed
  - Ensures consistency with the achievement-awarding logic

- **Documentation improvements:**
  - Clarified comments throughout to explain the calendar-date-based window
  - Updated progress target description to reflect the new behavior

## Notable Implementation Details
- Both helper methods work in local time (matching the existing seasons logic)
- `#calendarDayDiff()` uses `Math.round()` to handle DST transitions (23 or 25 hour days)
- The window is now: day before anniversary date, anniversary date itself, or day after (at any time of day)
- Added comprehensive test cases covering edge cases that the old ±24h window would miss

https://claude.ai/code/session_01T1idLSSfpUnkUdhAMicnHg