### PR TITLE
Add "first-game" achievement for playing your first game

### DIFF
--- a/frontend/src/client/client-db/__tests__/achievements/first-game.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/first-game.test.ts
@@ -1,0 +1,97 @@
+import { TennisTable } from "../../tennis-table";
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+
+// The "first-game" achievement is awarded on a player's very first game
+// ever — win or lose. It is earnable exactly once per player.
+
+describe("First Game Achievement", () => {
+  const game = (id: string, time: number, winner: string, loser: string): EventType => ({
+    time,
+    stream: id,
+    type: EventTypeEnum.GAME_CREATED,
+    data: { playedAt: time, winner, loser },
+  });
+
+  const players = (): EventType[] => [
+    { time: 1, stream: "alice", type: EventTypeEnum.PLAYER_CREATED, data: { name: "Alice" } },
+    { time: 2, stream: "bob", type: EventTypeEnum.PLAYER_CREATED, data: { name: "Bob" } },
+  ];
+
+  it("awards first-game to both players on their first game", () => {
+    const events: EventType[] = [...players(), game("g1", 100, "alice", "bob")];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const aliceFirst = tt.achievements.getAchievements("alice").filter((a) => a.type === "first-game");
+    expect(aliceFirst).toHaveLength(1);
+    expect(aliceFirst[0].earnedAt).toBe(100);
+    expect(aliceFirst[0].data).toEqual({ gameId: "g1", opponent: "bob" });
+
+    const bobFirst = tt.achievements.getAchievements("bob").filter((a) => a.type === "first-game");
+    expect(bobFirst).toHaveLength(1);
+    expect(bobFirst[0].earnedAt).toBe(100);
+    expect(bobFirst[0].data).toEqual({ gameId: "g1", opponent: "alice" });
+  });
+
+  it("awards first-game on a loss, not just a win", () => {
+    // Bob's first appearance is as the loser of g1.
+    const events: EventType[] = [...players(), game("g1", 100, "alice", "bob")];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("bob").filter((a) => a.type === "first-game")).toHaveLength(1);
+  });
+
+  it("is only awarded once even after many more games", () => {
+    const events: EventType[] = [
+      ...players(),
+      game("g1", 100, "alice", "bob"),
+      game("g2", 200, "alice", "bob"),
+      game("g3", 300, "bob", "alice"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "first-game")).toHaveLength(1);
+    expect(tt.achievements.getAchievements("bob").filter((a) => a.type === "first-game")).toHaveLength(1);
+  });
+
+  it("records the achievement on each player's own first game", () => {
+    // Carol joins later — her first game is g2, not g1.
+    const events: EventType[] = [
+      ...players(),
+      { time: 3, stream: "carol", type: EventTypeEnum.PLAYER_CREATED, data: { name: "Carol" } },
+      game("g1", 100, "alice", "bob"),
+      game("g2", 200, "alice", "carol"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const carolFirst = tt.achievements.getAchievements("carol").filter((a) => a.type === "first-game");
+    expect(carolFirst).toHaveLength(1);
+    expect(carolFirst[0].earnedAt).toBe(200);
+    expect(carolFirst[0].data).toEqual({ gameId: "g2", opponent: "alice" });
+  });
+
+  it("reports zero progress before any game and full progress after", () => {
+    const before = new TennisTable({ events: [...players()] });
+    before.achievements.calculateAchievements();
+    expect(before.achievements.getPlayerProgression("alice")["first-game"]).toEqual({
+      current: 0,
+      target: 1,
+      earned: 0,
+    });
+
+    const after = new TennisTable({ events: [...players(), game("g1", 100, "alice", "bob")] });
+    after.achievements.calculateAchievements();
+    expect(after.achievements.getPlayerProgression("alice")["first-game"]).toEqual({
+      current: 1,
+      target: 1,
+      earned: 1,
+    });
+  });
+});

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -114,10 +114,32 @@ export class Achievements {
       const winner = playerTracker.get(game.winner)!;
       const loser = playerTracker.get(game.loser)!;
 
+      // Check for "First Game" achievement: awarded on a player's very
+      // first game ever, win or lose. Earnable once.
+      winner.gamesPlayed++;
+      if (winner.gamesPlayed === 1) {
+        this.#addAchievement(
+          game.winner,
+          this.#createAchievement("first-game", game.winner, game.playedAt, {
+            gameId: game.id,
+            opponent: game.loser,
+          }),
+        );
+      }
+      loser.gamesPlayed++;
+      if (loser.gamesPlayed === 1) {
+        this.#addAchievement(
+          game.loser,
+          this.#createAchievement("first-game", game.loser, game.playedAt, {
+            gameId: game.id,
+            opponent: game.winner,
+          }),
+        );
+      }
+
       // Check for "Ranked" achievement: awarded on the game that pushes a
       // player up to gameLimitForRanked total games — i.e. the game that
       // makes them appear on the leaderboard. Earnable once.
