### PR TITLE
Add weighted Hall of Fame scoring for achievements

### DIFF
--- a/frontend/src/client/client-db/__tests__/hall-of-fame/achievement-scoring.test.ts
+++ b/frontend/src/client/client-db/__tests__/hall-of-fame/achievement-scoring.test.ts
@@ -72,18 +72,20 @@ describe("Weighted achievement scoring", () => {
     const events: EventType[] = [...players()];
     let t = 100;
     // 10 straight wins for Alice, each a donut set (bob scores 0), which
-    // also crosses the ranked threshold and the 10-game win streak.
+    // also crosses the ranked threshold and the 10-game win streak. The
+    // score is recorded via a separate GAME_SCORE event per game.
     for (let i = 0; i < 10; i++) {
       events.push({
         time: t,
         stream: `g${i}`,
         type: EventTypeEnum.GAME_CREATED,
-        data: {
-          playedAt: t,
-          winner: "alice",
-          loser: "bob",
-          score: { setsWon: { gameWinner: 1, gameLoser: 0 }, setPoints: [{ gameWinner: 11, gameLoser: 0 }] },
-        },
+        data: { playedAt: t, winner: "alice", loser: "bob" },
+      });
+      events.push({
+        time: t + 1,
+        stream: `g${i}`,
+        type: EventTypeEnum.GAME_SCORE,
+        data: { setsWon: { gameWinner: 1, gameLoser: 0 }, setPoints: [{ gameWinner: 11, gameLoser: 0 }] },
       });
       t += 1000;
     }
@@ -108,8 +110,10 @@ describe("Weighted achievement scoring", () => {
       expect(tier.count).toBe(expectedCount);
     }
 
-    // Alice earned at least one rare (30-pt) achievement (streak-all-10).
-    expect(earned.some((a) => a.type === "streak-all-10")).toBe(true);
+    // Alice earned at least one rare (30-pt) achievement: donut-5, from
+    // reaching 5 donut sets across the 10 donut wins.
+    expect(earned.some((a) => a.type === "donut-5")).toBe(true);
+    expect(getAchievementScore("donut-5")).toBe(30);
     expect(breakdown.byWeight.find((tier) => tier.weight === 30)!.count).toBeGreaterThan(0);
   });
 });

