### PR TITLE
Add "Ranked" achievement for reaching the leaderboard

### DIFF
--- a/frontend/src/client/client-db/__tests__/achievements/ranked.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/ranked.test.ts
@@ -1,0 +1,107 @@
+import { TennisTable } from "../../tennis-table";
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+
+// The "ranked" achievement is awarded on the exact game that pushes a
+// player up to gameLimitForRanked total games — the game that makes them
+// appear on the leaderboard. Progress is the games count toward that
+// threshold, capped at the target so it never exceeds 100% once earned
+// (which would otherwise leak the player's total games count).
+
+describe("Ranked Achievement", () => {
+  const game = (id: string, time: number, winner: string, loser: string): EventType => ({
+    time,
+    stream: id,
+    type: EventTypeEnum.GAME_CREATED,
+    data: { playedAt: time, winner, loser },
+  });
+
+  const players = (): EventType[] => [
+    { time: 1, stream: "alice", type: EventTypeEnum.PLAYER_CREATED, data: { name: "Alice" } },
+    { time: 2, stream: "bob", type: EventTypeEnum.PLAYER_CREATED, data: { name: "Bob" } },
+  ];
+
+  it("awards ranked on the game that crosses the threshold", () => {
+    // gameLimitForRankedOverride = 3 → the 3rd game makes a player ranked.
+    const events: EventType[] = [
+      ...players(),
+      game("g1", 100, "alice", "bob"),
+      game("g2", 200, "alice", "bob"),
+      game("g3", 300, "bob", "alice"),
+    ];
+
+    const tt = new TennisTable({ events, gameLimitForRankedOverride: 3 });
+    tt.achievements.calculateAchievements();
+
+    const aliceRanked = tt.achievements.getAchievements("alice").filter((a) => a.type === "ranked");
+    expect(aliceRanked).toHaveLength(1);
+    // Earned on the 3rd game (the one that crossed the threshold).
+    expect(aliceRanked[0].earnedAt).toBe(300);
+    expect(aliceRanked[0].data).toEqual({ gameId: "g3", opponent: "bob" });
+
+    const bobRanked = tt.achievements.getAchievements("bob").filter((a) => a.type === "ranked");
+    expect(bobRanked).toHaveLength(1);
+    expect(bobRanked[0].earnedAt).toBe(300);
+  });
+
+  it("does NOT award before the threshold is reached", () => {
+    const events: EventType[] = [
+      ...players(),
+      game("g1", 100, "alice", "bob"),
+      game("g2", 200, "alice", "bob"),
+    ];
+
+    const tt = new TennisTable({ events, gameLimitForRankedOverride: 3 });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "ranked")).toHaveLength(0);
+    expect(tt.achievements.getAchievements("bob").filter((a) => a.type === "ranked")).toHaveLength(0);
+  });
+
+  it("is only awarded once even after many more games", () => {
+    const events: EventType[] = [
+      ...players(),
+      game("g1", 100, "alice", "bob"),
+      game("g2", 200, "alice", "bob"),
+      game("g3", 300, "alice", "bob"),
+      game("g4", 400, "alice", "bob"),
+      game("g5", 500, "alice", "bob"),
+    ];
+
+    const tt = new TennisTable({ events, gameLimitForRankedOverride: 3 });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "ranked")).toHaveLength(1);
+  });
+
+  it("reports progress toward the threshold before becoming ranked", () => {
+    const events: EventType[] = [
+      ...players(),
+      game("g1", 100, "alice", "bob"),
+      game("g2", 200, "alice", "bob"),
+    ];
+
+    const tt = new TennisTable({ events, gameLimitForRankedOverride: 5 });
+    tt.achievements.calculateAchievements();
+
+    const prog = tt.achievements.getPlayerProgression("alice")["ranked"];
+    expect(prog).toEqual({ current: 2, target: 5, earned: 0 });
+  });
+
+  it("caps progress at the target once ranked, never exposing total games", () => {
+    // Alice plays 8 games against a threshold of 3. Progress must read
+    // 3/3 (100%), not 8/3 — otherwise the total games count would leak.
+    const events: EventType[] = [...players()];
+    let t = 100;
+    for (let i = 0; i < 8; i++) {
+      events.push(game(`g${i}`, t++, i % 2 === 0 ? "alice" : "bob", i % 2 === 0 ? "bob" : "alice"));
+    }
+
+    const tt = new TennisTable({ events, gameLimitForRankedOverride: 3 });
+    tt.achievements.calculateAchievements();
+
+    const prog = tt.achievements.getPlayerProgression("alice")["ranked"];
+    expect(prog.current).toBe(3);
+    expect(prog.target).toBe(3);
+    expect(prog.earned).toBe(1);
+  });
+});

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -62,8 +62,11 @@ export class Achievements {
         gamesPerOpponent: Map<string, { count: number; firstGame: number }>;
         firstOpponentFor: Set<string>; // Track players this person was first opponent for
         hatTrickWins: { playedAt: number }[]; // Track recent wins for hat-trick
+        gamesPlayed: number; // Total games played, used for the "ranked" achievement
       }
     >();
