### PR TITLE
Add win prediction card to live game views

### DIFF
--- a/frontend/src/pages/add-game/track-game.tsx
+++ b/frontend/src/pages/add-game/track-game.tsx
@@ -14,6 +14,7 @@ import { ProfilePicture } from "../player/profile-picture";
 import { stringToColor } from "../../common/string-to-color";
 import { getServeInfo, Server } from "../../common/serve-tracker";
 import { ServeTrackerDisplay } from "../../common/serve-tracker-display";
+import { LiveGamePredictionCard } from "../live-game/live-game-prediction-card";
 
 interface SetPoint {
   player1: number;
@@ -386,6 +387,19 @@ export const TrackGamePage: React.FC = () => {
                 </div>
               )}
             </button>
+          </div>
+
+          {/* Live Win Prediction */}
+          <div className="mb-4">
+            <LiveGamePredictionCard
+              player1Id={player1!}
+              player2Id={player2!}
+              player1Name={context.playerName(player1)}
+              player2Name={context.playerName(player2)}
+              setsWon={matchData.setsWon}
+              currentSet={currentSetScore}
+              completedSets={matchData.setPoints ?? []}
+            />
           </div>
 
           {/* Sets History */}

--- a/frontend/src/pages/live-game/live-game-admin-page.tsx
+++ b/frontend/src/pages/live-game/live-game-admin-page.tsx
@@ -21,6 +21,7 @@ import {
 } from "./use-live-game";
 import { emptyLiveGame, LiveGameSetPoint, LiveGameState } from "./live-game-types";
 import { CompletedSetsList } from "./completed-sets-list";
+import { LiveGamePredictionCard } from "./live-game-prediction-card";
 import ConfettiExplosion from "react-confetti-explosion";
 import { Server } from "../../common/serve-tracker";
 import { ServeTrackerDisplay } from "../../common/serve-tracker-display";
