### PR TITLE
Add stealth theme with dark color palette

### DIFF
--- a/frontend/src/client/client-config/get-client-config.tsx
+++ b/frontend/src/client/client-config/get-client-config.tsx
@@ -61,6 +61,7 @@ export enum Theme {
   DEFAULT = "default",
   HALLOWEEN = "halloween",
   EASTER = "easter",
+  STEALTH = "stealth",
   CLIENT_SKIMORE = "skimore",
   CLIENT_ASPLAN_VIAK = "asplanviak",
   CLIENT_DEEPINSIGHT = "deepinsight",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -32,6 +32,16 @@
   --color-tertiary-background: 243,255,7;
 }
 
+.theme-stealth {
+  --color-primary-text: 128,128,128;
+  --color-primary-background: 0,0,0;
+  --color-secondary-text: 115,115,115;
+  --color-secondary-background: 23,23,23;
+  --color-tertiary-text: 102,102,102;
+  --color-tertiary-background: 38,38,38;
+  --background-image-url: none;
+}
+
 .theme-skimore {
   --color-primary-text: 31,42,68;
   --color-primary-background: 183,220,225;


### PR DESCRIPTION
## Summary
Added a new "stealth" theme to the application with a dark color palette featuring grayscale tones and black backgrounds.

## Changes
- **frontend/src/index.css**: Added `.theme-stealth` CSS class with dark theme variables:
  - Primary text: gray (128,128,128)
  - Primary background: black (0,0,0)
  - Secondary text/background: dark gray tones (115,115,115 and 23,23,23)
  - Tertiary text/background: medium gray tones (102,102,102 and 38,38,38)
  - No background image

- **frontend/src/client/client-config/get-client-config.tsx**: Added `STEALTH = "stealth"` to the `Theme` enum to register the new theme option

## Implementation Details
The stealth theme follows the existing theme pattern used by other themes (default, halloween, easter) and uses CSS custom properties for consistent color management across the application.

https://claude.ai/code/session_01MB38AJPey3d8ePegc6xwEs