### PR TITLE
Add serve tracker to track game and live game

### DIFF
--- a/DenoServer/db/database.ts
+++ b/DenoServer/db/database.ts
@@ -16,6 +16,8 @@ export type LiveGameState = {
   };
   currentSet: SetPoint;
   completedSets: SetPoint[];
+  /** Which player (1 or 2) served the first point of the current set. */
+  firstServer: 1 | 2;
   startedAt: number | null;
   finishedAt: number | null;
   updatedAt: number;

--- a/frontend/src/common/serve-tracker-display.tsx
+++ b/frontend/src/common/serve-tracker-display.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { classNames } from "./class-names";
+import { getServeInfo, Server } from "./serve-tracker";
+
+type ServeTrackerProps = {
+  currentSet: { player1: number; player2: number };
+  firstServer: Server;
+  player1Name: string;
+  player2Name: string;
+  /**
+   * When provided, a "Starts serving" selector is shown while the current set
+   * is still 0-0, letting the operator pick who serves first. Omit for
+   * read-only displays (e.g. the public scoreboard / TV overlay).
+   */
+  onSelectFirstServer?: (player: Server) => void;
+};
+
+export const ServeTrackerDisplay: React.FC<ServeTrackerProps> = ({
+  currentSet,
+  firstServer,
+  player1Name,
+  player2Name,
+  onSelectFirstServer,
+}) => {
+  const { server, servesRemaining, isDeuce } = getServeInfo(currentSet, firstServer);
+  const serverName = server === 1 ? player1Name : player2Name;
+  const isSetEmpty = currentSet.player1 === 0 && currentSet.player2 === 0;
+
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <div
+        className={classNames(
+          "flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-semibold",
+          server === 1 ? "bg-blue-100 text-blue-700" : "bg-purple-100 text-purple-700",
+        )}
+      >
+        <span>🏓</span>
+        <span>{serverName} to serve</span>
+        {isDeuce ? (
+          <span className="text-xs font-normal opacity-80">(deuce)</span>
+        ) : (
+          <span className="text-xs font-normal opacity-80">
+            ({servesRemaining} serve{servesRemaining === 1 ? "" : "s"} left)
+          </span>
+        )}
+      </div>
+
+      {onSelectFirstServer && isSetEmpty && (
+        <div className="flex items-center gap-2 mt-1">
+          <span className="text-xs text-gray-400">Starts serving:</span>
+          <button
+            onClick={() => onSelectFirstServer(1)}
+            className={classNames(
+              "text-xs px-2 py-0.5 rounded-full font-semibold transition",
+              firstServer === 1 ? "bg-blue-600 text-white" : "bg-gray-100 text-gray-500 hover:bg-gray-200",
+            )}
+          >
+            {player1Name}
+          </button>
+          <button
+            onClick={() => onSelectFirstServer(2)}
+            className={classNames(
+              "text-xs px-2 py-0.5 rounded-full font-semibold transition",
+              firstServer === 2 ? "bg-purple-600 text-white" : "bg-gray-100 text-gray-500 hover:bg-gray-200",
+            )}
+          >
+            {player2Name}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/common/serve-tracker.test.ts
+++ b/frontend/src/common/serve-tracker.test.ts
@@ -1,0 +1,54 @@
+import { getServeInfo } from "./serve-tracker";
+
+describe("getServeInfo", () => {
+  it("first server serves the first two points", () => {
+    expect(getServeInfo({ player1: 0, player2: 0 }, 1)).toEqual({
+      server: 1,
+      servesRemaining: 2,
+      isDeuce: false,
+    });
+    expect(getServeInfo({ player1: 1, player2: 0 }, 1)).toMatchObject({
+      server: 1,
+      servesRemaining: 1,
+    });
+  });
+
+  it("switches to the other player after two points", () => {
+    expect(getServeInfo({ player1: 1, player2: 1 }, 1)).toMatchObject({
+      server: 2,
+      servesRemaining: 2,
+    });
+    expect(getServeInfo({ player1: 2, player2: 1 }, 1)).toMatchObject({
+      server: 2,
+      servesRemaining: 1,
+    });
+  });
+
+  it("switches back after four points", () => {
+    expect(getServeInfo({ player1: 2, player2: 2 }, 1)).toMatchObject({
+      server: 1,
+      servesRemaining: 2,
+    });
+  });
+
+  it("respects the chosen first server", () => {
+    expect(getServeInfo({ player1: 0, player2: 0 }, 2)).toMatchObject({ server: 2 });
+    expect(getServeInfo({ player1: 1, player2: 1 }, 2)).toMatchObject({ server: 1 });
+  });
+
+  it("alternates every point at deuce", () => {
+    expect(getServeInfo({ player1: 10, player2: 10 }, 1)).toMatchObject({
+      server: 1,
+      servesRemaining: 1,
+      isDeuce: true,
+    });
+    expect(getServeInfo({ player1: 11, player2: 10 }, 1)).toMatchObject({
+      server: 2,
+      isDeuce: true,
+    });
+    expect(getServeInfo({ player1: 11, player2: 11 }, 1)).toMatchObject({
+      server: 1,
+      isDeuce: true,
+    });
+  });
+});

--- a/frontend/src/common/serve-tracker.ts
+++ b/frontend/src/common/serve-tracker.ts
@@ -1,0 +1,30 @@
+export type Server = 1 | 2;
+
+export type ServeInfo = {
+  /** Which player is currently serving. */
+  server: Server;
+  /** Serves left in the current server's turn (1 during deuce, otherwise 1 or 2). */
+  servesRemaining: number;
+  /** True once both players have reached 10 points, when serve alternates every point. */
+  isDeuce: boolean;
+};
+
+/**
+ * Table tennis serve rules: each player serves 2 points in a row, then it
+ * switches. Once both players reach 10 (deuce), the serve switches every point.
+ *
+ * `firstServer` is whoever served the first point of the current set; the
+ * server for any later point is derived from the points played so far.
+ */
+export function getServeInfo(
+  setScore: { player1: number; player2: number },
+  firstServer: Server,
+): ServeInfo {
+  const totalPoints = setScore.player1 + setScore.player2;
+  const isDeuce = setScore.player1 >= 10 && setScore.player2 >= 10;
+  const serveTurn = isDeuce ? totalPoints : Math.floor(totalPoints / 2);
+  const otherServer: Server = firstServer === 1 ? 2 : 1;
+  const server: Server = serveTurn % 2 === 0 ? firstServer : otherServer;
+  const servesRemaining = isDeuce ? 1 : 2 - (totalPoints % 2);
+  return { server, servesRemaining, isDeuce };
+}

--- a/frontend/src/pages/add-game/track-game.tsx
+++ b/frontend/src/pages/add-game/track-game.tsx
@@ -12,6 +12,8 @@ import { useTennisParams } from "../../hooks/use-tennis-params";
 import { classNames } from "../../common/class-names";
 import { ProfilePicture } from "../player/profile-picture";
 import { stringToColor } from "../../common/string-to-color";
+import { getServeInfo, Server } from "../../common/serve-tracker";
+import { ServeTrackerDisplay } from "../../common/serve-tracker-display";
 
 interface SetPoint {
   player1: number;
@@ -45,6 +47,7 @@ export const TrackGamePage: React.FC = () => {
     player1: 0,
     player2: 0,
   });
+  const [firstServer, setFirstServer] = useState<Server>(1);
   const [validationError, setValidationError] = useState<string>("");
   const [gameSuccessfullyAdded, setGameSuccessfullyAdded] = useState(false);
 
@@ -77,6 +80,8 @@ export const TrackGamePage: React.FC = () => {
     }));
 
     setCurrentSetScore({ player1: 0, player2: 0 });
+    // Alternate who serves first in the next set, per table tennis convention.
+    setFirstServer((prev) => (prev === 1 ? 2 : 1));
   };
 
   const startMatch = () => {
@@ -184,6 +189,7 @@ export const TrackGamePage: React.FC = () => {
       setPoints: [],
     });
     setCurrentSetScore({ player1: 0, player2: 0 });