@@ -344,6 +345,13 @@ export const LiveGameAdminPage: React.FC = () => {
               </button>
             </div>
           </div>
+
+          <LiveGamePredictionCard
+            player1Id={localState.player1Id!}
+            player2Id={localState.player2Id!}
+            player1Name={context.playerName(localState.player1Id)}
+            player2Name={context.playerName(localState.player2Id)}
+          />
 
           <CompletedSetsList sets={localState.completedSets} />
 

--- a/frontend/src/pages/live-game/live-game-admin-page.tsx
+++ b/frontend/src/pages/live-game/live-game-admin-page.tsx
@@ -351,6 +351,9 @@ export const LiveGameAdminPage: React.FC = () => {
             player2Id={localState.player2Id!}
             player1Name={context.playerName(localState.player1Id)}
             player2Name={context.playerName(localState.player2Id)}
+            setsWon={localState.setsWon}
+            currentSet={localState.currentSet}
+            completedSets={localState.completedSets}
           />
 
           <CompletedSetsList sets={localState.completedSets} />

--- a/frontend/src/pages/live-game/live-game-page.tsx
+++ b/frontend/src/pages/live-game/live-game-page.tsx
@@ -6,6 +6,7 @@ import { stringToColor } from "../../common/string-to-color";
 import { Link } from "react-router-dom";
 import { session } from "../../services/auth";
 import { CompletedSetsList } from "./completed-sets-list";
+import { LiveGamePredictionCard } from "./live-game-prediction-card";
 import { LiveGameSetPoint } from "./live-game-types";
 import { Server } from "../../common/serve-tracker";
 import { ServeTrackerDisplay } from "../../common/serve-tracker-display";
@@ -164,6 +165,13 @@ const LiveScoreboard: React.FC<ScoreboardProps> = ({
           />
         </div>
       </div>
+
+      <LiveGamePredictionCard
+        player1Id={player1Id}
+        player2Id={player2Id}
+        player1Name={player1Name}
+        player2Name={player2Name}
+      />
 
       <CompletedSetsList sets={completedSets} />
     </div>

--- a/frontend/src/pages/live-game/live-game-page.tsx
+++ b/frontend/src/pages/live-game/live-game-page.tsx
@@ -171,6 +171,9 @@ const LiveScoreboard: React.FC<ScoreboardProps> = ({
         player2Id={player2Id}
         player1Name={player1Name}
         player2Name={player2Name}
+        setsWon={setsWon}
+        currentSet={currentSet}
+        completedSets={completedSets}
       />
 
       <CompletedSetsList sets={completedSets} />

--- a/frontend/src/pages/live-game/live-game-prediction-card.tsx
+++ b/frontend/src/pages/live-game/live-game-prediction-card.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useEventDbContext } from "../../wrappers/event-db-context";
 import { Predictions } from "../../client/client-db/predictions";
 import { fmtNum } from "../../common/number-utils";
@@ -40,7 +40,7 @@ export const LiveGamePredictionCard: React.FC<Props> = ({
   const bothUnranked = !player1Ranked && !player2Ranked;
   const hasUnranked = !player1Ranked || !player2Ranked;
 
-  // Static pairing prediction (same math as the player-page predictions tab).
+  // Static pre-game pairing prediction (same math as the player-page tab).
   const predictions = context.predictions;
   const direct = predictions.getDirectFraction(player1Id, player2Id);
   const oneLayer = predictions.getOneLayerFraction(player1Id, player2Id);
@@ -49,21 +49,38 @@ export const LiveGamePredictionCard: React.FC<Props> = ({
   const baseConfidence = base?.confidence ?? 0;
   const hasBasePrediction = baseConfidence > 0;
 
-  // Live prediction: starts at the pairing prediction and evolves with the
-  // points and sets played in the current game (see live-game-win-probability).
-  const { player1WinChance, confidence } = computeLiveWinPrediction({
-    basePlayer1WinChance: hasBasePrediction ? base.fraction : 0.5,
-    baseConfidence,
-    setsWon,
-    currentSet,
-    completedSets,
-  });
-  const player2WinChance = 1 - player1WinChance;
-
   const pointsPlayed =
     currentSet.player1 +
     currentSet.player2 +
     completedSets.reduce((sum, set) => sum + set.player1 + set.player2, 0);
+
+  // Live prediction: derive a per-point win chance from the pre-game prediction
+  // plus the points/sets played so far, then Monte-Carlo simulate the rest of
+  // the match from the current score (see live-game-win-probability). Memoised
+  // so the simulation only re-runs when the score actually changes.
+  const { player1WinChance, confidence } = useMemo(
+    () =>
+      computeLiveWinPrediction({
+        preGameWinChance: hasBasePrediction ? base.fraction : 0.5,
+        preGameConfidence: baseConfidence,
+        setsWon,
+        currentSet,
+        completedSets,
+      }),
+    [
+      hasBasePrediction,
+      base.fraction,
+      baseConfidence,
+      setsWon.player1,
+      setsWon.player2,
+      currentSet.player1,
+      currentSet.player2,
+      // Re-simulate whenever a set is completed (count + the latest set's score).
+      completedSets.length,
+    ],
+  );
+  const player2WinChance = 1 - player1WinChance;
+
   // With no pairing data and no points played yet there is nothing to predict.
   const hasPrediction = hasBasePrediction || pointsPlayed > 0;
 

--- a/frontend/src/pages/live-game/live-game-prediction-card.tsx
+++ b/frontend/src/pages/live-game/live-game-prediction-card.tsx
@@ -47,12 +47,21 @@ export const LiveGamePredictionCard: React.FC<Props> = ({
   const twoLayer = predictions.getTwoLayerFraction(player1Id, player2Id);
   const base = Predictions.combinePrioritizedFractions([direct, oneLayer, twoLayer]);
   const baseConfidence = base?.confidence ?? 0;
+  const baseFraction = base?.fraction ?? 0;
   const hasBasePrediction = baseConfidence > 0;
 
   const pointsPlayed =
     currentSet.player1 +
     currentSet.player2 +
     completedSets.reduce((sum, set) => sum + set.player1 + set.player2, 0);
+
+  // Primitives + a serialized key so the memo depends only on stable values
+  // (the score objects get new identities on every poll/render).
+  const setsWonP1 = setsWon.player1;
+  const setsWonP2 = setsWon.player2;
+  const currentSetP1 = currentSet.player1;
+  const currentSetP2 = currentSet.player2;
+  const completedSetsKey = JSON.stringify(completedSets);
 
   // Live prediction: derive a per-point win chance from the pre-game prediction
   // plus the points/sets played so far, then Monte-Carlo simulate the rest of
@@ -61,22 +70,21 @@ export const LiveGamePredictionCard: React.FC<Props> = ({
   const { player1WinChance, confidence } = useMemo(
     () =>
       computeLiveWinPrediction({
-        preGameWinChance: hasBasePrediction ? base.fraction : 0.5,
+        preGameWinChance: hasBasePrediction ? baseFraction : 0.5,
         preGameConfidence: baseConfidence,
-        setsWon,
-        currentSet,
-        completedSets,
+        setsWon: { player1: setsWonP1, player2: setsWonP2 },
+        currentSet: { player1: currentSetP1, player2: currentSetP2 },
+        completedSets: JSON.parse(completedSetsKey) as LiveGameSetPoint[],
       }),
     [
       hasBasePrediction,
-      base.fraction,
+      baseFraction,
       baseConfidence,
-      setsWon.player1,
-      setsWon.player2,
-      currentSet.player1,
-      currentSet.player2,
-      // Re-simulate whenever a set is completed (count + the latest set's score).
-      completedSets.length,
+      setsWonP1,
+      setsWonP2,
+      currentSetP1,
+      currentSetP2,
+      completedSetsKey,
     ],
   );
   const player2WinChance = 1 - player1WinChance;

--- a/frontend/src/pages/live-game/live-game-prediction-card.tsx
+++ b/frontend/src/pages/live-game/live-game-prediction-card.tsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useState } from "react";
+import { useEventDbContext } from "../../wrappers/event-db-context";
+import { Predictions } from "../../client/client-db/predictions";
+import { fmtNum } from "../../common/number-utils";
+import { stringToColor } from "../../common/string-to-color";
+
+type Props = {
+  player1Id: string;
+  player2Id: string;
+  player1Name: string;
+  player2Name: string;
+};
+
+export const LiveGamePredictionCard: React.FC<Props> = ({ player1Id, player2Id, player1Name, player2Name }) => {
+  const context = useEventDbContext();
+
+  // Mirror the player-page predictions tab: when at least one player is unranked
+  // the prediction is gated behind a warning the user must acknowledge before it
+  // is shown. Reset the acknowledgement whenever the matchup changes.
+  const [revealed, setRevealed] = useState(false);
+  useEffect(() => {
+    setRevealed(false);
+  }, [player1Id, player2Id]);
+
+  const player1Ranked = context.leaderboard.getPlayerSummary(player1Id)?.isRanked ?? false;
+  const player2Ranked = context.leaderboard.getPlayerSummary(player2Id)?.isRanked ?? false;
+  const bothUnranked = !player1Ranked && !player2Ranked;
+  const hasUnranked = !player1Ranked || !player2Ranked;
+
+  const predictions = context.predictions;
+  const direct = predictions.getDirectFraction(player1Id, player2Id);
+  const oneLayer = predictions.getOneLayerFraction(player1Id, player2Id);
+  const twoLayer = predictions.getTwoLayerFraction(player1Id, player2Id);
+  const combined = Predictions.combinePrioritizedFractions([direct, oneLayer, twoLayer]);
+
+  const confidence = combined?.confidence ?? 0;
+  const player1WinChance = combined?.fraction ?? 0;
+  const player2WinChance = 1 - player1WinChance;
+  const hasPrediction = confidence > 0;
+
+  const unrankedLabel = bothUnranked ? "Both players are not ranked" : "One player is not ranked";
+
+  // Unranked gate — acknowledge the warning before revealing the prediction.
+  if (hasUnranked && !revealed) {
+    return (
+      <div className="bg-white rounded-xl shadow-lg p-4 text-black text-center">
+        <h2 className="text-gray-400 text-xs uppercase tracking-widest font-bold mb-3">Win Prediction</h2>
+        <div className="text-3xl mb-2">⚠️</div>
+        <p className="text-base font-semibold mb-1">{unrankedLabel}</p>
+        <p className="text-sm text-gray-500 mb-4">
+          The prediction is based on insufficient data and may be unreliable.
+        </p>
+        <button
+          onClick={() => setRevealed(true)}
+          className="rounded-md bg-gray-800 px-4 py-2 text-sm font-medium text-white hover:bg-gray-700 transition-colors"
+        >
+          Show prediction anyway
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-xl shadow-lg p-4 text-black">
+      <h2 className="text-gray-400 text-xs uppercase tracking-widest font-bold mb-3 text-center">Win Prediction</h2>
+
+      {hasUnranked && (
+        <div className="mb-3 flex items-center gap-2 rounded-lg border border-yellow-500/60 bg-yellow-50 px-3 py-2 text-xs text-yellow-800">
+          <span className="text-base leading-none">⚠️</span>
+          <span>{unrankedLabel} — the prediction is based on insufficient data and may be unreliable.</span>
+        </div>
+      )}
+
+      {hasPrediction ? (
+        <>
+          <div className="flex items-baseline justify-between text-sm font-semibold mb-1">
+            <span className="truncate max-w-[45%]" style={{ color: stringToColor(player1Id) }}>
+              {player1Name}
+            </span>
+            <span className="truncate max-w-[45%] text-right" style={{ color: stringToColor(player2Id) }}>
+              {player2Name}
+            </span>
+          </div>
+          <div className="flex h-8 w-full overflow-hidden rounded-full bg-gray-100">
+            <div
+              className="flex items-center justify-start bg-blue-500 px-2 text-xs font-bold text-white transition-all"
+              style={{ width: `${player1WinChance * 100}%` }}
+            >
+              {player1WinChance >= 0.12 && `${fmtNum(player1WinChance * 100)}%`}
+            </div>
+            <div
+              className="flex items-center justify-end bg-purple-500 px-2 text-xs font-bold text-white transition-all"
+              style={{ width: `${player2WinChance * 100}%` }}
+            >
+              {player2WinChance >= 0.12 && `${fmtNum(player2WinChance * 100)}%`}
+            </div>
+          </div>
+          <div className="mt-1 flex justify-between text-xs font-semibold">
+            <span className="text-blue-600">{fmtNum(player1WinChance * 100)}% win chance</span>
+            <span className="text-purple-600">{fmtNum(player2WinChance * 100)}% win chance</span>
+          </div>
+          <div className="mt-3 text-center text-xs text-gray-500">{fmtNum(confidence * 100)}% confidence</div>
+        </>
+      ) : (
+        <p className="text-center text-sm text-gray-500 py-2">Not enough data to predict a winner yet.</p>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/pages/live-game/live-game-prediction-card.tsx
+++ b/frontend/src/pages/live-game/live-game-prediction-card.tsx
@@ -3,15 +3,28 @@ import { useEventDbContext } from "../../wrappers/event-db-context";
 import { Predictions } from "../../client/client-db/predictions";
 import { fmtNum } from "../../common/number-utils";
 import { stringToColor } from "../../common/string-to-color";
+import { LiveGameSetPoint } from "./live-game-types";
+import { computeLiveWinPrediction } from "./live-game-win-probability";
 
 type Props = {
   player1Id: string;
   player2Id: string;
   player1Name: string;
   player2Name: string;
+  setsWon: { player1: number; player2: number };
+  currentSet: LiveGameSetPoint;
+  completedSets: LiveGameSetPoint[];
 };
 
-export const LiveGamePredictionCard: React.FC<Props> = ({ player1Id, player2Id, player1Name, player2Name }) => {
+export const LiveGamePredictionCard: React.FC<Props> = ({
+  player1Id,
+  player2Id,
+  player1Name,
+  player2Name,
+  setsWon,
+  currentSet,
+  completedSets,
+}) => {
   const context = useEventDbContext();
 
   // Mirror the player-page predictions tab: when at least one player is unranked
@@ -27,16 +40,32 @@ export const LiveGamePredictionCard: React.FC<Props> = ({ player1Id, player2Id, 
   const bothUnranked = !player1Ranked && !player2Ranked;
   const hasUnranked = !player1Ranked || !player2Ranked;
 
+  // Static pairing prediction (same math as the player-page predictions tab).
   const predictions = context.predictions;
   const direct = predictions.getDirectFraction(player1Id, player2Id);
   const oneLayer = predictions.getOneLayerFraction(player1Id, player2Id);
   const twoLayer = predictions.getTwoLayerFraction(player1Id, player2Id);
-  const combined = Predictions.combinePrioritizedFractions([direct, oneLayer, twoLayer]);
+  const base = Predictions.combinePrioritizedFractions([direct, oneLayer, twoLayer]);
+  const baseConfidence = base?.confidence ?? 0;
+  const hasBasePrediction = baseConfidence > 0;
 
-  const confidence = combined?.confidence ?? 0;
-  const player1WinChance = combined?.fraction ?? 0;
+  // Live prediction: starts at the pairing prediction and evolves with the
+  // points and sets played in the current game (see live-game-win-probability).
+  const { player1WinChance, confidence } = computeLiveWinPrediction({
+    basePlayer1WinChance: hasBasePrediction ? base.fraction : 0.5,
+    baseConfidence,
+    setsWon,
+    currentSet,
+    completedSets,
+  });
   const player2WinChance = 1 - player1WinChance;
-  const hasPrediction = confidence > 0;
+
+  const pointsPlayed =
+    currentSet.player1 +
+    currentSet.player2 +
+    completedSets.reduce((sum, set) => sum + set.player1 + set.player2, 0);
+  // With no pairing data and no points played yet there is nothing to predict.
+  const hasPrediction = hasBasePrediction || pointsPlayed > 0;
 
   const unrankedLabel = bothUnranked ? "Both players are not ranked" : "One player is not ranked";
 
@@ -44,7 +73,7 @@ export const LiveGamePredictionCard: React.FC<Props> = ({ player1Id, player2Id, 
   if (hasUnranked && !revealed) {
     return (
       <div className="bg-white rounded-xl shadow-lg p-4 text-black text-center">
-        <h2 className="text-gray-400 text-xs uppercase tracking-widest font-bold mb-3">Win Prediction</h2>
+        <h2 className="text-gray-400 text-xs uppercase tracking-widest font-bold mb-3">Live Win Prediction</h2>
         <div className="text-3xl mb-2">⚠️</div>
         <p className="text-base font-semibold mb-1">{unrankedLabel}</p>
         <p className="text-sm text-gray-500 mb-4">
@@ -62,7 +91,9 @@ export const LiveGamePredictionCard: React.FC<Props> = ({ player1Id, player2Id, 
 
   return (
     <div className="bg-white rounded-xl shadow-lg p-4 text-black">
-      <h2 className="text-gray-400 text-xs uppercase tracking-widest font-bold mb-3 text-center">Win Prediction</h2>
+      <h2 className="text-gray-400 text-xs uppercase tracking-widest font-bold mb-3 text-center">
+        Live Win Prediction
+      </h2>
 
       {hasUnranked && (
         <div className="mb-3 flex items-center gap-2 rounded-lg border border-yellow-500/60 bg-yellow-50 px-3 py-2 text-xs text-yellow-800">
@@ -83,13 +114,13 @@ export const LiveGamePredictionCard: React.FC<Props> = ({ player1Id, player2Id, 
           </div>
           <div className="flex h-8 w-full overflow-hidden rounded-full bg-gray-100">
             <div
-              className="flex items-center justify-start bg-blue-500 px-2 text-xs font-bold text-white transition-all"
+              className="flex items-center justify-start bg-blue-500 px-2 text-xs font-bold text-white transition-all duration-500"
               style={{ width: `${player1WinChance * 100}%` }}
             >
               {player1WinChance >= 0.12 && `${fmtNum(player1WinChance * 100)}%`}
             </div>
             <div
-              className="flex items-center justify-end bg-purple-500 px-2 text-xs font-bold text-white transition-all"
+              className="flex items-center justify-end bg-purple-500 px-2 text-xs font-bold text-white transition-all duration-500"
               style={{ width: `${player2WinChance * 100}%` }}
             >
               {player2WinChance >= 0.12 && `${fmtNum(player2WinChance * 100)}%`}

--- a/frontend/src/pages/live-game/live-game-win-probability.test.ts
+++ b/frontend/src/pages/live-game/live-game-win-probability.test.ts
@@ -109,8 +109,9 @@ describe("computeLiveWinPrediction", () => {
     // The win chance is a genuine coin flip...
     expect(decider.player1WinChance).toBeGreaterThan(0.4);
     expect(decider.player1WinChance).toBeLessThan(0.6);
-    // ...but the match is almost over, so confidence in that 50/50 is high.
-    expect(decider.confidence).toBeGreaterThan(0.8);
+    // ...but the match is all but over, so we are ~fully confident in that
+    // 50/50 prediction.
+    expect(decider.confidence).toBeGreaterThan(0.95);
   });
 
   it("builds a confident prediction from live points alone when there is no pairing data", () => {

--- a/frontend/src/pages/live-game/live-game-win-probability.test.ts
+++ b/frontend/src/pages/live-game/live-game-win-probability.test.ts
@@ -93,7 +93,7 @@ describe("computeLiveWinPrediction", () => {
     expect(decided.confidence).toBe(1);
   });
 
-  it("keeps a genuine coin-flip decider uncertain", () => {
+  it("keeps a coin-flip decider's win chance even but stays confident it is close", () => {
     const decider = computeLiveWinPrediction({
       preGameWinChance: 0.5,
       preGameConfidence: 0.5,
@@ -106,8 +106,11 @@ describe("computeLiveWinPrediction", () => {
       simulations: 20000,
       random: seededRandom(7),
     });
+    // The win chance is a genuine coin flip...
     expect(decider.player1WinChance).toBeGreaterThan(0.4);
     expect(decider.player1WinChance).toBeLessThan(0.6);
+    // ...but the match is almost over, so confidence in that 50/50 is high.
+    expect(decider.confidence).toBeGreaterThan(0.8);
   });
 
   it("builds a confident prediction from live points alone when there is no pairing data", () => {

--- a/frontend/src/pages/live-game/live-game-win-probability.test.ts
+++ b/frontend/src/pages/live-game/live-game-win-probability.test.ts
@@ -1,67 +1,93 @@
 import { computeLiveWinPrediction, LiveWinPredictionInput } from "./live-game-win-probability";
 
+// Deterministic RNG so the Monte-Carlo simulation is reproducible in tests.
+function seededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state |= 0;
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
 const freshGame = (
-  base: Pick<LiveWinPredictionInput, "basePlayer1WinChance" | "baseConfidence">,
+  base: Pick<LiveWinPredictionInput, "preGameWinChance" | "preGameConfidence">,
 ): LiveWinPredictionInput => ({
   ...base,
   setsWon: { player1: 0, player2: 0 },
   currentSet: { player1: 0, player2: 0 },
   completedSets: [],
+  simulations: 20000,
+  random: seededRandom(12345),
 });
 
 describe("computeLiveWinPrediction", () => {
-  it("reproduces the pairing prediction at the start of the game", () => {
+  it("reproduces the pre-game prediction at the start of the game", () => {
     const { player1WinChance, confidence } = computeLiveWinPrediction(
-      freshGame({ basePlayer1WinChance: 0.65, baseConfidence: 0.5 }),
+      freshGame({ preGameWinChance: 0.65, preGameConfidence: 0.5 }),
     );
-    expect(player1WinChance).toBeCloseTo(0.65, 2);
-    expect(confidence).toBeCloseTo(0.5, 2);
+    expect(player1WinChance).toBeCloseTo(0.65, 1);
+    expect(confidence).toBeCloseTo(0.5, 1);
   });
 
   it("reproduces an even no-data prediction at the start", () => {
     const { player1WinChance, confidence } = computeLiveWinPrediction(
-      freshGame({ basePlayer1WinChance: 0.5, baseConfidence: 0 }),
+      freshGame({ preGameWinChance: 0.5, preGameConfidence: 0 }),
     );
-    expect(player1WinChance).toBeCloseTo(0.5, 2);
+    expect(player1WinChance).toBeCloseTo(0.5, 1);
     expect(confidence).toBeCloseTo(0, 2);
   });
 
   it("raises the win chance and confidence when player 1 leads", () => {
-    const base = freshGame({ basePlayer1WinChance: 0.5, baseConfidence: 0.5 });
-    const leading = computeLiveWinPrediction({ ...base, currentSet: { player1: 7, player2: 2 } });
+    const base = freshGame({ preGameWinChance: 0.5, preGameConfidence: 0.5 });
+    const leading = computeLiveWinPrediction({ ...base, currentSet: { player1: 8, player2: 2 } });
     expect(leading.player1WinChance).toBeGreaterThan(0.5);
     expect(leading.confidence).toBeGreaterThan(0.5);
   });
 
   it("lowers the win chance when player 1 trails", () => {
-    const base = freshGame({ basePlayer1WinChance: 0.5, baseConfidence: 0.5 });
-    const trailing = computeLiveWinPrediction({ ...base, currentSet: { player1: 2, player2: 7 } });
+    const base = freshGame({ preGameWinChance: 0.5, preGameConfidence: 0.5 });
+    const trailing = computeLiveWinPrediction({ ...base, currentSet: { player1: 2, player2: 8 } });
     expect(trailing.player1WinChance).toBeLessThan(0.5);
   });
 
+  it("derives a per-point win chance below the match win chance for a favourite", () => {
+    const { perPointWinChance, player1WinChance } = computeLiveWinPrediction(
+      freshGame({ preGameWinChance: 0.8, preGameConfidence: 0.6 }),
+    );
+    // A big match-win edge comes from a much smaller per-point edge.
+    expect(perPointWinChance).toBeGreaterThan(0.5);
+    expect(perPointWinChance).toBeLessThan(player1WinChance);
+  });
+
   it("converges toward certainty as the match nears its end", () => {
-    // Player 1 up a set and holding match point in the second set.
     const nearWin = computeLiveWinPrediction({
-      basePlayer1WinChance: 0.5,
-      baseConfidence: 0.5,
+      preGameWinChance: 0.5,
+      preGameConfidence: 0.5,
       setsWon: { player1: 1, player2: 0 },
       currentSet: { player1: 10, player2: 4 },
       completedSets: [{ player1: 11, player2: 6 }],
+      simulations: 20000,
+      random: seededRandom(999),
     });
-    expect(nearWin.player1WinChance).toBeGreaterThan(0.97);
-    expect(nearWin.confidence).toBeGreaterThan(0.95);
+    expect(nearWin.player1WinChance).toBeGreaterThan(0.95);
+    expect(nearWin.confidence).toBeGreaterThan(0.9);
   });
 
   it("returns a decided result once a player has won two sets", () => {
     const decided = computeLiveWinPrediction({
-      basePlayer1WinChance: 0.5,
-      baseConfidence: 0.5,
+      preGameWinChance: 0.5,
+      preGameConfidence: 0.5,
       setsWon: { player1: 2, player2: 0 },
       currentSet: { player1: 0, player2: 0 },
       completedSets: [
         { player1: 11, player2: 5 },
         { player1: 11, player2: 8 },
       ],
+      simulations: 1000,
+      random: seededRandom(1),
     });
     expect(decided.player1WinChance).toBe(1);
     expect(decided.confidence).toBe(1);
@@ -69,14 +95,16 @@ describe("computeLiveWinPrediction", () => {
 
   it("keeps a genuine coin-flip decider uncertain", () => {
     const decider = computeLiveWinPrediction({
-      basePlayer1WinChance: 0.5,
-      baseConfidence: 0.5,
+      preGameWinChance: 0.5,
+      preGameConfidence: 0.5,
       setsWon: { player1: 1, player2: 1 },
       currentSet: { player1: 10, player2: 10 },
       completedSets: [
         { player1: 11, player2: 7 },
         { player1: 7, player2: 11 },
       ],
+      simulations: 20000,
+      random: seededRandom(7),
     });
     expect(decider.player1WinChance).toBeGreaterThan(0.4);
     expect(decider.player1WinChance).toBeLessThan(0.6);
@@ -84,13 +112,15 @@ describe("computeLiveWinPrediction", () => {
 
   it("builds a confident prediction from live points alone when there is no pairing data", () => {
     const dominating = computeLiveWinPrediction({
-      basePlayer1WinChance: 0.5,
-      baseConfidence: 0,
+      preGameWinChance: 0.5,
+      preGameConfidence: 0,
       setsWon: { player1: 1, player2: 0 },
       currentSet: { player1: 9, player2: 1 },
       completedSets: [{ player1: 11, player2: 2 }],
+      simulations: 20000,
+      random: seededRandom(42),
     });
     expect(dominating.player1WinChance).toBeGreaterThan(0.9);
-    expect(dominating.confidence).toBeGreaterThan(0.9);
+    expect(dominating.confidence).toBeGreaterThan(0.85);
   });
 });

--- a/frontend/src/pages/live-game/live-game-win-probability.test.ts
+++ b/frontend/src/pages/live-game/live-game-win-probability.test.ts
@@ -1,0 +1,96 @@
+import { computeLiveWinPrediction, LiveWinPredictionInput } from "./live-game-win-probability";
+
+const freshGame = (
+  base: Pick<LiveWinPredictionInput, "basePlayer1WinChance" | "baseConfidence">,
+): LiveWinPredictionInput => ({
+  ...base,
+  setsWon: { player1: 0, player2: 0 },
+  currentSet: { player1: 0, player2: 0 },
+  completedSets: [],
+});
+
+describe("computeLiveWinPrediction", () => {
+  it("reproduces the pairing prediction at the start of the game", () => {
+    const { player1WinChance, confidence } = computeLiveWinPrediction(
+      freshGame({ basePlayer1WinChance: 0.65, baseConfidence: 0.5 }),
+    );
+    expect(player1WinChance).toBeCloseTo(0.65, 2);
+    expect(confidence).toBeCloseTo(0.5, 2);
+  });
+
+  it("reproduces an even no-data prediction at the start", () => {
+    const { player1WinChance, confidence } = computeLiveWinPrediction(
+      freshGame({ basePlayer1WinChance: 0.5, baseConfidence: 0 }),
+    );
+    expect(player1WinChance).toBeCloseTo(0.5, 2);
+    expect(confidence).toBeCloseTo(0, 2);
+  });
+
+  it("raises the win chance and confidence when player 1 leads", () => {
+    const base = freshGame({ basePlayer1WinChance: 0.5, baseConfidence: 0.5 });
+    const leading = computeLiveWinPrediction({ ...base, currentSet: { player1: 7, player2: 2 } });
+    expect(leading.player1WinChance).toBeGreaterThan(0.5);
+    expect(leading.confidence).toBeGreaterThan(0.5);
+  });
+
+  it("lowers the win chance when player 1 trails", () => {
+    const base = freshGame({ basePlayer1WinChance: 0.5, baseConfidence: 0.5 });
+    const trailing = computeLiveWinPrediction({ ...base, currentSet: { player1: 2, player2: 7 } });
+    expect(trailing.player1WinChance).toBeLessThan(0.5);
+  });
+
+  it("converges toward certainty as the match nears its end", () => {
+    // Player 1 up a set and holding match point in the second set.
+    const nearWin = computeLiveWinPrediction({
+      basePlayer1WinChance: 0.5,
+      baseConfidence: 0.5,
+      setsWon: { player1: 1, player2: 0 },
+      currentSet: { player1: 10, player2: 4 },
+      completedSets: [{ player1: 11, player2: 6 }],
+    });
+    expect(nearWin.player1WinChance).toBeGreaterThan(0.97);
+    expect(nearWin.confidence).toBeGreaterThan(0.95);
+  });
+
+  it("returns a decided result once a player has won two sets", () => {
+    const decided = computeLiveWinPrediction({
+      basePlayer1WinChance: 0.5,
+      baseConfidence: 0.5,
+      setsWon: { player1: 2, player2: 0 },
+      currentSet: { player1: 0, player2: 0 },
+      completedSets: [
+        { player1: 11, player2: 5 },
+        { player1: 11, player2: 8 },
+      ],
+    });
+    expect(decided.player1WinChance).toBe(1);
+    expect(decided.confidence).toBe(1);
+  });
+
+  it("keeps a genuine coin-flip decider uncertain", () => {
+    const decider = computeLiveWinPrediction({
+      basePlayer1WinChance: 0.5,
+      baseConfidence: 0.5,
+      setsWon: { player1: 1, player2: 1 },
+      currentSet: { player1: 10, player2: 10 },
+      completedSets: [
+        { player1: 11, player2: 7 },
+        { player1: 7, player2: 11 },
+      ],
+    });
+    expect(decider.player1WinChance).toBeGreaterThan(0.4);
+    expect(decider.player1WinChance).toBeLessThan(0.6);
+  });
+
+  it("builds a confident prediction from live points alone when there is no pairing data", () => {
+    const dominating = computeLiveWinPrediction({
+      basePlayer1WinChance: 0.5,
+      baseConfidence: 0,
+      setsWon: { player1: 1, player2: 0 },
+      currentSet: { player1: 9, player2: 1 },
+      completedSets: [{ player1: 11, player2: 2 }],
+    });
+    expect(dominating.player1WinChance).toBeGreaterThan(0.9);
+    expect(dominating.confidence).toBeGreaterThan(0.9);
+  });
+});

--- a/frontend/src/pages/live-game/live-game-win-probability.ts
+++ b/frontend/src/pages/live-game/live-game-win-probability.ts
@@ -1,0 +1,180 @@
+import { LiveGameSetPoint } from "./live-game-types";
+
+/**
+ * Live win-probability model for a best-of-3 table tennis match
+ * (first to 2 sets; each set first to 11, win by 2 / deuce).
+ *
+ * Two things evolve as the match is played:
+ *
+ *  1. ACCURACY — the points actually scored in this game are fresh evidence
+ *     about the true per-point skill gap. We start from the pairing prediction
+ *     as a Bayesian prior and update it with the live points, so the win % gets
+ *     more accurate as more points are played.
+ *
+ *  2. RESOLUTION — conditioning on the current score, the match-win
+ *     probability is pushed toward 0 or 1 as the match nears its end, and the
+ *     confidence converges to 100 % as the outcome becomes determined.
+ *
+ * At 0–0 with no points played the model reproduces the static pairing
+ * prediction exactly (both win % and confidence).
+ */
+
+export type LiveWinPrediction = {
+  /** Probability player 1 wins the match, in [0, 1]. */
+  player1WinChance: number;
+  /** Confidence in the prediction, in [0, 1]. */
+  confidence: number;
+};
+
+export type LiveWinPredictionInput = {
+  /** Static pairing prediction: player 1's chance to win the match, [0, 1]. */
+  basePlayer1WinChance: number;
+  /** Static pairing prediction confidence, [0, 1]. */
+  baseConfidence: number;
+  setsWon: { player1: number; player2: number };
+  currentSet: LiveGameSetPoint;
+  completedSets: LiveGameSetPoint[];
+};
+
+const SETS_TO_WIN_MATCH = 2;
+const POINTS_TO_WIN_SET = 11;
+
+// Beta-prior strength mapped from the base confidence. A confident pairing
+// prediction is a strong prior (live points move it little); a weak prediction
+// is a loose prior (live points dominate quickly).
+const PRIOR_STRENGTH_MIN = 6;
+const PRIOR_STRENGTH_MAX = 120;
+
+/**
+ * Probability player 1 wins a single set given the current set score (a, b),
+ * assuming a constant per-point win probability `p`. Handles the win-by-2
+ * deuce rule analytically once both players reach 10.
+ */
+function makeSetSolver(p: number): (a: number, b: number) => number {
+  const q = 1 - p;
+  // Win probability from an even score in the deuce zone (10–10, 11–11, …):
+  // win two in a row, or split and return to even.
+  const deuceEven = p * p + q * q === 0 ? 0.5 : (p * p) / (p * p + q * q);
+  const memo = new Map<number, number>();
+
+  const solve = (a: number, b: number): number => {
+    if (a >= POINTS_TO_WIN_SET && a - b >= 2) return 1;
+    if (b >= POINTS_TO_WIN_SET && b - a >= 2) return 0;
+
+    if (a >= POINTS_TO_WIN_SET - 1 && b >= POINTS_TO_WIN_SET - 1) {
+      const diff = a - b;
+      if (diff >= 2) return 1;
+      if (diff <= -2) return 0;
+      if (diff === 0) return deuceEven;
+      if (diff === 1) return p + q * deuceEven;
+      return p * deuceEven; // diff === -1
+    }
+
+    const key = a * 100 + b;
+    const cached = memo.get(key);
+    if (cached !== undefined) return cached;
+
+    const result = p * solve(a + 1, b) + q * solve(a, b + 1);
+    memo.set(key, result);
+    return result;
+  };
+
+  return solve;
+}
+
+/**
+ * Probability player 1 wins the match given sets won so far, the current set
+ * score, and a constant per-point win probability `p`.
+ */
+function matchWinProbability(
+  p: number,
+  setsWon1: number,
+  setsWon2: number,
+  currentA: number,
+  currentB: number,
+): number {
+  if (setsWon1 >= SETS_TO_WIN_MATCH) return 1;
+  if (setsWon2 >= SETS_TO_WIN_MATCH) return 0;
+
+  const setSolver = makeSetSolver(p);
+  const freshSetWin = setSolver(0, 0);
+
+  const fromSetStart = (s1: number, s2: number): number => {
+    if (s1 >= SETS_TO_WIN_MATCH) return 1;
+    if (s2 >= SETS_TO_WIN_MATCH) return 0;
+    return freshSetWin * fromSetStart(s1 + 1, s2) + (1 - freshSetWin) * fromSetStart(s1, s2 + 1);
+  };
+
+  const currentSetWin = setSolver(currentA, currentB);
+  return currentSetWin * fromSetStart(setsWon1 + 1, setsWon2) + (1 - currentSetWin) * fromSetStart(setsWon1, setsWon2 + 1);
+}
+
+/** Match-win probability for player 1 from a fresh 0–0 start. */
+function matchWinFromStart(p: number): number {
+  return matchWinProbability(p, 0, 0, 0, 0);
+}
+
+/**
+ * Invert the match model: find the per-point win probability `p` that yields a
+ * given match-win probability from a 0–0 start. Monotonic in `p`, so a binary
+ * search converges quickly.
+ */
+function perPointProbabilityForMatchChance(matchChance: number): number {
+  const target = clamp(matchChance, 1e-4, 1 - 1e-4);
+  let low = 0;
+  let high = 1;
+  for (let i = 0; i < 40; i++) {
+    const mid = (low + high) / 2;
+    if (matchWinFromStart(mid) < target) {
+      low = mid;
+    } else {
+      high = mid;
+    }
+  }
+  return (low + high) / 2;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function computeLiveWinPrediction(input: LiveWinPredictionInput): LiveWinPrediction {
+  const { basePlayer1WinChance, baseConfidence, setsWon, currentSet, completedSets } = input;
+
+  const baseChance = clamp(basePlayer1WinChance, 1e-4, 1 - 1e-4);
+
+  // Prior per-point probability implied by the static pairing prediction.
+  const priorPerPoint = perPointProbabilityForMatchChance(baseChance);
+
+  // Effect 1: blend the live points in as Bayesian evidence about per-point skill.
+  const livePointsP1 =
+    currentSet.player1 + completedSets.reduce((sum, set) => sum + set.player1, 0);
+  const livePointsP2 =
+    currentSet.player2 + completedSets.reduce((sum, set) => sum + set.player2, 0);
+
+  const priorStrength = PRIOR_STRENGTH_MIN + baseConfidence * (PRIOR_STRENGTH_MAX - PRIOR_STRENGTH_MIN);
+  const alpha = priorPerPoint * priorStrength + livePointsP1;
+  const beta = (1 - priorPerPoint) * priorStrength + livePointsP2;
+  const updatedPerPoint = alpha / (alpha + beta);
+
+  // Effect 2: condition on the current score. Converges toward 0/1 as the
+  // match resolves.
+  const player1WinChance = matchWinProbability(
+    updatedPerPoint,
+    setsWon.player1,
+    setsWon.player2,
+    currentSet.player1,
+    currentSet.player2,
+  );
+
+  // Confidence rises from the base toward 100 % as the outcome becomes
+  // determined. Measured by how much the match-outcome variance has collapsed
+  // relative to the pre-game prediction. At 0–0 with no points this is exactly
+  // the base confidence.
+  const baseVariance = baseChance * (1 - baseChance);
+  const currentVariance = player1WinChance * (1 - player1WinChance);
+  const resolution = baseVariance === 0 ? 1 : clamp(1 - currentVariance / baseVariance, 0, 1);
+  const confidence = baseConfidence + (1 - baseConfidence) * resolution;
+
+  return { player1WinChance, confidence };
+}

--- a/frontend/src/pages/live-game/live-game-win-probability.ts
+++ b/frontend/src/pages/live-game/live-game-win-probability.ts
@@ -218,10 +218,16 @@ export function computeLiveWinPrediction(input: LiveWinPredictionInput): LiveWin
 
   // Confidence rises from the per-point estimate's data confidence toward 100 %
   // as the match nears its end — measured by how few points remain to be played
-  // relative to a full match from 0–0 (NOT by how lopsided the win % is, so a
-  // tied deciding set is still high-confidence: we are confident it is close).
+  // relative to a full match from 0–0. This is independent of how lopsided the
+  // win % is: a tied deciding deuce is high-confidence because we are confident
+  // in the prediction (a 50/50), even though the result itself is a coin flip.
+  //
+  // The mapping is concave (1 − r²) so the final stretch saturates to ~100 %:
+  // once only a handful of points remain we are essentially certain of the
+  // prediction, whatever it is.
   const fullMatch = runSimulations(perPoint.fraction, 0, 0, 0, 0, simulations, random);
-  const matchProgress = clamp(1 - current.avgRemainingPoints / Math.max(fullMatch.avgRemainingPoints, 1), 0, 1);
+  const remainingRatio = current.avgRemainingPoints / Math.max(fullMatch.avgRemainingPoints, 1);
+  const matchProgress = clamp(1 - remainingRatio * remainingRatio, 0, 1);
   const confidence = perPoint.confidence + (1 - perPoint.confidence) * matchProgress;
 
   return { player1WinChance, confidence, perPointWinChance: perPoint.fraction };

--- a/frontend/src/pages/live-game/live-game-win-probability.ts
+++ b/frontend/src/pages/live-game/live-game-win-probability.ts
@@ -1,22 +1,34 @@
 import { LiveGameSetPoint } from "./live-game-types";
+import {
+  Fraction,
+  POINT_CONFIDENCE_CONFIG,
+  Predictions,
+  SET_CONFIDENCE_CONFIG,
+} from "../../client/client-db/predictions";
+import { pointToGame, setToGame } from "../../client/client-db/future-elo-probability-lookups";
 
 /**
  * Live win-probability model for a best-of-3 table tennis match
  * (first to 2 sets; each set first to 11, win by 2 / deuce).
  *
- * Two things evolve as the match is played:
+ * Approach (see chat design):
  *
- *  1. ACCURACY — the points actually scored in this game are fresh evidence
- *     about the true per-point skill gap. We start from the pairing prediction
- *     as a Bayesian prior and update it with the live points, so the win % gets
- *     more accurate as more points are played.
+ *  1. Derive a single per-point win probability for player 1 from
+ *     pre-game data + the points/sets played so far in this game.
  *
- *  2. RESOLUTION — conditioning on the current score, the match-win
- *     probability is pushed toward 0 or 1 as the match nears its end, and the
- *     confidence converges to 100 % as the outcome becomes determined.
+ *     The static prediction maps point% and set% up to a game% and combines
+ *     them by confidence. Here we run that in reverse: we take the pre-game
+ *     game% and the live set% / point% and map each back down to a per-point%
+ *     (`pointToGame` and `setToGame` are best-of-3-to-11 tables, so inverting
+ *     them is exact), then combine by confidence into one per-point%.
  *
- * At 0–0 with no points played the model reproduces the static pairing
- * prediction exactly (both win % and confidence).
+ *  2. Monte-Carlo simulate the remainder of the match from the current score
+ *     with that per-point% and use the win ratio as the prediction.
+ *
+ * At 0–0 with no points played this reproduces the static pairing prediction
+ * (inverting then simulating the same best-of-3-to-11 model round-trips), and
+ * as points/sets are played the per-point% sharpens and the simulated win
+ * ratio converges toward 0/1 as the match nears its end.
  */
 
 export type LiveWinPrediction = {
@@ -24,108 +36,53 @@ export type LiveWinPrediction = {
   player1WinChance: number;
   /** Confidence in the prediction, in [0, 1]. */
   confidence: number;
+  /** The derived per-point win probability used for the simulation. */
+  perPointWinChance: number;
 };
 
 export type LiveWinPredictionInput = {
-  /** Static pairing prediction: player 1's chance to win the match, [0, 1]. */
-  basePlayer1WinChance: number;
-  /** Static pairing prediction confidence, [0, 1]. */
-  baseConfidence: number;
+  /** Pre-game pairing prediction: player 1's chance to win the match, [0, 1]. */
+  preGameWinChance: number;
+  /** Pre-game pairing prediction confidence, [0, 1]. */
+  preGameConfidence: number;
   setsWon: { player1: number; player2: number };
   currentSet: LiveGameSetPoint;
   completedSets: LiveGameSetPoint[];
+  /** Number of Monte-Carlo simulations. Defaults to 1000. */
+  simulations?: number;
+  /** Injectable RNG for deterministic tests. Defaults to Math.random. */
+  random?: () => number;
 };
 
 const SETS_TO_WIN_MATCH = 2;
 const POINTS_TO_WIN_SET = 11;
+const DEFAULT_SIMULATIONS = 1000;
 
-// Beta-prior strength mapped from the base confidence. A confident pairing
-// prediction is a strong prior (live points move it little); a weak prediction
-// is a loose prior (live points dominate quickly).
-const PRIOR_STRENGTH_MIN = 6;
-const PRIOR_STRENGTH_MAX = 120;
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
 
-/**
- * Probability player 1 wins a single set given the current set score (a, b),
- * assuming a constant per-point win probability `p`. Handles the win-by-2
- * deuce rule analytically once both players reach 10.
- */
-function makeSetSolver(p: number): (a: number, b: number) => number {
-  const q = 1 - p;
-  // Win probability from an even score in the deuce zone (10–10, 11–11, …):
-  // win two in a row, or split and return to even.
-  const deuceEven = p * p + q * q === 0 ? 0.5 : (p * p) / (p * p + q * q);
-  const memo = new Map<number, number>();
-
-  const solve = (a: number, b: number): number => {
-    if (a >= POINTS_TO_WIN_SET && a - b >= 2) return 1;
-    if (b >= POINTS_TO_WIN_SET && b - a >= 2) return 0;
-
-    if (a >= POINTS_TO_WIN_SET - 1 && b >= POINTS_TO_WIN_SET - 1) {
-      const diff = a - b;
-      if (diff >= 2) return 1;
-      if (diff <= -2) return 0;
-      if (diff === 0) return deuceEven;
-      if (diff === 1) return p + q * deuceEven;
-      return p * deuceEven; // diff === -1
-    }
-
-    const key = a * 100 + b;
-    const cached = memo.get(key);
-    if (cached !== undefined) return cached;
-
-    const result = p * solve(a + 1, b) + q * solve(a, b + 1);
-    memo.set(key, result);
-    return result;
-  };
-
-  return solve;
+/** Interpolated lookup of a [0..100]-indexed probability table at fraction x ∈ [0, 1]. */
+function lookupAtFraction(table: number[], x: number): number {
+  const exact = clamp(x, 0, 1) * 100;
+  const lower = Math.floor(exact);
+  const upper = Math.ceil(exact);
+  if (lower === upper) return table[lower];
+  return table[lower] + (table[upper] - table[lower]) * (exact - lower);
 }
 
 /**
- * Probability player 1 wins the match given sets won so far, the current set
- * score, and a constant per-point win probability `p`.
+ * Invert a "level% → game%" table to recover the per-point win probability that
+ * would produce a given game-win probability. `pointToGame` is monotonic, so a
+ * binary search converges quickly.
  */
-function matchWinProbability(
-  p: number,
-  setsWon1: number,
-  setsWon2: number,
-  currentA: number,
-  currentB: number,
-): number {
-  if (setsWon1 >= SETS_TO_WIN_MATCH) return 1;
-  if (setsWon2 >= SETS_TO_WIN_MATCH) return 0;
-
-  const setSolver = makeSetSolver(p);
-  const freshSetWin = setSolver(0, 0);
-
-  const fromSetStart = (s1: number, s2: number): number => {
-    if (s1 >= SETS_TO_WIN_MATCH) return 1;
-    if (s2 >= SETS_TO_WIN_MATCH) return 0;
-    return freshSetWin * fromSetStart(s1 + 1, s2) + (1 - freshSetWin) * fromSetStart(s1, s2 + 1);
-  };
-
-  const currentSetWin = setSolver(currentA, currentB);
-  return currentSetWin * fromSetStart(setsWon1 + 1, setsWon2) + (1 - currentSetWin) * fromSetStart(setsWon1, setsWon2 + 1);
-}
-
-/** Match-win probability for player 1 from a fresh 0–0 start. */
-function matchWinFromStart(p: number): number {
-  return matchWinProbability(p, 0, 0, 0, 0);
-}
-
-/**
- * Invert the match model: find the per-point win probability `p` that yields a
- * given match-win probability from a 0–0 start. Monotonic in `p`, so a binary
- * search converges quickly.
- */
-function perPointProbabilityForMatchChance(matchChance: number): number {
-  const target = clamp(matchChance, 1e-4, 1 - 1e-4);
+function gameChanceToPerPoint(gameChance: number): number {
+  const target = clamp(gameChance, 0, 1);
   let low = 0;
   let high = 1;
   for (let i = 0; i < 40; i++) {
     const mid = (low + high) / 2;
-    if (matchWinFromStart(mid) < target) {
+    if (lookupAtFraction(pointToGame, mid) < target) {
       low = mid;
     } else {
       high = mid;
@@ -134,47 +91,114 @@ function perPointProbabilityForMatchChance(matchChance: number): number {
   return (low + high) / 2;
 }
 
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(Math.max(value, min), max);
+/**
+ * Combine pre-game and live evidence into a single per-point win probability for
+ * player 1. Each source is expressed as a per-point% with a confidence and
+ * combined with the same confidence-prioritised blend used by the static
+ * predictions.
+ */
+function derivePerPointWinChance(input: LiveWinPredictionInput): Fraction {
+  const { preGameWinChance, preGameConfidence, setsWon, currentSet, completedSets } = input;
+
+  const livePointsP1 = currentSet.player1 + completedSets.reduce((sum, set) => sum + set.player1, 0);
+  const livePointsP2 = currentSet.player2 + completedSets.reduce((sum, set) => sum + set.player2, 0);
+  const liveSetsP1 = setsWon.player1;
+  const liveSetsP2 = setsWon.player2;
+
+  const estimators: Fraction[] = [];
+
+  // Pre-game data (already a combined game%, direct + indirect) → per-point%.
+  if (preGameConfidence > 0) {
+    estimators.push({ fraction: gameChanceToPerPoint(preGameWinChance), confidence: preGameConfidence });
+  }
+
+  // Live sets → per-point% (set% → game% → per-point%).
+  if (liveSetsP1 + liveSetsP2 > 0) {
+    const setLevel = Predictions.getWinFractionWithConfidence(
+      liveSetsP1,
+      liveSetsP2,
+      setToGame,
+      SET_CONFIDENCE_CONFIG,
+    );
+    estimators.push({ fraction: gameChanceToPerPoint(setLevel.fraction), confidence: setLevel.confidence });
+  }
+
+  // Live points → per-point% (point% maps to itself, i.e. the raw point fraction).
+  if (livePointsP1 + livePointsP2 > 0) {
+    const pointLevel = Predictions.getWinFractionWithConfidence(
+      livePointsP1,
+      livePointsP2,
+      pointToGame,
+      POINT_CONFIDENCE_CONFIG,
+    );
+    estimators.push({ fraction: gameChanceToPerPoint(pointLevel.fraction), confidence: pointLevel.confidence });
+  }
+
+  const combined = Predictions.combinePrioritizedFractions(estimators);
+  // No evidence at all → an even coin flip.
+  if (combined.confidence === 0) return { fraction: 0.5, confidence: 0 };
+  return combined;
+}
+
+/** Play a single set to completion from (a, b); returns the winning player (1 or 2). */
+function simulateSet(perPoint: number, startA: number, startB: number, random: () => number): 1 | 2 {
+  let a = startA;
+  let b = startB;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (a >= POINTS_TO_WIN_SET && a - b >= 2) return 1;
+    if (b >= POINTS_TO_WIN_SET && b - a >= 2) return 2;
+    if (random() < perPoint) a++;
+    else b++;
+  }
+}
+
+/** Simulate the rest of the match once from the current score; returns true if player 1 wins. */
+function simulateMatchOnce(
+  perPoint: number,
+  setsWon1: number,
+  setsWon2: number,
+  currentA: number,
+  currentB: number,
+  random: () => number,
+): boolean {
+  let s1 = setsWon1;
+  let s2 = setsWon2;
+  let a = currentA;
+  let b = currentB;
+  while (s1 < SETS_TO_WIN_MATCH && s2 < SETS_TO_WIN_MATCH) {
+    if (simulateSet(perPoint, a, b, random) === 1) s1++;
+    else s2++;
+    a = 0;
+    b = 0;
+  }
+  return s1 >= SETS_TO_WIN_MATCH;
 }
 
 export function computeLiveWinPrediction(input: LiveWinPredictionInput): LiveWinPrediction {
-  const { basePlayer1WinChance, baseConfidence, setsWon, currentSet, completedSets } = input;
+  const { setsWon, currentSet, preGameWinChance, preGameConfidence } = input;
+  const simulations = input.simulations ?? DEFAULT_SIMULATIONS;
+  const random = input.random ?? Math.random;
 
-  const baseChance = clamp(basePlayer1WinChance, 1e-4, 1 - 1e-4);
+  const perPoint = derivePerPointWinChance(input);
 
-  // Prior per-point probability implied by the static pairing prediction.
-  const priorPerPoint = perPointProbabilityForMatchChance(baseChance);
+  let wins = 0;
+  for (let i = 0; i < simulations; i++) {
+    if (simulateMatchOnce(perPoint.fraction, setsWon.player1, setsWon.player2, currentSet.player1, currentSet.player2, random)) {
+      wins++;
+    }
+  }
+  const player1WinChance = wins / simulations;
 
-  // Effect 1: blend the live points in as Bayesian evidence about per-point skill.
-  const livePointsP1 =
-    currentSet.player1 + completedSets.reduce((sum, set) => sum + set.player1, 0);
-  const livePointsP2 =
-    currentSet.player2 + completedSets.reduce((sum, set) => sum + set.player2, 0);
-
-  const priorStrength = PRIOR_STRENGTH_MIN + baseConfidence * (PRIOR_STRENGTH_MAX - PRIOR_STRENGTH_MIN);
-  const alpha = priorPerPoint * priorStrength + livePointsP1;
-  const beta = (1 - priorPerPoint) * priorStrength + livePointsP2;
-  const updatedPerPoint = alpha / (alpha + beta);
-
-  // Effect 2: condition on the current score. Converges toward 0/1 as the
-  // match resolves.
-  const player1WinChance = matchWinProbability(
-    updatedPerPoint,
-    setsWon.player1,
-    setsWon.player2,
-    currentSet.player1,
-    currentSet.player2,
-  );
-
-  // Confidence rises from the base toward 100 % as the outcome becomes
-  // determined. Measured by how much the match-outcome variance has collapsed
-  // relative to the pre-game prediction. At 0–0 with no points this is exactly
-  // the base confidence.
-  const baseVariance = baseChance * (1 - baseChance);
+  // Confidence rises from the per-point estimate's data confidence toward 100 %
+  // as the match outcome becomes determined (outcome-variance collapse relative
+  // to the pre-game prediction). At 0–0 with no points this is the pre-game
+  // confidence.
+  const baseMatchChance = preGameConfidence > 0 ? preGameWinChance : 0.5;
+  const baseVariance = Math.max(baseMatchChance * (1 - baseMatchChance), 1e-6);
   const currentVariance = player1WinChance * (1 - player1WinChance);
-  const resolution = baseVariance === 0 ? 1 : clamp(1 - currentVariance / baseVariance, 0, 1);
-  const confidence = baseConfidence + (1 - baseConfidence) * resolution;
+  const resolution = clamp(1 - currentVariance / baseVariance, 0, 1);
+  const confidence = perPoint.confidence + (1 - perPoint.confidence) * resolution;
 
-  return { player1WinChance, confidence };
+  return { player1WinChance, confidence, perPointWinChance: perPoint.fraction };
 }

--- a/frontend/src/pages/live-game/live-game-win-probability.ts
+++ b/frontend/src/pages/live-game/live-game-win-probability.ts
@@ -140,65 +140,89 @@ function derivePerPointWinChance(input: LiveWinPredictionInput): Fraction {
   return combined;
 }
 
-/** Play a single set to completion from (a, b); returns the winning player (1 or 2). */
-function simulateSet(perPoint: number, startA: number, startB: number, random: () => number): 1 | 2 {
-  let a = startA;
-  let b = startB;
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    if (a >= POINTS_TO_WIN_SET && a - b >= 2) return 1;
-    if (b >= POINTS_TO_WIN_SET && b - a >= 2) return 2;
-    if (random() < perPoint) a++;
-    else b++;
-  }
-}
+type SimulationSummary = {
+  /** Fraction of simulations player 1 won. */
+  winRate: number;
+  /** Average number of points still to be played before the match ends. */
+  avgRemainingPoints: number;
+};
 
-/** Simulate the rest of the match once from the current score; returns true if player 1 wins. */
-function simulateMatchOnce(
+/**
+ * Simulate the rest of the match many times from a given score. Returns the win
+ * rate and the average number of points left to play (used as a measure of how
+ * close the match is to finishing).
+ */
+function runSimulations(
   perPoint: number,
   setsWon1: number,
   setsWon2: number,
   currentA: number,
   currentB: number,
+  simulations: number,
   random: () => number,
-): boolean {
-  let s1 = setsWon1;
-  let s2 = setsWon2;
-  let a = currentA;
-  let b = currentB;
-  while (s1 < SETS_TO_WIN_MATCH && s2 < SETS_TO_WIN_MATCH) {
-    if (simulateSet(perPoint, a, b, random) === 1) s1++;
-    else s2++;
-    a = 0;
-    b = 0;
+): SimulationSummary {
+  let wins = 0;
+  let totalRemainingPoints = 0;
+
+  for (let i = 0; i < simulations; i++) {
+    let s1 = setsWon1;
+    let s2 = setsWon2;
+    let a = currentA;
+    let b = currentB;
+    let points = 0;
+
+    while (s1 < SETS_TO_WIN_MATCH && s2 < SETS_TO_WIN_MATCH) {
+      // Play one set to completion, counting the points played.
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        if (a >= POINTS_TO_WIN_SET && a - b >= 2) {
+          s1++;
+          break;
+        }
+        if (b >= POINTS_TO_WIN_SET && b - a >= 2) {
+          s2++;
+          break;
+        }
+        if (random() < perPoint) a++;
+        else b++;
+        points++;
+      }
+      a = 0;
+      b = 0;
+    }
+
+    if (s1 >= SETS_TO_WIN_MATCH) wins++;
+    totalRemainingPoints += points;
   }
-  return s1 >= SETS_TO_WIN_MATCH;
+
+  return { winRate: wins / simulations, avgRemainingPoints: totalRemainingPoints / simulations };
 }
 
 export function computeLiveWinPrediction(input: LiveWinPredictionInput): LiveWinPrediction {
-  const { setsWon, currentSet, preGameWinChance, preGameConfidence } = input;
+  const { setsWon, currentSet } = input;
   const simulations = input.simulations ?? DEFAULT_SIMULATIONS;
   const random = input.random ?? Math.random;
 
   const perPoint = derivePerPointWinChance(input);
 
-  let wins = 0;
-  for (let i = 0; i < simulations; i++) {
-    if (simulateMatchOnce(perPoint.fraction, setsWon.player1, setsWon.player2, currentSet.player1, currentSet.player2, random)) {
-      wins++;
-    }
-  }
-  const player1WinChance = wins / simulations;
+  const current = runSimulations(
+    perPoint.fraction,
+    setsWon.player1,
+    setsWon.player2,
+    currentSet.player1,
+    currentSet.player2,
+    simulations,
+    random,
+  );
+  const player1WinChance = current.winRate;
 
   // Confidence rises from the per-point estimate's data confidence toward 100 %
-  // as the match outcome becomes determined (outcome-variance collapse relative
-  // to the pre-game prediction). At 0–0 with no points this is the pre-game
-  // confidence.
-  const baseMatchChance = preGameConfidence > 0 ? preGameWinChance : 0.5;
-  const baseVariance = Math.max(baseMatchChance * (1 - baseMatchChance), 1e-6);
-  const currentVariance = player1WinChance * (1 - player1WinChance);
-  const resolution = clamp(1 - currentVariance / baseVariance, 0, 1);
-  const confidence = perPoint.confidence + (1 - perPoint.confidence) * resolution;
+  // as the match nears its end — measured by how few points remain to be played
+  // relative to a full match from 0–0 (NOT by how lopsided the win % is, so a
+  // tied deciding set is still high-confidence: we are confident it is close).
+  const fullMatch = runSimulations(perPoint.fraction, 0, 0, 0, 0, simulations, random);
+  const matchProgress = clamp(1 - current.avgRemainingPoints / Math.max(fullMatch.avgRemainingPoints, 1), 0, 1);
+  const confidence = perPoint.confidence + (1 - perPoint.confidence) * matchProgress;
 
   return { player1WinChance, confidence, perPointWinChance: perPoint.fraction };
 }


### PR DESCRIPTION
Show a predicted win chance and confidence card in both the broadcasted
live game view and the local admin tracking view, positioned above the
completed sets list and below the main score/controls card.

For unranked players the card mirrors the player-page predictions tab: when
at least one player is unranked it gates the prediction behind a warning
that must be acknowledged before the prediction is revealed, and keeps a
persistent warning banner once shown.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01K4cfCxNLPxovn2ovKTPsaq