+
+    const gameLimitForRanked = this.parent.client.gameLimitForRanked;
 
     this.parent.games.forEach((game) => {
       // Initialize player trackers if they don't exist
@@ -84,6 +87,7 @@ export class Achievements {
           gamesPerOpponent: new Map(),
           firstOpponentFor: new Set(),
           hatTrickWins: [],
+          gamesPlayed: 0,
         });
       }
       if (!playerTracker.has(game.loser)) {
@@ -103,11 +107,36 @@ export class Achievements {
           gamesPerOpponent: new Map(),
           firstOpponentFor: new Set(),
           hatTrickWins: [],
+          gamesPlayed: 0,
         });
       }
 
       const winner = playerTracker.get(game.winner)!;
       const loser = playerTracker.get(game.loser)!;
+
+      // Check for "Ranked" achievement: awarded on the game that pushes a
+      // player up to gameLimitForRanked total games — i.e. the game that
+      // makes them appear on the leaderboard. Earnable once.
+      winner.gamesPlayed++;
+      if (winner.gamesPlayed === gameLimitForRanked) {
+        this.#addAchievement(
+          game.winner,
+          this.#createAchievement("ranked", game.winner, game.playedAt, {
+            gameId: game.id,
+            opponent: game.loser,
+          }),
+        );
+      }
+      loser.gamesPlayed++;
+      if (loser.gamesPlayed === gameLimitForRanked) {
+        this.#addAchievement(
+          game.loser,
+          this.#createAchievement("ranked", game.loser, game.playedAt, {
+            gameId: game.id,
+            opponent: game.winner,
+          }),
+        );
+      }
 
       // Check for Welcome Committee achievement
       // If this is the loser's first game ever, the winner is their first opponent