+    setFirstServer(1);
     setValidationError("");
   };
 
@@ -216,6 +222,9 @@ export const TrackGamePage: React.FC = () => {
     const canEndMatch =
       (matchData.setPoints?.length || 0) > 0 && isSetEmpty && matchData.setsWon.player1 !== matchData.setsWon.player2;
 
+    // Serve tracker: each player serves 2 points in a row, then it switches.
+    const { server: currentServer } = getServeInfo(currentSetScore, firstServer);
+
     return (
       <div className="text-black p-4 pt-0">
         <div className="max-w-sm mx-auto">
@@ -246,6 +255,17 @@ export const TrackGamePage: React.FC = () => {
               <h2 className="text-gray-400 text-xs uppercase tracking-widest font-bold mt-4">
                 Set {(matchData.setPoints?.length || 0) + 1}
               </h2>
+
+              {/* Serve Tracker */}
+              <div className="mt-3">
+                <ServeTrackerDisplay
+                  currentSet={currentSetScore}
+                  firstServer={firstServer}
+                  player1Name={context.playerName(player1)}
+                  player2Name={context.playerName(player2)}
+                  onSelectFirstServer={setFirstServer}
+                />
+              </div>
             </div>
 
             {/* Score Display */}
@@ -254,6 +274,7 @@ export const TrackGamePage: React.FC = () => {
               {/* Player 1 */}
               <div className="bg-blue-50 rounded-lg p-2">
                 <h3 className="text-sm font-semibold text-gray-700 mb-1 text-center truncate">
+                  {currentServer === 1 && <span className="mr-1">🏓</span>}
                   {context.playerName(player1)}
                 </h3>
                 <div className="flex flex-col items-center justify-center gap-2">
@@ -286,6 +307,7 @@ export const TrackGamePage: React.FC = () => {
               {/* Player 2 */}
               <div className="bg-purple-50 rounded-lg p-2">
                 <h3 className="text-sm font-semibold text-gray-700 mb-1 text-center truncate">
+                  {currentServer === 2 && <span className="mr-1">🏓</span>}
                   {context.playerName(player2)}
                 </h3>
                 <div className="flex flex-col items-center justify-center gap-2">

--- a/frontend/src/pages/leaderboard/live-game-card.tsx
+++ b/frontend/src/pages/leaderboard/live-game-card.tsx
@@ -4,6 +4,7 @@ import { UseQueryResult } from "@tanstack/react-query";
 import { LiveGameState } from "../live-game/live-game-types";
 import { ProfilePicture } from "../player/profile-picture";
 import { useEventDbContext } from "../../wrappers/event-db-context";
+import { getServeInfo } from "../../common/serve-tracker";
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
 
@@ -21,6 +22,7 @@ export const LiveGameCard: React.FC<Props> = ({ liveGameQuery }) => {
 
   const player1Won = state.setsWon.player1 > state.setsWon.player2;
   const winnerName = player1Won ? context.playerName(state.player1Id) : context.playerName(state.player2Id);
+  const server = isActive ? getServeInfo(state.currentSet, state.firstServer ?? 1).server : null;
 
   return (
     <Link
@@ -48,7 +50,10 @@ export const LiveGameCard: React.FC<Props> = ({ liveGameQuery }) => {
       <div className="flex items-center justify-between gap-2">
         <div className="flex flex-col items-center gap-1 min-w-0">
           <ProfilePicture playerId={state.player1Id!} size={32} border={2} />
-          <span className="font-semibold text-sm truncate max-w-[100px]">{context.playerName(state.player1Id)}</span>
+          <span className="font-semibold text-sm truncate max-w-[100px]">
+            {server === 1 && "🏓 "}
+            {context.playerName(state.player1Id)}
+          </span>
         </div>
         <div className="flex flex-col items-center shrink-0">
           <span className="text-[10px] font-bold uppercase tracking-wider opacity-70">Sets</span>
@@ -70,7 +75,10 @@ export const LiveGameCard: React.FC<Props> = ({ liveGameQuery }) => {
         </div>
         <div className="flex flex-col items-center gap-1 min-w-0">
           <ProfilePicture playerId={state.player2Id!} size={32} border={2} />
-          <span className="font-semibold text-sm truncate max-w-[100px]">{context.playerName(state.player2Id)}</span>
+          <span className="font-semibold text-sm truncate max-w-[100px]">
+            {server === 2 && "🏓 "}
+            {context.playerName(state.player2Id)}
+          </span>
         </div>
       </div>
     </Link>

--- a/frontend/src/pages/live-game/live-game-admin-page.tsx
+++ b/frontend/src/pages/live-game/live-game-admin-page.tsx
@@ -22,6 +22,8 @@ import {
 import { emptyLiveGame, LiveGameSetPoint, LiveGameState } from "./live-game-types";
 import { CompletedSetsList } from "./completed-sets-list";
 import ConfettiExplosion from "react-confetti-explosion";
+import { Server } from "../../common/serve-tracker";
+import { ServeTrackerDisplay } from "../../common/serve-tracker-display";
 
 type Stage = "scoring" | "confirm";
 
@@ -42,7 +44,9 @@ export const LiveGameAdminPage: React.FC = () => {
 
   useEffect(() => {
     if (localState === null && liveGameQuery.isSuccess) {
-      setLocalState(liveGameQuery.data ?? emptyLiveGame);
+      // Spread over emptyLiveGame so older games without newer fields (e.g.
+      // firstServer) pick up sensible defaults.
+      setLocalState(liveGameQuery.data ? { ...emptyLiveGame, ...liveGameQuery.data } : emptyLiveGame);
     }
   }, [localState, liveGameQuery.isSuccess, liveGameQuery.data]);
 
@@ -78,10 +82,15 @@ export const LiveGameAdminPage: React.FC = () => {
       setsWon: { player1: 0, player2: 0 },
       currentSet: { player1: 0, player2: 0 },
       completedSets: [],
+      firstServer: localState!.firstServer,
       startedAt: Date.now(),
       finishedAt: null,
       updatedAt: Date.now(),
     });
+  }
+
+  function setFirstServer(player: Server) {
+    pushState({ ...localState!, firstServer: player });
   }
 
   function addPoint(player: 1 | 2) {
@@ -115,6 +124,8 @@ export const LiveGameAdminPage: React.FC = () => {
       },
       completedSets: [...localState!.completedSets, { ...localState!.currentSet }],
       currentSet: { player1: 0, player2: 0 },
+      // Alternate who serves first in the next set, per table tennis convention.
+      firstServer: localState!.firstServer === 1 ? 2 : 1,
     });
   }
 
@@ -125,6 +136,7 @@ export const LiveGameAdminPage: React.FC = () => {
       setsWon: { player1: 0, player2: 0 },
       currentSet: { player1: 0, player2: 0 },
       completedSets: [],
+      firstServer: 1,
       updatedAt: Date.now(),
     });
   }
@@ -275,6 +287,16 @@ export const LiveGameAdminPage: React.FC = () => {
             <h2 className="text-gray-400 text-xs uppercase tracking-widest font-bold mt-4 text-center">
               Set {localState.completedSets.length + 1}
             </h2>
+
+            <div className="mt-3">
+              <ServeTrackerDisplay
+                currentSet={localState.currentSet}
+                firstServer={localState.firstServer}
+                player1Name={context.playerName(localState.player1Id)}
+                player2Name={context.playerName(localState.player2Id)}
+                onSelectFirstServer={setFirstServer}
+              />
+            </div>
           </div>
 
           <div className="bg-white rounded-xl shadow-lg p-4 text-black">

--- a/frontend/src/pages/live-game/live-game-overlay.tsx
+++ b/frontend/src/pages/live-game/live-game-overlay.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useSearchParams } from "react-router-dom";
 import { useLiveGameQuery } from "./use-live-game";
 import { useEventDbContext } from "../../wrappers/event-db-context";
+import { getServeInfo } from "../../common/serve-tracker";
 
 const POLL_FALLBACK_MS = 1_000;
 const CHROMA_GREEN = "#00b140";
@@ -25,6 +26,7 @@ export const LiveGameOverlay: React.FC = () => {
 
   const p1Name = context.playerName(state.player1Id);
   const p2Name = context.playerName(state.player2Id);
+  const { server } = getServeInfo(state.currentSet, state.firstServer ?? 1);
 
   return (
     <div
@@ -34,7 +36,8 @@ export const LiveGameOverlay: React.FC = () => {
       <div className="relative flex flex-col items-center gap-0" style={{ zoom }}>
         {/* Sets bar */}
         <div className="flex rounded-lg overflow-hidden ">
-          <div className="bg-white text-gray-800 px-4 py-2 flex items-center min-w-[90px]">
+          <div className="bg-white text-gray-800 px-4 py-2 flex items-center min-w-[90px] gap-1">
+            {server === 1 && <span className="text-sm">🏓</span>}
             <span className="text-sm font-semibold truncate">{p1Name}</span>
           </div>
           <div
@@ -45,8 +48,9 @@ export const LiveGameOverlay: React.FC = () => {
             <span className={`text-sm font-bold opacity-70 ${DASH_W} text-center`}>-</span>
             <span className={`text-2xl font-black ${DIGIT_W} text-left`}>{state.setsWon.player2}</span>
           </div>
-          <div className="bg-white text-gray-800 px-4 py-2 flex items-center min-w-[90px] justify-end">
+          <div className="bg-white text-gray-800 px-4 py-2 flex items-center min-w-[90px] justify-end gap-1">
             <span className="text-sm font-semibold truncate">{p2Name}</span>
+            {server === 2 && <span className="text-sm">🏓</span>}
           </div>
         </div>
 

--- a/frontend/src/pages/live-game/live-game-page.tsx
+++ b/frontend/src/pages/live-game/live-game-page.tsx
@@ -7,6 +7,8 @@ import { Link } from "react-router-dom";
 import { session } from "../../services/auth";
 import { CompletedSetsList } from "./completed-sets-list";
 import { LiveGameSetPoint } from "./live-game-types";
+import { Server } from "../../common/serve-tracker";
+import { ServeTrackerDisplay } from "../../common/serve-tracker-display";
 
 // Fallback poll in case the WebSocket drops — primary updates come from
 // the LIVE_GAME broadcast handled in WebSocketRefetcher.
@@ -65,6 +67,7 @@ export const LiveGamePage: React.FC = () => {
           setsWon={state.setsWon}
           currentSet={state.currentSet}
           completedSets={state.completedSets}
+          firstServer={state.firstServer ?? 1}
           player1Name={context.playerName(state.player1Id)}
           player2Name={context.playerName(state.player2Id)}
         />
@@ -90,6 +93,7 @@ type ScoreboardProps = {
   setsWon: { player1: number; player2: number };
   currentSet: LiveGameSetPoint;
   completedSets: LiveGameSetPoint[];
+  firstServer: Server;
   player1Name: string;
   player2Name: string;
 };
@@ -100,6 +104,7 @@ const LiveScoreboard: React.FC<ScoreboardProps> = ({
   setsWon,
   currentSet,
   completedSets,
+  firstServer,
   player1Name,
   player2Name,
 }) => {
@@ -149,6 +154,14 @@ const LiveScoreboard: React.FC<ScoreboardProps> = ({
             <h3 className="text-sm font-semibold text-gray-700 mb-1 truncate">{player2Name}</h3>
             <div className="text-7xl font-bold text-purple-600">{currentSet.player2}</div>
           </div>
+        </div>
+        <div className="mt-4 flex justify-center">
+          <ServeTrackerDisplay
+            currentSet={currentSet}
+            firstServer={firstServer}
+            player1Name={player1Name}
+            player2Name={player2Name}
+          />
         </div>
       </div>
 

--- a/frontend/src/pages/live-game/live-game-types.ts
+++ b/frontend/src/pages/live-game/live-game-types.ts
@@ -12,6 +12,8 @@ export type LiveGameState = {
   };
   currentSet: LiveGameSetPoint;
   completedSets: LiveGameSetPoint[];
+  /** Which player (1 or 2) served the first point of the current set. */
+  firstServer: 1 | 2;
   startedAt: number | null;
   finishedAt: number | null;
   updatedAt: number;
@@ -23,6 +25,7 @@ export const emptyLiveGame: LiveGameState = {
   setsWon: { player1: 0, player2: 0 },
   currentSet: { player1: 0, player2: 0 },
   completedSets: [],
+  firstServer: 1,
   startedAt: null,
   finishedAt: null,
   updatedAt: 0,


### PR DESCRIPTION
Track whose serve it is during scoring: each player serves 2 points in a
row, switching to 1 each at deuce (10-10). The operator can pick who
serves first in each set, and the first server auto-alternates between
sets per table tennis convention.

- Shared pure helper `getServeInfo` (with unit tests) and a reusable
  `ServeTrackerDisplay` component.
- Track Game scoring screen: serve badge, first-server selector, and a
  serve indicator on the leading score box.
- Live Game: `firstServer` added to the shared LiveGameState so the
  admin controls it and the public scoreboard, TV overlay, and
  leaderboard card all show whose serve it is.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0162bsLce3DeJeeN8hpSNQsc