### PR TITLE
Lower game limit for ranked mode from 30 to 20

### DIFF
--- a/frontend/src/client/client-config/clients/optio-client.tsx
+++ b/frontend/src/client/client-config/clients/optio-client.tsx
@@ -75,5 +75,5 @@ export class OptioClient implements ClientConfig {
   snow = false;
   title = new GuestClient().title;
   favicon = new GuestClient().favicon;
-  gameLimitForRanked = 30;
+  gameLimitForRanked = 20;
 }


### PR DESCRIPTION
## Summary
Reduced the minimum game requirement for ranked mode eligibility in the Optio client configuration from 30 games to 20 games.

## Changes
- Updated `gameLimitForRanked` in `OptioClient` from 30 to 20

## Details
This change lowers the barrier to entry for players to participate in ranked matches, allowing players with 20+ games (instead of 30+) to access ranked mode.

https://claude.ai/code/session_01WUA8PRpeUAcNbbCWqZoxzH