### PR TITLE
Show next season info card on leaderboard podium during off-season

### DIFF
--- a/frontend/src/client/client-db/__tests__/seasons/determine-season.ts
+++ b/frontend/src/client/client-db/__tests__/seasons/determine-season.ts
@@ -1,4 +1,4 @@
-import { determineSeason } from "../../seasons/seasons";
+import { determineNextSeason, determineSeason } from "../../seasons/seasons";
 
 describe("determineSeason", () => {
   describe("Season start times", () => {
@@ -238,6 +238,46 @@ describe("determineSeason", () => {
       // Allowing some variance due to month length differences
       expect(durationDays).toBeGreaterThan(70);
       expect(durationDays).toBeLessThan(90);
+    });
+  });
+
+  describe("determineNextSeason", () => {
+    it("should return the next quarter's season when time is within an active season", () => {
+      const time = new Date(2024, 0, 15).getTime(); // Mid-January (Q1)
+      const result = determineNextSeason(time);
+
+      const expectedStart = new Date(2024, 3, 1, 8, 0, 0, 0).getTime(); // April 1, 2024 is a Monday
+      expect(result.start).toBe(expectedStart);
+    });
+
+    it("should return the upcoming season when time is in the 10-day gap", () => {
+      // Q1 2024 ends March 22 at 17:00, Q2 starts April 1 at 08:00
+      const timeInGap = new Date(2024, 2, 25, 12, 0, 0, 0).getTime(); // March 25
+      const result = determineNextSeason(timeInGap);
+
+      const expectedStart = new Date(2024, 3, 1, 8, 0, 0, 0).getTime();
+      expect(result.start).toBe(expectedStart);
+      expect(result.start).toBeGreaterThan(timeInGap);
+    });
+
+    it("should return next year's Q1 season when time is in Q4", () => {
+      const time = new Date(2024, 11, 15).getTime(); // December (Q4)
+      const result = determineNextSeason(time);
+
+      const startDate = new Date(result.start);
+      expect(startDate.getFullYear()).toBe(2025);
+      expect(startDate.getMonth()).toBe(0); // January
+    });
+
+    it("should return a season directly following the current one", () => {
+      const time = new Date(2025, 4, 10).getTime(); // Mid-Q2 2025
+      const current = determineSeason(time);
+      const next = determineNextSeason(time);
+
+      // Next season starts 10 days after the current one ends (grace period)
+      const gapDays = (next.start - current.end) / (24 * 60 * 60 * 1000);
+      expect(gapDays).toBeGreaterThan(9);
+      expect(gapDays).toBeLessThan(11);
     });
   });
 

--- a/frontend/src/client/client-db/seasons/seasons.ts
+++ b/frontend/src/client/client-db/seasons/seasons.ts
@@ -77,6 +77,14 @@ export function determineSeason(time: number): { start: number; end: number } {
   return seasonOfQuarter(year, seasonStartMonth - 3);
 }
 
+/** Returns start and end time of the season following the one the provided time stamp belongs to */
+export function determineNextSeason(time: number): { start: number; end: number } {
+  const season = determineSeason(time);
+  // The next season starts 10 days after the current one ends,
+  // so a time 11 days past the end is always within the next season.
+  return determineSeason(season.end + 11 * 24 * 60 * 60 * 1000);
+}
+
 function seasonOfQuarter(year: number, seasonStartMonth: number): { start: number; end: number } {
   const seasonStart = firstMondayAt8(year, seasonStartMonth);
   const nextSeasonStart = firstMondayAt8(year, seasonStartMonth + 3);

--- a/frontend/src/pages/leaderboard/leader-board.tsx
+++ b/frontend/src/pages/leaderboard/leader-board.tsx
@@ -16,6 +16,8 @@ import { classNames } from "../../common/class-names";
 import { useLocalStorage } from "../../hooks/use-local-storage";
 import { useLiveGameQuery } from "../live-game/use-live-game";
 import { LiveGameCard } from "./live-game-card";
+import { determineNextSeason, determineSeason } from "../../client/client-db/seasons/seasons";
+import { RelativeTime } from "../../common/date-utils";
 
 type LeaderboardView = "overall" | "season";
 
@@ -78,6 +80,12 @@ export const LeaderBoard: React.FC = () => {
   const currentSeason = seasons.find((s) => Date.now() >= s.start && Date.now() <= s.end);
   const seasonLeaderboard = currentSeason?.getLeaderboard() || [];
 
+  // Off-season: we are in the grace period between two seasons
+  const isOffSeason = Date.now() > determineSeason(Date.now()).end;
+  const nextSeason = determineNextSeason(Date.now());
+  const lastSeason = isOffSeason ? [...seasons].reverse().find((s) => s.end < Date.now()) : undefined;
+  const lastSeasonTop3 = lastSeason?.getLeaderboard().slice(0, 3) ?? [];
+
   // Get players who haven't participated in current season
   const seasonParticipantIds = new Set(seasonLeaderboard.map((p) => p.playerId));
   const playersNotInSeason = context.players
@@ -127,47 +135,88 @@ export const LeaderBoard: React.FC = () => {
             view={view}
             setView={setView}
           />
-          {nr1 && (
-            <PodiumPlace
-              size="default"
-              place={1}
-              playerSummary={nr1}
-              profilePicture
-              score={nr1Score}
-              to={
-                view === "season" && currentSeason
-                  ? `/player/${nr1.id}?tab=season`
-                  : undefined
-              }
-            />
-          )}
-          {nr2 && (
-            <PodiumPlace
-              size="sm"
-              place={2}
-              playerSummary={nr2}
-              profilePicture
-              score={nr2Score}
-              to={
-                view === "season" && currentSeason
-                  ? `/player/${nr2.id}?tab=season`
-                  : undefined
-              }
-            />
-          )}
-          {nr3 && (
-            <PodiumPlace
-              size="xs"
-              place={3}
-              playerSummary={nr3}
-              profilePicture
-              score={nr3Score}
-              to={
-                view === "season" && currentSeason
-                  ? `/player/${nr3.id}?tab=season`
-                  : undefined
-              }
-            />
+          {view === "season" && isOffSeason ? (
+            <>
+              <div className="w-full p-4 rounded-lg bg-secondary-background text-secondary-text text-center space-y-1">
+                <p className="text-lg font-medium">
+                  Next season starts <RelativeTime date={new Date(nextSeason.start)} />
+                </p>
+                <p className="text-sm opacity-80">
+                  {new Date(nextSeason.start).toLocaleString("nb-NO", {
+                    weekday: "long",
+                    day: "numeric",
+                    month: "long",
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                </p>
+              </div>
+              {lastSeason && lastSeasonTop3.length > 0 && (
+                <>
+                  <h2 className="text-lg text-center text-primary-text pt-2">Top 3 last season</h2>
+                  {lastSeasonTop3.map((player, index) => {
+                    const playerSummary = context.leaderboard.getPlayerSummary(player.playerId);
+                    if (!playerSummary) return null;
+                    return (
+                      <PodiumPlace
+                        key={player.playerId}
+                        size={(["default", "sm", "xs"] as const)[index]}
+                        place={index + 1}
+                        playerSummary={playerSummary}
+                        profilePicture
+                        score={player.seasonScore}
+                        to={`/season/player?seasonStart=${lastSeason.start}&playerId=${player.playerId}`}
+                      />
+                    );
+                  })}
+                </>
+              )}
+            </>
+          ) : (
+            <>
+              {nr1 && (
+                <PodiumPlace
+                  size="default"
+                  place={1}
+                  playerSummary={nr1}
+                  profilePicture
+                  score={nr1Score}
+                  to={
+                    view === "season" && currentSeason
+                      ? `/player/${nr1.id}?tab=season`
+                      : undefined
+                  }
+                />
+              )}
+              {nr2 && (
+                <PodiumPlace
+                  size="sm"
+                  place={2}
+                  playerSummary={nr2}
+                  profilePicture
+                  score={nr2Score}
+                  to={
+                    view === "season" && currentSeason
+                      ? `/player/${nr2.id}?tab=season`
+                      : undefined
+                  }
+                />
+              )}
+              {nr3 && (
+                <PodiumPlace
+                  size="xs"
+                  place={3}
+                  playerSummary={nr3}
+                  profilePicture
+                  score={nr3Score}
+                  to={
+                    view === "season" && currentSeason
+                      ? `/player/${nr3.id}?tab=season`
+                      : undefined
+                  }
+                />
+              )}
+            </>
           )}
         </div>
         <RecentGames view={view} />


### PR DESCRIPTION
When the season view is selected and no season is active (the grace
period between seasons), the podium area now shows a card with when
the next season starts (relative + absolute time) and the top 3 from
the last season, linking to their season player pages.

Adds determineNextSeason() to the seasons module with tests.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Mn7DnBhUsygnC5kp9Cu2em