### PR TITLE
Fix seasons including grace period games from before season start

### DIFF
--- a/frontend/src/client/client-db/__tests__/seasons/determine-season.ts
+++ b/frontend/src/client/client-db/__tests__/seasons/determine-season.ts
@@ -2,39 +2,39 @@ import { determineSeason } from "../../seasons/seasons";
 
 describe("determineSeason", () => {
   describe("Season start times", () => {
-    it("should start Q1 season on first Monday of January at 10:00", () => {
+    it("should start Q1 season on first Monday of January at 08:00", () => {
       // January 1, 2024 is a Monday
       const time = new Date(2024, 0, 15).getTime(); // Mid-January
       const result = determineSeason(time);
 
-      const expectedStart = new Date(2024, 0, 1, 10, 0, 0, 0).getTime();
+      const expectedStart = new Date(2024, 0, 1, 8, 0, 0, 0).getTime();
       expect(result.start).toBe(expectedStart);
     });
 
-    it("should start Q2 season on first Monday of April at 10:00", () => {
+    it("should start Q2 season on first Monday of April at 08:00", () => {
       // April 1, 2024 is a Monday
       const time = new Date(2024, 3, 15).getTime(); // Mid-April
       const result = determineSeason(time);
 
-      const expectedStart = new Date(2024, 3, 1, 10, 0, 0, 0).getTime();
+      const expectedStart = new Date(2024, 3, 1, 8, 0, 0, 0).getTime();
       expect(result.start).toBe(expectedStart);
     });
 
-    it("should start Q3 season on first Monday of July at 10:00", () => {
+    it("should start Q3 season on first Monday of July at 08:00", () => {
       // July 1, 2024 is a Monday
       const time = new Date(2024, 6, 15).getTime(); // Mid-July
       const result = determineSeason(time);
 
-      const expectedStart = new Date(2024, 6, 1, 10, 0, 0, 0).getTime();
+      const expectedStart = new Date(2024, 6, 1, 8, 0, 0, 0).getTime();
       expect(result.start).toBe(expectedStart);
     });
 
-    it("should start Q4 season on first Monday of October at 10:00", () => {
+    it("should start Q4 season on first Monday of October at 08:00", () => {
       // October 7, 2024 is the first Monday (Oct 1 is Tuesday)
       const time = new Date(2024, 9, 15).getTime(); // Mid-October
       const result = determineSeason(time);
 
-      const expectedStart = new Date(2024, 9, 7, 10, 0, 0, 0).getTime();
+      const expectedStart = new Date(2024, 9, 7, 8, 0, 0, 0).getTime();
       expect(result.start).toBe(expectedStart);
     });
 
@@ -43,7 +43,7 @@ describe("determineSeason", () => {
       const time = new Date(2024, 8, 15).getTime(); // Mid-September (Q3)
       const result = determineSeason(time);
 
-      const expectedStart = new Date(2024, 6, 1, 10, 0, 0, 0).getTime(); // July 1 is Monday
+      const expectedStart = new Date(2024, 6, 1, 8, 0, 0, 0).getTime(); // July 1 is Monday
       expect(result.start).toBe(expectedStart);
     });
 
@@ -52,7 +52,7 @@ describe("determineSeason", () => {
       const time = new Date(2024, 9, 15).getTime();
       const result = determineSeason(time);
 
-      const expectedStart = new Date(2024, 9, 7, 10, 0, 0, 0).getTime();
+      const expectedStart = new Date(2024, 9, 7, 8, 0, 0, 0).getTime();
       expect(result.start).toBe(expectedStart);
     });
   });
@@ -62,10 +62,10 @@ describe("determineSeason", () => {
       const time = new Date(2024, 0, 15).getTime(); // Mid-January (Q1)
       const result = determineSeason(time);
 
-      // Q2 starts April 1 (Monday) at 10:00
+      // Q2 starts April 1 (Monday) at 08:00
       // 10 days before = March 22
       // Find the Friday before that at 17:00
-      const q2Start = new Date(2024, 3, 1, 10, 0, 0, 0).getTime();
+      const q2Start = new Date(2024, 3, 1, 8, 0, 0, 0).getTime();
       const tenDaysBefore = q2Start - 10 * 24 * 60 * 60 * 1000;
       const expectedEnd = new Date(tenDaysBefore);
       expectedEnd.setHours(17, 0, 0, 0);
@@ -137,7 +137,7 @@ describe("determineSeason", () => {
 
   describe("10-day gap period", () => {
     it("should return the just-ended season when time is in the 10-day gap", () => {
-      // Q2 2024 starts April 1 at 10:00
+      // Q2 2024 starts April 1 at 08:00
       // Q1 ends 10 days before (March 22) at 17:00
       // March 23-31 is the gap period and should return Q1 season
       const timeInGap = new Date(2024, 2, 25, 12, 0, 0, 0).getTime(); // March 25
@@ -157,7 +157,7 @@ describe("determineSeason", () => {
     });
 
     it("should return the just-ended season when the gap extends into the new quarter's first month", () => {
-      // Q4 2024 starts Monday October 7 at 10:00 (October 1 is a Tuesday)
+      // Q4 2024 starts Monday October 7 at 08:00 (October 1 is a Tuesday)
       // Q3 2024 ends Friday September 27 at 17:00
       // October 1-6 is still gap period and should return the Q3 season
       const timeInGap = new Date(2024, 9, 2, 12, 0, 0, 0).getTime(); // October 2
@@ -169,7 +169,7 @@ describe("determineSeason", () => {
     });
 
     it("should return the previous year's Q4 season when the gap extends into January", () => {
-      // Q1 2027 starts Monday January 4 2027 at 10:00 (January 1 2027 is a Friday)
+      // Q1 2027 starts Monday January 4 2027 at 08:00 (January 1 2027 is a Friday)
       // Q4 2026 ends Friday December 25 2026 at 17:00
       const timeInGap = new Date(2027, 0, 2, 12, 0, 0, 0).getTime(); // January 2 2027
       const result = determineSeason(timeInGap);
@@ -182,7 +182,7 @@ describe("determineSeason", () => {
 
   describe("Edge cases", () => {
     it("should handle exact season start time", () => {
-      const seasonStartTime = new Date(2024, 0, 1, 10, 0, 0, 0).getTime();
+      const seasonStartTime = new Date(2024, 0, 1, 8, 0, 0, 0).getTime();
       const result = determineSeason(seasonStartTime);
 
       expect(result.start).toBe(seasonStartTime);

--- a/frontend/src/client/client-db/__tests__/seasons/determine-season.ts
+++ b/frontend/src/client/client-db/__tests__/seasons/determine-season.ts
@@ -155,6 +155,29 @@ describe("determineSeason", () => {
       const startDate = new Date(result.start);
       expect(startDate.getMonth()).toBe(0); // Should return Q1
     });
+
+    it("should return the just-ended season when the gap extends into the new quarter's first month", () => {
+      // Q4 2024 starts Monday October 7 at 10:00 (October 1 is a Tuesday)
+      // Q3 2024 ends Friday September 27 at 17:00
+      // October 1-6 is still gap period and should return the Q3 season
+      const timeInGap = new Date(2024, 9, 2, 12, 0, 0, 0).getTime(); // October 2
+      const result = determineSeason(timeInGap);
+
+      const startDate = new Date(result.start);
+      expect(startDate.getMonth()).toBe(6); // Should return Q3 (July start)
+      expect(result.end).toBeLessThan(timeInGap); // The returned season has already ended
+    });
+
+    it("should return the previous year's Q4 season when the gap extends into January", () => {
+      // Q1 2027 starts Monday January 4 2027 at 10:00 (January 1 2027 is a Friday)
+      // Q4 2026 ends Friday December 25 2026 at 17:00
+      const timeInGap = new Date(2027, 0, 2, 12, 0, 0, 0).getTime(); // January 2 2027
+      const result = determineSeason(timeInGap);
+
+      const startDate = new Date(result.start);
+      expect(startDate.getFullYear()).toBe(2026);
+      expect(startDate.getMonth()).toBe(9); // Should return Q4 (October start)
+    });
   });
 
   describe("Edge cases", () => {

--- a/frontend/src/client/client-db/__tests__/seasons/season.test.ts
+++ b/frontend/src/client/client-db/__tests__/seasons/season.test.ts
@@ -2,6 +2,10 @@ import { TennisTable } from "../../tennis-table";
 import { EventType, EventTypeEnum } from "../../event-store/event-types";
 import { Season } from "../../seasons/season";
 
+// Q1 2024 season: starts Monday January 1 2024 at 10:00, ends Friday March 22 2024 at 17:00.
+// Game times are small offsets from mid-season so they always fall within a single season.
+const SEASON = new Date(2024, 0, 15, 12, 0, 0, 0).getTime();
+
 describe("Season Class Tests", () => {
   let tennisTable: TennisTable;
   let baseEvents: EventType[];
@@ -53,7 +57,7 @@ describe("Season Class Tests", () => {
           stream: "game-1",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 4000,
+            playedAt: SEASON + 4000,
             winner: "player-1",
             loser: "player-2",
           },
@@ -77,7 +81,7 @@ describe("Season Class Tests", () => {
           stream: "game-1",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 4000, // Within first season
+            playedAt: SEASON + 4000, // Within first season
             winner: "player-1",
             loser: "player-2",
           },
@@ -87,7 +91,7 @@ describe("Season Class Tests", () => {
           stream: "game-2",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 10000, // In a different season
+            playedAt: new Date(2024, 4, 15, 12, 0, 0, 0).getTime(), // In a different season (Q2 2024)
             winner: "player-2",
             loser: "player-3",
           },
@@ -106,6 +110,46 @@ describe("Season Class Tests", () => {
         expect(season.games.length).toBeGreaterThan(0);
       });
     });
+
+    it("should not include grace period games in any season", () => {
+      // Q3 2024 ends Friday September 27 at 17:00, Q4 2024 starts Monday October 7 at 10:00.
+      // The days in between are the grace period and count towards no season.
+      const inQ3 = new Date(2024, 8, 20, 12, 0, 0, 0).getTime(); // September 20
+      const inGraceSameMonth = new Date(2024, 8, 28, 12, 0, 0, 0).getTime(); // September 28
+      const inGraceNextMonth = new Date(2024, 9, 2, 12, 0, 0, 0).getTime(); // October 2, before Q4 starts
+      const inQ4 = new Date(2024, 9, 10, 12, 0, 0, 0).getTime(); // October 10
+
+      const events: EventType[] = [
+        ...baseEvents,
+        ...[inQ3, inGraceSameMonth, inGraceNextMonth, inQ4].map((playedAt, index) => ({
+          time: playedAt,
+          stream: `game-${index + 1}`,
+          type: EventTypeEnum.GAME_CREATED as const,
+          data: {
+            playedAt,
+            winner: "player-1",
+            loser: "player-2",
+          },
+        })),
+      ];
+
+      tennisTable = new TennisTable({ events });
+      const seasons = tennisTable.seasons.getSeasons();
+
+      expect(seasons).toHaveLength(2);
+      expect(seasons[0].games).toHaveLength(1);
+      expect(seasons[0].games[0].playedAt).toBe(inQ3);
+      expect(seasons[1].games).toHaveLength(1);
+      expect(seasons[1].games[0].playedAt).toBe(inQ4);
+
+      // Every included game must be within its season's start and end
+      seasons.forEach((season) => {
+        season.games.forEach((game) => {
+          expect(game.playedAt).toBeGreaterThanOrEqual(season.start);
+          expect(game.playedAt).toBeLessThan(season.end);
+        });
+      });
+    });
   });
 
   describe("Leaderboard Calculation", () => {
@@ -117,7 +161,7 @@ describe("Season Class Tests", () => {
           stream: "game-1",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 4000,
+            playedAt: SEASON + 4000,
             winner: "player-1",
             loser: "player-2",
           },
@@ -142,7 +186,7 @@ describe("Season Class Tests", () => {
           stream: "game-1",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 4000,
+            playedAt: SEASON + 4000,
             winner: "player-1",
             loser: "player-2",
           },
@@ -152,7 +196,7 @@ describe("Season Class Tests", () => {
           stream: "game-2",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 5000,
+            playedAt: SEASON + 5000,
             winner: "player-1",
             loser: "player-3",
           },
@@ -162,7 +206,7 @@ describe("Season Class Tests", () => {
           stream: "game-3",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 6000,
+            playedAt: SEASON + 6000,
             winner: "player-2",
             loser: "player-3",
           },
@@ -187,7 +231,7 @@ describe("Season Class Tests", () => {
           stream: "game-1",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 4000,
+            playedAt: SEASON + 4000,
             winner: "player-1",
             loser: "player-2",
           },
@@ -212,7 +256,7 @@ describe("Season Class Tests", () => {
           stream: "game-1",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 4000,
+            playedAt: SEASON + 4000,
             winner: "player-1",
             loser: "player-2",
           },
@@ -222,7 +266,7 @@ describe("Season Class Tests", () => {
           stream: "game-2",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 5000,
+            playedAt: SEASON + 5000,
             winner: "player-2",
             loser: "player-1",
           },
@@ -254,7 +298,7 @@ describe("Season Class Tests", () => {
           stream: "game-1",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 5000,
+            playedAt: SEASON + 5000,
             winner: "player-1",
             loser: "player-2",
           },
@@ -265,7 +309,7 @@ describe("Season Class Tests", () => {
           stream: "game-2",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 6000,
+            playedAt: SEASON + 6000,
             winner: "player-3",
             loser: "player-2",
           },
@@ -275,7 +319,7 @@ describe("Season Class Tests", () => {
           stream: "game-3",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 7000,
+            playedAt: SEASON + 7000,
             winner: "player-3",
             loser: "player-4",
           },
@@ -303,7 +347,7 @@ describe("Season Class Tests", () => {
           stream: "game-1",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 4000,
+            playedAt: SEASON + 4000,
             winner: "player-1",
             loser: "player-2",
           },
@@ -314,7 +358,7 @@ describe("Season Class Tests", () => {
           stream: "game-2",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 3000, // Earlier than player-1
+            playedAt: SEASON + 3000, // Earlier than player-1
             winner: "player-3",
             loser: "player-4",
           },
@@ -348,7 +392,7 @@ describe("Season Class Tests", () => {
           stream: "game-1",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 4000,
+            playedAt: SEASON + 4000,
             winner: "player-1",
             loser: "player-2",
           },
@@ -373,7 +417,7 @@ describe("Season Class Tests", () => {
           stream: "game-1",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 4000,
+            playedAt: SEASON + 4000,
             winner: "player-1",
             loser: "player-2",
           },
@@ -412,7 +456,7 @@ describe("Season Class Tests", () => {
           stream: "game-1",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 4000,
+            playedAt: SEASON + 4000,
             winner: "player-1",
             loser: "player-2",
           },
@@ -436,7 +480,7 @@ describe("Season Class Tests", () => {
           stream: "game-2",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 5000,
+            playedAt: SEASON + 5000,
             winner: "player-1",
             loser: "player-2",
           },
@@ -476,7 +520,7 @@ describe("Season Class Tests", () => {
           stream: "game-1",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 4000,
+            playedAt: SEASON + 4000,
             winner: "player-1",
             loser: "player-2",
           },
@@ -501,7 +545,7 @@ describe("Season Class Tests", () => {
           stream: "game-1",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 4000,
+            playedAt: SEASON + 4000,
             winner: "player-1",
             loser: "player-2",
           },
@@ -511,7 +555,7 @@ describe("Season Class Tests", () => {
           stream: "game-2",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 5000,
+            playedAt: SEASON + 5000,
             winner: "player-1",
             loser: "player-3",
           },
@@ -542,7 +586,7 @@ describe("Season Class Tests", () => {
           stream: "game-1",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 4000,
+            playedAt: SEASON + 4000,
             winner: "player-1",
             loser: "player-2",
           },
@@ -567,7 +611,7 @@ describe("Season Class Tests", () => {
           stream: "game-2",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 5000,
+            playedAt: SEASON + 5000,
             winner: "player-2",
             loser: "player-3",
           },
@@ -577,7 +621,7 @@ describe("Season Class Tests", () => {
           stream: "game-1",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 4000,
+            playedAt: SEASON + 4000,
             winner: "player-1",
             loser: "player-2",
           },
@@ -615,7 +659,7 @@ describe("Season Class Tests", () => {
           stream: "game-1",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 4000,
+            playedAt: SEASON + 4000,
             winner: "player-1",
             loser: "player-2",
           },
@@ -625,7 +669,7 @@ describe("Season Class Tests", () => {
           stream: "game-2",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 5000,
+            playedAt: SEASON + 5000,
             winner: "player-1",
             loser: "player-2",
           },
@@ -635,7 +679,7 @@ describe("Season Class Tests", () => {
           stream: "game-3",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 6000,
+            playedAt: SEASON + 6000,
             winner: "player-2",
             loser: "player-1",
           },
@@ -660,7 +704,7 @@ describe("Season Class Tests", () => {
           stream: "game-1",
           type: EventTypeEnum.GAME_CREATED,
           data: {
-            playedAt: 4000,
+            playedAt: SEASON + 4000,
             winner: "player-1",
             loser: "player-2",
           },
@@ -679,13 +723,13 @@ describe("Season Class Tests", () => {
     });
 
     it("should invalidate cache when adding new game", () => {
-      const season = new Season({ start: 1000, end: 10000 });
+      const season = new Season({ start: SEASON, end: SEASON + 10000 });
       const leaderboard1 = season.getLeaderboard();
 
       // Add a game
       season.addGame({
         id: "game-1",
-        playedAt: 5000,
+        playedAt: SEASON + 5000,
         winner: "player-1",
         loser: "player-2",
         score: undefined,

--- a/frontend/src/client/client-db/__tests__/seasons/season.test.ts
+++ b/frontend/src/client/client-db/__tests__/seasons/season.test.ts
@@ -2,7 +2,7 @@ import { TennisTable } from "../../tennis-table";
 import { EventType, EventTypeEnum } from "../../event-store/event-types";
 import { Season } from "../../seasons/season";
 
-// Q1 2024 season: starts Monday January 1 2024 at 10:00, ends Friday March 22 2024 at 17:00.
+// Q1 2024 season: starts Monday January 1 2024 at 08:00, ends Friday March 22 2024 at 17:00.
 // Game times are small offsets from mid-season so they always fall within a single season.
 const SEASON = new Date(2024, 0, 15, 12, 0, 0, 0).getTime();
 
@@ -112,7 +112,7 @@ describe("Season Class Tests", () => {
     });
 
     it("should not include grace period games in any season", () => {
-      // Q3 2024 ends Friday September 27 at 17:00, Q4 2024 starts Monday October 7 at 10:00.
+      // Q3 2024 ends Friday September 27 at 17:00, Q4 2024 starts Monday October 7 at 08:00.
       // The days in between are the grace period and count towards no season.
       const inQ3 = new Date(2024, 8, 20, 12, 0, 0, 0).getTime(); // September 20
       const inGraceSameMonth = new Date(2024, 8, 28, 12, 0, 0, 0).getTime(); // September 28

--- a/frontend/src/client/client-db/seasons/season.ts
+++ b/frontend/src/client/client-db/seasons/season.ts
@@ -23,6 +23,10 @@ export class Season {
   }
 
   addGame(game: Game) {
+    // A season only includes games within its own start and end
+    if (game.playedAt < this.start || game.playedAt >= this.end) {
+      return;
+    }
     this.games.push(game);
     this.leaderboard = undefined; // Invalidate cache
   }

--- a/frontend/src/client/client-db/seasons/seasons.ts
+++ b/frontend/src/client/client-db/seasons/seasons.ts
@@ -19,18 +19,19 @@ export class Seasons {
     let currentSeason: Season | undefined = undefined;
 
     for (const game of this.parent.games) {
-      // Initialise first season
-      if (!currentSeason) {
-        currentSeason = new Season(determineSeason(game.playedAt));
+      const gameSeason = determineSeason(game.playedAt);
+
+      // Only games within the season's start and end count.
+      // Games in the grace period between seasons do not count towards any season.
+      if (game.playedAt < gameSeason.start || game.playedAt >= gameSeason.end) {
+        continue;
       }
+
       // Start next season
-      if (game.playedAt >= currentSeason.end) {
-        const gameSeason = determineSeason(game.playedAt);
-        if (gameSeason.start === currentSeason.start) {
-          // Game is after end but before next. Does not count towards any season
-          continue;
+      if (!currentSeason || gameSeason.start !== currentSeason.start) {
+        if (currentSeason) {
+          seasons.push(currentSeason);
         }
-        seasons.push(currentSeason);
         currentSeason = new Season(gameSeason);
       }
 
@@ -65,19 +66,20 @@ export function determineSeason(time: number): { start: number; end: number } {
   // Round down to nearest quarter start month (0, 3, 6, 9)
   const seasonStartMonth = Math.floor(month / 3) * 3;
 
-  // Find the first Monday of the season start month
-  const firstOfMonth = new Date(year, seasonStartMonth, 1);
-  const dayOfWeek = firstOfMonth.getDay(); // 0 = Sunday, 1 = Monday, etc.
+  const season = seasonOfQuarter(year, seasonStartMonth);
+  if (time >= season.start) {
+    return season;
+  }
 
-  // Calculate days until next Monday (if not already Monday)
-  const daysUntilMonday = dayOfWeek === 0 ? 1 : dayOfWeek === 1 ? 0 : 8 - dayOfWeek;
-  const seasonStart = new Date(year, seasonStartMonth, 1 + daysUntilMonday, 10, 0, 0, 0).getTime();
+  // Time is before this quarter's season starts, i.e. in the part of the grace
+  // period that spills into the new quarter's first month. It belongs to the
+  // season that just ended.
+  return seasonOfQuarter(year, seasonStartMonth - 3);
+}
 
-  // Find the first Monday of the next season
-  const nextSeasonFirstOfMonth = new Date(year, seasonStartMonth + 3, 1);
-  const nextDayOfWeek = nextSeasonFirstOfMonth.getDay();
-  const nextDaysUntilMonday = nextDayOfWeek === 0 ? 1 : nextDayOfWeek === 1 ? 0 : 8 - nextDayOfWeek;
-  const nextSeasonStart = new Date(year, seasonStartMonth + 3, 1 + nextDaysUntilMonday, 10, 0, 0, 0).getTime();
+function seasonOfQuarter(year: number, seasonStartMonth: number): { start: number; end: number } {
+  const seasonStart = firstMondayAt10(year, seasonStartMonth);
+  const nextSeasonStart = firstMondayAt10(year, seasonStartMonth + 3);
 
   // Season ends on Friday, 10 days before next season starts, at 17:00
   const seasonEnd = nextSeasonStart - 10 * 24 * 60 * 60 * 1000;
@@ -85,4 +87,13 @@ export function determineSeason(time: number): { start: number; end: number } {
   seasonEndDate.setHours(17, 0, 0, 0);
 
   return { start: seasonStart, end: seasonEndDate.getTime() };
+}
+
+function firstMondayAt10(year: number, month: number): number {
+  const firstOfMonth = new Date(year, month, 1);
+  const dayOfWeek = firstOfMonth.getDay(); // 0 = Sunday, 1 = Monday, etc.
+
+  // Calculate days until next Monday (if not already Monday)
+  const daysUntilMonday = dayOfWeek === 0 ? 1 : dayOfWeek === 1 ? 0 : 8 - dayOfWeek;
+  return new Date(year, month, 1 + daysUntilMonday, 10, 0, 0, 0).getTime();
 }

--- a/frontend/src/client/client-db/seasons/seasons.ts
+++ b/frontend/src/client/client-db/seasons/seasons.ts
@@ -52,7 +52,7 @@ export class Seasons {
 }
 
 /** Returns start and end time of the season that the provided time stamp belongs to
- * Seasons start on first Monday of the month at 10:00.
+ * Seasons start on first Monday of the month at 08:00.
  * Seasons end on the Friday at 17:00, 10 days before the next season starts.
  * A provided time within the 10 day period will return the season that just ended.
  */
@@ -78,8 +78,8 @@ export function determineSeason(time: number): { start: number; end: number } {
 }
 
 function seasonOfQuarter(year: number, seasonStartMonth: number): { start: number; end: number } {
-  const seasonStart = firstMondayAt10(year, seasonStartMonth);
-  const nextSeasonStart = firstMondayAt10(year, seasonStartMonth + 3);
+  const seasonStart = firstMondayAt8(year, seasonStartMonth);
+  const nextSeasonStart = firstMondayAt8(year, seasonStartMonth + 3);
 
   // Season ends on Friday, 10 days before next season starts, at 17:00
   const seasonEnd = nextSeasonStart - 10 * 24 * 60 * 60 * 1000;
@@ -89,11 +89,11 @@ function seasonOfQuarter(year: number, seasonStartMonth: number): { start: numbe
   return { start: seasonStart, end: seasonEndDate.getTime() };
 }
 
-function firstMondayAt10(year: number, month: number): number {
+function firstMondayAt8(year: number, month: number): number {
   const firstOfMonth = new Date(year, month, 1);
   const dayOfWeek = firstOfMonth.getDay(); // 0 = Sunday, 1 = Monday, etc.
 
   // Calculate days until next Monday (if not already Monday)
   const daysUntilMonday = dayOfWeek === 0 ? 1 : dayOfWeek === 1 ? 0 : 8 - dayOfWeek;
-  return new Date(year, month, 1 + daysUntilMonday, 10, 0, 0, 0).getTime();
+  return new Date(year, month, 1 + daysUntilMonday, 8, 0, 0, 0).getTime();
 }


### PR DESCRIPTION
Seasons start on the first Monday of the quarter month, so part of the
~10 day grace period can spill into that month (e.g. Oct 1-6 2024 when
Q4 starts Oct 7). determineSeason placed those days in the new quarter's
season, and getSeasons() then added those games to the new season even
though they were played before its start.

- determineSeason now returns the just-ended season for times before the
  new quarter's season start, as its doc already stated
- getSeasons() now explicitly skips any game outside its season's
  start/end limits
- Season.addGame() ignores games outside the season's time frame
- Test timestamps moved into a real season window (the old epoch-based
  timestamps fell before the first Monday of January 1970) and added
  regression tests for grace period games

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S7AjYCgtNmd289N5NVdcNh