-      winner.gamesPlayed++;
       if (winner.gamesPlayed === gameLimitForRanked) {
         this.#addAchievement(
           game.winner,
@@ -127,7 +149,6 @@ export class Achievements {
           }),
         );
       }
-      loser.gamesPlayed++;
       if (loser.gamesPlayed === gameLimitForRanked) {
         this.#addAchievement(
           game.loser,
@@ -1482,6 +1503,7 @@ export class Achievements {
     const gameLimitForRanked = this.parent.client.gameLimitForRanked;
 
     const progression: AchievementProgression = {
+      "first-game": { current: 0, target: 1, earned: 0 },
       "ranked": { current: 0, target: gameLimitForRanked, earned: 0 },
       "donut-1": { current: 0, target: 1, earned: 0 },
       "donut-5": { current: 0, target: 5, earned: 0 },
@@ -1670,6 +1692,7 @@ export class Achievements {
     // "Ranked" progress is the games played toward the ranked threshold,
     // capped at the target so it never exceeds 100% once earned — going
     // beyond would leak the player's total games count.
+    progression["first-game"].current = Math.min(gamesPlayedCount, 1);
     progression["ranked"].current = Math.min(gamesPlayedCount, gameLimitForRanked);
     progression["donut-1"].current = donutCount;
     progression["donut-5"].current = donutCount;
@@ -1898,6 +1921,7 @@ export class Achievements {
 
 // Type Definitions
 type AchievementDefinitions = {
+  "first-game": { gameId: string; opponent: string };
   "ranked": { gameId: string; opponent: string };
   "donut-1": { gameId: string; opponent: string };
   "donut-5": undefined;
@@ -2028,6 +2052,7 @@ type MarathonSetProgression = BaseProgression & {
 };
 
 export type AchievementProgression = {
+  "first-game": ProgressionWithTarget;
   "ranked": ProgressionWithTarget;
   "donut-1": ProgressionWithTarget;
   "donut-5": ProgressionWithTarget;

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -11,6 +11,11 @@ type Props = {
 };
 
 export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: string; icon: string }> = {
+  "first-game": {
+    title: "Welcome to the Table",
+    description: "Play your first game",
+    icon: "🐣",
+  },
   "ranked": {
     title: "Ranked",
     // The number of games is client-specific (gameLimitForRanked); the

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -12,9 +12,9 @@ type Props = {
 
 export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: string; icon: string }> = {
   "first-game": {
-    title: "Welcome to the Table",
+    title: "First Game",
     description: "Play your first game",
-    icon: "🐣",
+    icon: "👶",
   },
   "ranked": {
     title: "Ranked",


### PR DESCRIPTION
Awards a "Welcome to the Table" achievement to a player on their very
first game ever, win or lose. Earnable once per player.

- Award logic in the achievements game loop, alongside the existing
  "ranked" check (first game = gamesPlayed reaches 1)
- Type definition, progression entry (target 1), and display label
- Tests covering wins, losses, idempotency, per-player first games,
  and progression

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FHQL24inkUWtDJQotmdmP6