--- a/frontend/src/client/client-db/__tests__/hall-of-fame/achievement-scoring.test.ts
+++ b/frontend/src/client/client-db/__tests__/hall-of-fame/achievement-scoring.test.ts
@@ -1,0 +1,115 @@
+import { TennisTable } from "../../tennis-table";
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import {
+  ACHIEVEMENT_SCORE_TIERS,
+  ACHIEVEMENT_SCORES,
+  DEFAULT_ACHIEVEMENT_SCORE,
+  getAchievementScore,
+} from "../../achievements";
+
+// The Hall of Fame "achievements earned" factor sums a static per-type
+// weight (10 / 20 / 30) instead of a flat 20-per-achievement, and reports
+// how many were earned at each weight tier.
+
+describe("Weighted achievement scoring", () => {
+  const game = (id: string, time: number, winner: string, loser: string): EventType => ({
+    time,
+    stream: id,
+    type: EventTypeEnum.GAME_CREATED,
+    data: { playedAt: time, winner, loser },
+  });
+
+  const players = (): EventType[] => [
+    { time: 1, stream: "alice", type: EventTypeEnum.PLAYER_CREATED, data: { name: "Alice" } },
+    { time: 2, stream: "bob", type: EventTypeEnum.PLAYER_CREATED, data: { name: "Bob" } },
+  ];
+
+  it("assigns a weight in an allowed tier to every achievement type", () => {
+    for (const weight of Object.values(ACHIEVEMENT_SCORES)) {
+      expect(ACHIEVEMENT_SCORE_TIERS).toContain(weight);
+    }
+  });
+
+  it("getAchievementScore falls back to the default for unknown types", () => {
+    expect(getAchievementScore("first-game")).toBe(10);
+    expect(getAchievementScore("touched-the-throne")).toBe(30);
+    expect(getAchievementScore("not-a-real-achievement")).toBe(DEFAULT_ACHIEVEMENT_SCORE);
+  });
+
+  it("scores achievements by their weight and tallies each tier", () => {
+    const events: EventType[] = [...players(), game("g1", 100, "alice", "bob")];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const earned = tt.achievements.getAchievements("alice");
+    const expectedScore = earned.reduce((sum, a) => sum + getAchievementScore(a.type), 0);
+
+    const entry = tt.hallOfFame.getScoreForAnyPlayer("alice");
+    expect(entry).toBeDefined();
+
+    const breakdown = entry!.score.achievementsEarned;
+    expect(breakdown.count).toBe(earned.length);
+    expect(breakdown.score).toBe(expectedScore);
+
+    // Only "first-game" (weight 10) is earned from a single game.
+    expect(earned.map((a) => a.type)).toEqual(["first-game"]);
+    expect(breakdown.score).toBe(10);
+
+    // All tiers are represented, in ascending order, with per-tier counts.
+    expect(breakdown.byWeight.map((t) => t.weight)).toEqual([...ACHIEVEMENT_SCORE_TIERS]);
+    expect(breakdown.byWeight).toEqual([
+      { weight: 10, count: 1 },
+      { weight: 20, count: 0 },
+      { weight: 30, count: 0 },
+    ]);
+  });
+
+  it("sums mixed-weight achievements and counts them per tier", () => {
+    // Give Alice a spread of achievements across tiers by playing enough
+    // games: first-game (10) + ranked (10) + donut sets, and a 10-win
+    // streak (streak-all-10, weight 30).
+    const events: EventType[] = [...players()];
+    let t = 100;
+    // 10 straight wins for Alice, each a donut set (bob scores 0), which
+    // also crosses the ranked threshold and the 10-game win streak.
+    for (let i = 0; i < 10; i++) {
+      events.push({
+        time: t,
+        stream: `g${i}`,
+        type: EventTypeEnum.GAME_CREATED,
+        data: {
+          playedAt: t,
+          winner: "alice",
+          loser: "bob",
+          score: { setsWon: { gameWinner: 1, gameLoser: 0 }, setPoints: [{ gameWinner: 11, gameLoser: 0 }] },
+        },
+      });
+      t += 1000;
+    }
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const earned = tt.achievements.getAchievements("alice");
+    const expectedScore = earned.reduce((sum, a) => sum + getAchievementScore(a.type), 0);
+
+    const breakdown = tt.hallOfFame.getScoreForAnyPlayer("alice")!.score.achievementsEarned;
+    expect(breakdown.score).toBe(expectedScore);
+    expect(breakdown.count).toBe(earned.length);
+
+    // Per-tier counts must add up to the total count.
+    const tierTotal = breakdown.byWeight.reduce((sum, tier) => sum + tier.count, 0);
+    expect(tierTotal).toBe(breakdown.count);
+
+    // Each tier's count matches an independent tally of the earned types.
+    for (const tier of breakdown.byWeight) {
+      const expectedCount = earned.filter((a) => getAchievementScore(a.type) === tier.weight).length;
+      expect(tier.count).toBe(expectedCount);
+    }
+
+    // Alice earned at least one rare (30-pt) achievement (streak-all-10).
+    expect(earned.some((a) => a.type === "streak-all-10")).toBe(true);
+    expect(breakdown.byWeight.find((tier) => tier.weight === 30)!.count).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -1991,6 +1991,79 @@ type AchievementDefinitions = {
 
 type AchievementType = keyof AchievementDefinitions;
 
+// The distinct Hall of Fame point values an achievement can be worth,
+// ascending. 20 is the standard value; common/easy achievements are
+// worth 10 and rare/difficult ones 30. The Hall of Fame UI renders one
+// badge per tier, so keep this in sync with ACHIEVEMENT_SCORES below.
+export const ACHIEVEMENT_SCORE_TIERS = [10, 20, 30] as const;
+
+// The standard value used when an achievement is not listed (or as the
+// neutral middle tier).
+export const DEFAULT_ACHIEVEMENT_SCORE = 20;
+
+// Static Hall of Fame point value for every achievement type. This is
+// the single source of truth for achievement scoring — it lives with
+// the achievement definitions so the client-db core owns it rather than
+// a page component. Using Record<AchievementType, number> forces every
+// new achievement to declare a score at compile time.
+export const ACHIEVEMENT_SCORES: Record<AchievementType, number> = {
+  // Common / easy — worth 10
+  "first-game": 10,
+  "ranked": 10,
+  "donut-1": 10,
+  "variety-player": 10,
+  "anniversary": 10,
+  "tournament-participated": 10,
+  "back-after-6-months": 10,
+  "active-6-months": 10,
+  "punching-bag": 10,
+  "goliath": 10,
+
+  // Standard — worth 20
+  "donut-5": 20,
+  "global-player": 20,
+  "back-after-1-year": 20,
+  "active-1-year": 20,
+  "nice-game": 20,
+  "less-is-more": 20,
+  "close-calls": 20,
+  "consistency-is-key": 20,
+  "welcome-committee": 20,
+  "never-give-up": 20,
+  "comeback-kid": 20,
+  "hat-trick": 20,
+  "king-maker": 20,
+  "photo-finish": 20,
+  "leap-frog": 20,
+  "david": 20,
+  "streak-ender": 20,
+
+  // Rare / difficult — worth 30
+  "streak-all-10": 30,
+  "streak-player-10": 30,
+  "streak-player-20": 30,
+  "back-after-2-years": 30,
+  "active-2-years": 30,
+  "edge-lord": 30,
+  "best-friends": 30,
+  "community-builder": 30,
+  "unbreakable-spirit": 30,
+  "kingslayer": 30,
+  "on-the-podium": 30,
+  "climber": 30,
+  "marathon-set": 30,
+  "group-stage-star": 30,
+  "tournament-winner": 30,
+  "season-winner": 30,
+  "touched-the-throne": 30,
+};
+
+// Resolves the static Hall of Fame point value for an achievement type,
+// falling back to the standard value for any unrecognised type.
+export function getAchievementScore(type: string): number {
+  return (ACHIEVEMENT_SCORES as Record<string, number>)[type] ?? DEFAULT_ACHIEVEMENT_SCORE;
+}
+
 type GenericAchievement<T extends AchievementType = AchievementType> = {
   type: T;
   earnedBy: string;

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -2006,56 +2006,65 @@ export const DEFAULT_ACHIEVEMENT_SCORE = 20;
 // the achievement definitions so the client-db core owns it rather than
 // a page component. Using Record<AchievementType, number> forces every
 // new achievement to declare a score at compile time.
+//
+// Tiers are driven primarily by how rare each achievement actually is
+// across the league (rarer = worth more), with two deliberate overrides:
+//   - The marquee championships (season / tournament win, reaching #1)
+//     are only mid-frequency but are the most prestigious, so they are
+//     bumped to the top tier.
+//   - Purely negative outcomes (Goliath = getting upset, Never Give Up =
+//     losing 20 in a row) are held down despite being rare — a Hall of
+//     Fame score shouldn't reward them like a real accomplishment.
 export const ACHIEVEMENT_SCORES: Record<AchievementType, number> = {
-  // Common / easy — worth 10
-  "first-game": 10,
-  "ranked": 10,
-  "donut-1": 10,
-  "variety-player": 10,
-  "anniversary": 10,
+  // Common — worth 10 (frequently earned across the league)
   "tournament-participated": 10,
-  "back-after-6-months": 10,
-  "active-6-months": 10,
+  "first-game": 10,
+  "donut-1": 10,
+  "ranked": 10,
+  "less-is-more": 10,
+  "streak-player-10": 10,
+  "variety-player": 10,
+  "hat-trick": 10,
+  "anniversary": 10,
   "punching-bag": 10,
-  "goliath": 10,
+  "goliath": 10, // rare, but a negative outcome — kept low
 
-  // Standard — worth 20
-  "donut-5": 20,
+  // Standard — worth 20 (mid-frequency)
+  "streak-all-10": 20,
   "global-player": 20,
-  "back-after-1-year": 20,
-  "active-1-year": 20,
-  "nice-game": 20,
-  "less-is-more": 20,
-  "close-calls": 20,
-  "consistency-is-key": 20,
-  "welcome-committee": 20,
-  "never-give-up": 20,
-  "comeback-kid": 20,
-  "hat-trick": 20,
-  "king-maker": 20,
+  "kingslayer": 20,
   "photo-finish": 20,
-  "leap-frog": 20,
-  "david": 20,
   "streak-ender": 20,
+  "group-stage-star": 20,
+  "comeback-kid": 20,
+  "consistency-is-key": 20,
+  "best-friends": 20,
+  "active-6-months": 20,
+  "nice-game": 20,
+  "close-calls": 20,
+  "welcome-committee": 20,
+  "on-the-podium": 20,
+  "king-maker": 20,
+  "climber": 20,
+  "never-give-up": 20, // rare, but a negative outcome — held at standard
 
-  // Rare / difficult — worth 30
-  "streak-all-10": 30,
-  "streak-player-10": 30,
+  // Rare / prestigious — worth 30
+  "season-winner": 30, // prestige bump (mid-frequency)
+  "tournament-winner": 30, // prestige bump (mid-frequency)
+  "touched-the-throne": 30, // prestige bump (mid-frequency)
+  "back-after-6-months": 30,
+  "marathon-set": 30,
+  "back-after-1-year": 30,
+  "leap-frog": 30,
   "streak-player-20": 30,
-  "back-after-2-years": 30,
+  "unbreakable-spirit": 30,
+  "active-1-year": 30,
+  "donut-5": 30,
   "active-2-years": 30,
   "edge-lord": 30,
-  "best-friends": 30,
+  "david": 30,
   "community-builder": 30,
-  "unbreakable-spirit": 30,
-  "kingslayer": 30,
-  "on-the-podium": 30,
-  "climber": 30,
-  "marathon-set": 30,
-  "group-stage-star": 30,
-  "tournament-winner": 30,
-  "season-winner": 30,
-  "touched-the-throne": 30,
+  "back-after-2-years": 30,
 };
 
 // Resolves the static Hall of Fame point value for an achievement type,

--- a/frontend/src/client/client-db/hall-of-fame.ts
+++ b/frontend/src/client/client-db/hall-of-fame.ts
@@ -1,13 +1,16 @@
+import { ACHIEVEMENT_SCORE_TIERS, getAchievementScore } from "./achievements";
 import { Elo } from "./elo";
 import { EventTypeEnum } from "./event-store/event-types";
 import { TennisTable } from "./tennis-table";
+
+export type AchievementWeightTier = { weight: number; count: number };
 
 export type SeasonDetail = { rank: number; points: number };
 export type TournamentDetail = { name: string; placement: string; points: number };
 
 export type HallOfFameScoreBreakdown = {
   seasonPerformance: { score: number; seasons: SeasonDetail[] };
-  achievementsEarned: { score: number; count: number };
+  achievementsEarned: { score: number; count: number; byWeight: AchievementWeightTier[] };
   socialDiversity: { score: number; uniqueOpponents: number };
   tournamentProgression: { score: number; tournaments: TournamentDetail[] };
   longevity: { score: number; activeDays: number };
@@ -269,9 +272,26 @@ export class HallOfFame {
 
   #calcAchievements(playerId: string): HallOfFameScoreBreakdown["achievementsEarned"] {
     this.parent.achievements.calculateAchievements();
-    const achievements = this.parent.achievements.achievementMap.get(playerId);
-    const count = achievements?.length ?? 0;
-    return { score: count * 20, count };
+    const achievements = this.parent.achievements.achievementMap.get(playerId) ?? [];
+    const count = achievements.length;
+
+    // Each achievement contributes its static weight (see ACHIEVEMENT_SCORES).
+    // We also tally how many the player earned at each weight tier so the
+    // Hall of Fame page can render one badge per tier.
+    const countsByWeight = new Map<number, number>();
+    let score = 0;
+    for (const achievement of achievements) {
+      const weight = getAchievementScore(achievement.type);
+      score += weight;
+      countsByWeight.set(weight, (countsByWeight.get(weight) ?? 0) + 1);
+    }
+
+    const byWeight: AchievementWeightTier[] = ACHIEVEMENT_SCORE_TIERS.map((weight) => ({
+      weight,
+      count: countsByWeight.get(weight) ?? 0,
+    }));
+
+    return { score, count, byWeight };
   }
 
   #calcSocialDiversity(playerId: string): HallOfFameScoreBreakdown["socialDiversity"] {

--- a/frontend/src/pages/achievements/achievements-list.tsx
+++ b/frontend/src/pages/achievements/achievements-list.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { Achievement } from "../../client/client-db/achievements";
+import { Achievement, getAchievementScore } from "../../client/client-db/achievements";
 import { useEventDbContext } from "../../wrappers/event-db-context";
 import { getAchievementLabel, dateString } from "../player/player-achievements";
 import { relativeTimeString } from "../../common/date-utils";
@@ -28,6 +28,7 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
     <div className="space-y-2">
       {achievements.map((achievement, index) => {
         const label = getAchievementLabel(achievement.type, context.client.gameLimitForRanked);
+        const score = getAchievementScore(achievement.type);
 
         return (
           <div
@@ -40,6 +41,9 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                 <div className="flex items-center justify-between gap-2">
                   <div className="flex items-baseline gap-2 overflow-hidden">
                     <h3 className="font-semibold text-primary-text whitespace-nowrap">{label.title}</h3>
+                    <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-primary-text/10 whitespace-nowrap self-center">
+                      {score} pts
+                    </span>
                     <p className="text-xs opacity-70 truncate hidden sm:block">{label.description}</p>
                   </div>
                   <div className="text-[10px] whitespace-nowrap opacity-60 text-right shrink-0">

--- a/frontend/src/pages/achievements/progress-list.tsx
+++ b/frontend/src/pages/achievements/progress-list.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import { Link } from "react-router-dom";
 import { useEventDbContext } from "../../wrappers/event-db-context";
+import { getAchievementScore } from "../../client/client-db/achievements";
 import { ACHIEVEMENT_LABELS, getAchievementLabel } from "../player/player-achievements";
 import { ProfilePicture } from "../player/profile-picture";
 import { fmtNum } from "../../common/number-utils";
@@ -89,11 +90,14 @@ export const ProgressList: React.FC<ProgressListProps> = ({ selectedType }) => {
       ) : (
         <div className="space-y-2">
           <div className="mb-6">
-            <h2 className="text-xl font-bold flex items-center gap-3">
+            <h2 className="text-xl font-bold flex items-center gap-3 flex-wrap">
               <span>Progress:</span>
               <span className="bg-background-secondary px-3 py-1 rounded-md border border-primary-text/20 flex items-center gap-2">
                 {ACHIEVEMENT_LABELS[selectedType]?.icon}{" "}
                 {ACHIEVEMENT_LABELS[selectedType]?.title}
+              </span>
+              <span className="text-xs font-semibold px-2 py-1 rounded-full bg-primary-text/10">
+                {getAchievementScore(selectedType)} pts
               </span>
             </h2>
             <p className="text-sm opacity-70 mt-2">

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
@@ -52,15 +52,30 @@ function renderDetails(breakdown: HallOfFameScoreBreakdown, key: FactorKey): Rea
     }
     case "achievementsEarned": {
       const d = data as HallOfFameScoreBreakdown["achievementsEarned"];
+      const tierLabels: Record<number, string> = { 10: "Common", 20: "Standard", 30: "Rare" };
       return (
         <div className="text-primary-text text-xs space-y-1.5">
+          <p className="italic">Each achievement is worth points based on how rare or difficult it is.</p>
           <div className="flex flex-wrap gap-1.5">
-            <span className="bg-secondary-background text-secondary-text px-2 py-0.5 rounded text-xs inline-flex items-center gap-1.5">
-              Achievements: 20 pts
-              <span className="bg-tertiary-background text-tertiary-text h-5 min-w-5 px-1 rounded-full inline-flex items-center justify-center text-xs font-bold">
-                {d.count}x
+            {d.byWeight.map((tier) => (
+              <span
+                key={tier.weight}
+                className={classNames(
+                  "px-2 py-0.5 rounded text-xs inline-flex items-center gap-1.5",
+                  tier.count === 0
+                    ? "bg-secondary-background/50 text-secondary-text/75"
+                    : "bg-secondary-background text-secondary-text",
+                )}
+              >
+                {tierLabels[tier.weight] ? `${tierLabels[tier.weight]}: ` : ""}
+                {tier.weight} pts
+                {tier.count > 0 && (
+                  <span className="bg-tertiary-background text-tertiary-text h-5 min-w-5 px-1 rounded-full inline-flex items-center justify-center text-xs font-bold">
+                    {tier.count}x
+                  </span>
+                )}
               </span>
-            </span>
+            ))}
           </div>
         </div>
       );

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -2,7 +2,7 @@ import { useEventDbContext } from "../../wrappers/event-db-context";
 import { relativeTimeString } from "../../common/date-utils";
 import { classNames } from "../../common/class-names";
 import { useState } from "react";
-import { Achievement, AchievementProgression } from "../../client/client-db/achievements";
+import { Achievement, AchievementProgression, getAchievementScore } from "../../client/client-db/achievements";
 import { Link } from "react-router-dom";
 import { fmtNum } from "../../common/number-utils";
 
@@ -325,6 +325,7 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
     <div className="space-y-3">
       {achievements.map((achievement, index) => {
         const label = getAchievementLabel(achievement.type, context.client.gameLimitForRanked);
+        const score = getAchievementScore(achievement.type);
 
         return (
           <div
@@ -335,7 +336,12 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
               <div className="text-4xl">{label.icon}</div>
               <div className="flex-1">
                 <div className="flex items-center justify-between">
-                  <h3 className="font-semibold text-secondary-text">{label.title}</h3>
+                  <div className="flex items-center gap-2">
+                    <h3 className="font-semibold text-secondary-text">{label.title}</h3>
+                    <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-secondary-text/10 text-secondary-text whitespace-nowrap">
+                      {score} pts
+                    </span>
+                  </div>
                   <span className="text-xs text-secondary-text">
                     {relativeTimeString(new Date(achievement.earnedAt))} - {dateString(achievement.earnedAt)}
                   </span>
@@ -535,13 +541,14 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
     return {
       type,
       label,
+      score: getAchievementScore(type),
       data,
     };
   });
 
   return (
     <div className="space-y-4 text-secondary-text">
-      {progressItems.map(({ type, label, data }) => {
+      {progressItems.map(({ type, label, score, data }) => {
         const hasTarget = "target" in data && !!data.target;
         const hasCurrent = "current" in data && !!data.current;
         const percentage = hasTarget && hasCurrent ? Math.min((data.current! / data.target!) * 100, 100) : 0;
@@ -581,6 +588,9 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                     <div className="flex-1">
                       <div className="flex items-center gap-3">
                         <h3 className="font-semibold ">{label.title}</h3>
+                        <span className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full bg-secondary-text/10 whitespace-nowrap">
+                          {score} pts
+                        </span>
                         {hasTarget && <span className="text-lg font-bold">{percentage.toFixed(0)}%</span>}
                       </div>
                       <p className="text-sm text-secondary-text">{label.description}</p>


### PR DESCRIPTION
Achievements previously contributed a flat 20 points each to the Hall of
Fame score. They now carry a static per-type weight — 10 for common/easy
achievements, 20 (the standard) for most, and 30 for rare/difficult ones.

- Define ACHIEVEMENT_SCORES (and the 10/20/30 tiers) alongside the
  achievement definitions in the client-db core, so scoring is owned there
  rather than in a page component. Record<AchievementType, number> forces
  every future achievement to declare a weight.
- Hall of Fame #calcAchievements sums each earned achievement's weight and
  tallies the count per tier.
- Hall of Fame player page renders one badge per tier (Common/Standard/
  Rare), greyed at zero, matching the Season and Podium sections.
- Player page shows each achievement's point value in both the earned list
  and the progress bar; the separate achievements page lists it too.
- Add tests covering the weighting, tier tallies, and default fallback.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BsrCQzWyzyy6vsHPce9KVA