@@ -1450,8 +1479,10 @@ export class Achievements {
     const SIX_MONTHS = 6 * 30 * 24 * 60 * 60 * 1000;
     const ONE_YEAR = 365 * 24 * 60 * 60 * 1000;
     const TWO_YEARS = 2 * ONE_YEAR;
+    const gameLimitForRanked = this.parent.client.gameLimitForRanked;
 
     const progression: AchievementProgression = {
+      "ranked": { current: 0, target: gameLimitForRanked, earned: 0 },
       "donut-1": { current: 0, target: 1, earned: 0 },
       "donut-5": { current: 0, target: 5, earned: 0 },
       "streak-all-10": { current: 0, target: 10, earned: 0 },
@@ -1507,6 +1538,7 @@ export class Achievements {
 
     let firstActiveAt: number | null = null;
     let lastActiveAt: number | null = null;
+    let gamesPlayedCount = 0;
     let currentWinStreakAll = 0;
     let currentLoseStreakAll = 0;
     let donutCount = 0;
@@ -1550,6 +1582,8 @@ export class Achievements {
       const isLoser = game.loser === playerId;
 
       if (!isWinner && !isLoser) return;
+
+      gamesPlayedCount++;
 
       // Track first active time
       if (firstActiveAt === null) {
@@ -1633,6 +1667,10 @@ export class Achievements {
     });
 
     // Update progression with current stats
+    // "Ranked" progress is the games played toward the ranked threshold,
+    // capped at the target so it never exceeds 100% once earned — going
+    // beyond would leak the player's total games count.
+    progression["ranked"].current = Math.min(gamesPlayedCount, gameLimitForRanked);
     progression["donut-1"].current = donutCount;
     progression["donut-5"].current = donutCount;
     progression["streak-all-10"].current = currentWinStreakAll;
@@ -1860,6 +1898,7 @@ export class Achievements {
 
 // Type Definitions
 type AchievementDefinitions = {
+  "ranked": { gameId: string; opponent: string };
   "donut-1": { gameId: string; opponent: string };
   "donut-5": undefined;
   "streak-all-10": { startedAt: number };
@@ -1989,6 +2028,7 @@ type MarathonSetProgression = BaseProgression & {
 };
 
 export type AchievementProgression = {
+  "ranked": ProgressionWithTarget;
   "donut-1": ProgressionWithTarget;
   "donut-5": ProgressionWithTarget;
   "streak-all-10": ProgressionWithTarget;

--- a/frontend/src/pages/achievements/achievements-list.tsx
+++ b/frontend/src/pages/achievements/achievements-list.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { Achievement } from "../../client/client-db/achievements";
 import { useEventDbContext } from "../../wrappers/event-db-context";
-import { ACHIEVEMENT_LABELS, dateString } from "../player/player-achievements";
+import { getAchievementLabel, dateString } from "../player/player-achievements";
 import { relativeTimeString } from "../../common/date-utils";
 import { ProfilePicture } from "../player/profile-picture";
 import { fmtNum } from "../../common/number-utils";
@@ -27,11 +27,7 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
   return (
     <div className="space-y-2">
       {achievements.map((achievement, index) => {
-        const label = ACHIEVEMENT_LABELS[achievement.type] || {
-          title: achievement.type,
-          description: "",
-          icon: "🏅",
-        };
+        const label = getAchievementLabel(achievement.type, context.client.gameLimitForRanked);
 
         return (
           <div

--- a/frontend/src/pages/achievements/progress-list.tsx
+++ b/frontend/src/pages/achievements/progress-list.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { Link } from "react-router-dom";
 import { useEventDbContext } from "../../wrappers/event-db-context";
-import { ACHIEVEMENT_LABELS } from "../player/player-achievements";
+import { ACHIEVEMENT_LABELS, getAchievementLabel } from "../player/player-achievements";
 import { ProfilePicture } from "../player/profile-picture";
 import { fmtNum } from "../../common/number-utils";
 import { classNames } from "../../common/class-names";
@@ -97,7 +97,7 @@ export const ProgressList: React.FC<ProgressListProps> = ({ selectedType }) => {
               </span>
             </h2>
             <p className="text-sm opacity-70 mt-2">
-              {ACHIEVEMENT_LABELS[selectedType]?.description}
+              {getAchievementLabel(selectedType, context.client.gameLimitForRanked).description}
             </p>
           </div>
 

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -13,8 +13,10 @@ type Props = {
 export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: string; icon: string }> = {
   "ranked": {
     title: "Ranked",
+    // The number of games is client-specific (gameLimitForRanked); the
+    // concrete count is filled in by getAchievementLabel at render time.
     description: "Play enough games to qualify for the leaderboard",
-    icon: "📊",
+    icon: "🔢",
   },
   "donut-1": {
     title: "Donut",
@@ -228,6 +230,20 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
   },
 };
 
+// Resolves the display label for an achievement type, filling in any
+// client-specific values. The "ranked" description embeds the current
+// gameLimitForRanked so players see the exact number of games required.
+export function getAchievementLabel(
+  type: string,
+  gameLimitForRanked: number,
+): { title: string; description: string; icon: string } {
+  const label = ACHIEVEMENT_LABELS[type] || { title: type, description: "", icon: "🏅" };
+  if (type === "ranked") {
+    return { ...label, description: `Play ${gameLimitForRanked} games to qualify for the leaderboard` };
+  }
+  return label;
+}
+
 type TabType = "earned" | "progress";
 const tabs: { id: TabType; label: string }[] = [
   { id: "earned", label: "Earned" },
@@ -303,11 +319,7 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
   return (
     <div className="space-y-3">
       {achievements.map((achievement, index) => {
-        const label = ACHIEVEMENT_LABELS[achievement.type] || {
-          title: achievement.type,
-          description: "",
-          icon: "🏅",
-        };
+        const label = getAchievementLabel(achievement.type, context.client.gameLimitForRanked);
 
         return (
           <div
@@ -513,11 +525,7 @@ type ProgressTabProps = {
 const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
   const context = useEventDbContext();
   const progressItems = Object.entries(progression).map(([type, data]) => {
-    const label = ACHIEVEMENT_LABELS[type] || {
-      title: type,
-      description: "",
-      icon: "🏅",
-    };
+    const label = getAchievementLabel(type, context.client.gameLimitForRanked);
 
     return {
       type,

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -11,6 +11,11 @@ type Props = {
 };
 
 export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: string; icon: string }> = {
+  "ranked": {
+    title: "Ranked",
+    description: "Play enough games to qualify for the leaderboard",
+    icon: "📊",
+  },
   "donut-1": {
     title: "Donut",
     description: "Won a set without opponent scoring",


### PR DESCRIPTION
Awarded on the exact game that pushes a player to gameLimitForRanked
total games — the game that makes them appear on the leaderboard.

Progress tracks games played toward the threshold, capped at the target
so it never exceeds 100% once earned. Capping is deliberate: showing
raw games-played beyond the threshold would leak the player's total
games count.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011Kxzgx26gmVSZzBtKpjf4r