### PR TITLE
Add Full House and Humbled achievements

### DIFF
--- a/achievement-suggestions.md
+++ b/achievement-suggestions.md
@@ -9,38 +9,32 @@ Play 100 total games.
 ## 2. Free Fall 📉
 Drop 300 Score from your all-time high.
 
-## 3. Conqueror 🗺️
-Beat every currently ranked active player at least once.
-
-## 4. Cursed 🪦
-Lose to every currently ranked active player at least once.
-
-## 5. Throne Holder 👑
+## 3. Throne Holder 👑
 Hold rank #1 for 30 consecutive days.
 
-## 6. Dynasty 🏛️
+## 4. Dynasty 🏛️
 Hold rank #1 for 90 consecutive days.
 
-## 7. Rocket 🚀
+## 5. Rocket 🚀
 Climb 100 Score in a single calendar week.
 
-## 8. Yin Yang ☯️
+## 6. Yin Yang ☯️
 Alternate Win/Loss/Win/Loss for 10 games straight.
 
-## 9. Perfect Day ☀️
+## 7. Perfect Day ☀️
 Go undefeated across 5+ games in a single day.
 
-## 10. Worst Day 🌧️
+## 8. Worst Day 🌧️
 Lose 5+ games in a single day without a win.
 
-## 11. Tour de Table 🚲
+## 9. Tour de Table 🚲
 Play against 5 different opponents in a single day.
 
-## 12. Late Bloomer 🌷
+## 10. Late Bloomer 🌷
 Enter a season's top 3 only in its final week.
 
-## 13. Founding Member 🪴
+## 11. Founding Member 🪴
 Be among the first 5 players ever created in the league.
 
-## 14. Block Party 🎉
+## 12. Block Party 🎉
 Play on a day where every currently active ranked player also plays.

--- a/frontend/src/client/client-db/__tests__/achievements/full-house-humbled.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/full-house-humbled.test.ts
@@ -279,6 +279,40 @@ describe("Full House & Humbled Achievements", () => {
     expect(eProgress["humbled"].current).toBe(4);
   });
 
+  it("lists the players still missing from the set in progression", () => {
+    // 5-player double round-robin where A beats B, C, D but loses to E both
+    // rounds. A is missing only E for Full House; E is missing only A for
+    // Humbled (E beats A but loses to B, C, D).
+    const events: EventType[] = [
+      createPlayer("a", 1),
+      createPlayer("b", 2),
+      createPlayer("c", 3),
+      createPlayer("d", 4),
+      createPlayer("e", 5),
+    ];
+    const outcomes: [string, string, string][] = [
+      ["a-b", "a", "b"], ["a-c", "a", "c"], ["a-d", "a", "d"], ["e-a", "e", "a"],
+      ["b-c", "b", "c"], ["b-d", "b", "d"], ["b-e", "b", "e"],
+      ["c-d", "c", "d"], ["c-e", "c", "e"], ["d-e", "d", "e"],
+    ];
+    let t = 100;
+    for (let round = 0; round < 2; round++) {
+      for (const [id, winner, loser] of outcomes) {
+        events.push(game(`${id}-${round}`, t++, winner, loser));
+      }
+    }
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const aProgress = tt.achievements.getPlayerProgression("a");
+    expect(aProgress["full-house"].current).toBe(3);
+    expect(aProgress["full-house"].target).toBe(4);
+    expect(Array.from(aProgress["full-house"].missing!)).toEqual(["e"]);
+
+    const eProgress = tt.achievements.getPlayerProgression("e");
+    expect(Array.from(eProgress["humbled"].missing!)).toEqual(["a"]);
+  });
+
   it("targets the full ranked count for an unranked player (no self subtraction)", () => {
     // Z plays a single game, so Z is not ranked. The target is the total
     // number of ranked players (5) with no minus-one, since Z isn't in the

--- a/frontend/src/client/client-db/__tests__/achievements/full-house-humbled.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/full-house-humbled.test.ts
@@ -172,6 +172,65 @@ describe("Full House & Humbled Achievements", () => {
     const fullHouse = tt.achievements.getAchievements("a").filter((x) => x.type === "full-house");
     expect(fullHouse).toHaveLength(1);
     expect(fullHouse[0].earnedAt).toBe(200);
+    // A is ranked, so the completed set is the cohort of 5 minus A → 4. A's
+    // first game was against F at t=100.
+    expect(fullHouse[0].data).toEqual({ count: 4, firstGameAt: 100 });
+  });
+
+  it("can be earned by an unranked player who beat the whole ranked field", () => {
+    // gameLimitForRanked is raised to 6 so a player can beat all 5 ranked
+    // players (5 games) while still being unranked themselves. A–E become
+    // ranked via the double round-robin (8 games each). Z then beats all of
+    // them across 5 games — Z has only 5 games (< 6) so is NOT ranked, yet
+    // Full House still fires, counting all 5 beaten players.
+    const events = [
+      ...fivePlayerSetup(),
+      createPlayer("z", 50),
+      game("z-a", 2000, "z", "a"),
+      game("z-b", 2001, "z", "b"),
+      game("z-c", 2002, "z", "c"),
+      game("z-d", 2003, "z", "d"),
+      game("z-e", 2004, "z", "e"),
+    ];
+    const tt = new TennisTable({ events, gameLimitForRankedOverride: 6 });
+    tt.achievements.calculateAchievements();
+
+    // Sanity: Z is not on the leaderboard (only 5 games, needs 6).
+    const ranked = tt.leaderboard.getLeaderboard().rankedPlayers.map((p) => p.id);
+    expect(ranked).not.toContain("z");
+
+    const fullHouse = tt.achievements.getAchievements("z").filter((x) => x.type === "full-house");
+    expect(fullHouse).toHaveLength(1);
+    expect(fullHouse[0].earnedAt).toBe(2004);
+    // Z is unranked, so nothing is subtracted — all 5 ranked players counted.
+    expect(fullHouse[0].data).toEqual({ count: 5, firstGameAt: 2000 });
+  });
+
+  it("shows 0 progress while fewer than 5 players are ranked", () => {
+    // 4-player double round-robin: A beats B, C, D. Only 4 players are
+    // ranked, below the ≥5 gate, so progress is reported as 0 even though A
+    // has beaten every ranked opponent.
+    const events: EventType[] = [
+      createPlayer("a", 1),
+      createPlayer("b", 2),
+      createPlayer("c", 3),
+      createPlayer("d", 4),
+    ];
+    const outcomes: [string, string, string][] = [
+      ["a-b", "a", "b"], ["a-c", "a", "c"], ["a-d", "a", "d"],
+      ["b-c", "b", "c"], ["b-d", "b", "d"], ["c-d", "c", "d"],
+    ];
+    let t = 100;
+    for (let round = 0; round < 2; round++) {
+      for (const [id, winner, loser] of outcomes) {
+        events.push(game(`${id}-${round}`, t++, winner, loser));
+      }
+    }
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const aProgress = tt.achievements.getPlayerProgression("a");
+    expect(aProgress["full-house"].current).toBe(0);
   });
 
   it("does NOT award when a deactivation drops the cohort below 5", () => {

--- a/frontend/src/client/client-db/__tests__/achievements/full-house-humbled.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/full-house-humbled.test.ts
@@ -1,0 +1,159 @@
+import { TennisTable } from "../../tennis-table";
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+
+// Full House: beat every currently ranked active player at least once.
+// Humbled: lose to every currently ranked active player at least once.
+// The target cohort is the CURRENT leaderboard (ranked active players now),
+// and each requires ≥5 ranked active players to be earnable — matching the
+// cohort gate used by the rank achievements. Default GuestClient has
+// gameLimitForRanked = 5.
+
+describe("Full House & Humbled Achievements", () => {
+  const createPlayer = (id: string, time: number): EventType => ({
+    time,
+    stream: id,
+    type: EventTypeEnum.PLAYER_CREATED,
+    data: { name: id },
+  });
+
+  const game = (id: string, time: number, winner: string, loser: string): EventType => ({
+    time,
+    stream: id,
+    type: EventTypeEnum.GAME_CREATED,
+    data: { playedAt: time, winner, loser },
+  });
+
+  const deactivate = (id: string, time: number): EventType => ({
+    time,
+    stream: id,
+    type: EventTypeEnum.PLAYER_DEACTIVATED,
+    data: null,
+  });
+
+  // 5-player double round-robin (20 games). Every player ends with 8 games
+  // (all ranked). Standings: A(rank1) B C D E(rank5).
+  const fivePlayerSetup = (): EventType[] => {
+    const events: EventType[] = [
+      createPlayer("a", 1),
+      createPlayer("b", 2),
+      createPlayer("c", 3),
+      createPlayer("d", 4),
+      createPlayer("e", 5),
+    ];
+    const pairs: [string, string][] = [
+      ["a", "b"], ["a", "c"], ["a", "d"], ["a", "e"],
+      ["b", "c"], ["b", "d"], ["b", "e"],
+      ["c", "d"], ["c", "e"],
+      ["d", "e"],
+    ];
+    let t = 100;
+    for (let round = 0; round < 2; round++) {
+      for (const [winner, loser] of pairs) {
+        events.push(game(`g-${round}-${winner}-${loser}`, t++, winner, loser));
+      }
+    }
+    return events;
+  };
+
+  it("awards Full House when a player has beaten every currently ranked active player", () => {
+    // In the double round-robin, A beats B, C, D and E at least once — A has
+    // beaten all 4 other ranked players, so Full House fires for A.
+    const events = fivePlayerSetup();
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const fullHouse = tt.achievements.getAchievements("a").filter((x) => x.type === "full-house");
+    expect(fullHouse).toHaveLength(1);
+  });
+
+  it("awards Humbled when a player has lost to every currently ranked active player", () => {
+    // E loses to A, B, C and D at least once — Humbled fires for E.
+    const events = fivePlayerSetup();
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const humbled = tt.achievements.getAchievements("e").filter((x) => x.type === "humbled");
+    expect(humbled).toHaveLength(1);
+  });
+
+  it("does NOT award Full House to a player who has not beaten all ranked players", () => {
+    // E never beats anyone → no Full House for E.
+    const events = fivePlayerSetup();
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("e").filter((x) => x.type === "full-house")).toHaveLength(0);
+  });
+
+  it("does NOT award Humbled to a player who never lost to all ranked players", () => {
+    // A never loses → no Humbled for A.
+    const events = fivePlayerSetup();
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("a").filter((x) => x.type === "humbled")).toHaveLength(0);
+  });
+
+  it("awards each at most once", () => {
+    const events = fivePlayerSetup();
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("a").filter((x) => x.type === "full-house")).toHaveLength(1);
+    expect(tt.achievements.getAchievements("e").filter((x) => x.type === "humbled")).toHaveLength(1);
+  });
+
+  it("does NOT award when fewer than 5 players are ranked", () => {
+    // 4-player double round-robin (12 games). All 4 ranked but only 4 in the
+    // pool — below the ≥5 cohort gate, so neither achievement fires.
+    const events: EventType[] = [
+      createPlayer("a", 1),
+      createPlayer("b", 2),
+      createPlayer("c", 3),
+      createPlayer("d", 4),
+    ];
+    const pairs: [string, string][] = [
+      ["a", "b"], ["a", "c"], ["a", "d"],
+      ["b", "c"], ["b", "d"],
+      ["c", "d"],
+    ];
+    let t = 100;
+    for (let round = 0; round < 2; round++) {
+      for (const [winner, loser] of pairs) {
+        events.push(game(`g-${round}-${winner}-${loser}`, t++, winner, loser));
+      }
+    }
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("a").filter((x) => x.type === "full-house")).toHaveLength(0);
+    expect(tt.achievements.getAchievements("d").filter((x) => x.type === "humbled")).toHaveLength(0);
+  });
+
+  it("ignores results against players who are no longer ranked active", () => {
+    // A beats B, C, D, E. Then E is deactivated, dropping the ranked cohort
+    // to 4 (A, B, C, D). Full House now needs ≥5 ranked active — the gate
+    // fails and A gets nothing despite having beaten everyone historically.
+    const events = [...fivePlayerSetup(), deactivate("e", 5000)];
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("a").filter((x) => x.type === "full-house")).toHaveLength(0);
+  });
+
+  it("reflects Full House / Humbled progression against the current ranked cohort", () => {
+    const events = fivePlayerSetup();
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    // A is ranked, so the target pool excludes A → 4 opponents.
+    const aProgress = tt.achievements.getPlayerProgression("a");
+    expect(aProgress["full-house"].target).toBe(4);
+    expect(aProgress["full-house"].current).toBe(4);
+
+    // E lost to all 4 other ranked players.
+    const eProgress = tt.achievements.getPlayerProgression("e");
+    expect(eProgress["humbled"].target).toBe(4);
+    expect(eProgress["humbled"].current).toBe(4);
+  });
+});

--- a/frontend/src/client/client-db/__tests__/achievements/full-house-humbled.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/full-house-humbled.test.ts
@@ -130,11 +130,74 @@ describe("Full House & Humbled Achievements", () => {
     expect(tt.achievements.getAchievements("d").filter((x) => x.type === "humbled")).toHaveLength(0);
   });
 
-  it("ignores results against players who are no longer ranked active", () => {
-    // A beats B, C, D, E. Then E is deactivated, dropping the ranked cohort
-    // to 4 (A, B, C, D). Full House now needs ≥5 ranked active — the gate
-    // fails and A gets nothing despite having beaten everyone historically.
-    const events = [...fivePlayerSetup(), deactivate("e", 5000)];
+  it("awards Full House the moment a deactivation removes the last unbeaten ranked player", () => {
+    // 6 players. F is made ranked first and beats A (so A never beats F).
+    // A then beats B, C, D, E, and B–E are brought up to ranked. With all 6
+    // ranked, A is missing only F, so Full House does NOT fire. When F is
+    // deactivated the cohort drops to {A,B,C,D,E} (still 5) and A has beaten
+    // all of them — Full House fires, stamped at the deactivation time.
+    const events: EventType[] = [
+      createPlayer("a", 1),
+      createPlayer("b", 2),
+      createPlayer("c", 3),
+      createPlayer("d", 4),
+      createPlayer("e", 5),
+      createPlayer("f", 6),
+    ];
+    // Phase 1 — F plays everyone once (F reaches 5 games → ranked first).
+    // F beats A, so A can never complete the set while F is in the cohort.
+    events.push(game("f-a", 100, "f", "a"));
+    events.push(game("f-b", 101, "f", "b"));
+    events.push(game("f-c", 102, "f", "c"));
+    events.push(game("f-d", 103, "f", "d"));
+    events.push(game("f-e", 104, "f", "e"));
+    // Phase 2 — A beats B, C, D, E (A reaches 5 games → ranked).
+    events.push(game("a-b", 110, "a", "b"));
+    events.push(game("a-c", 111, "a", "c"));
+    events.push(game("a-d", 112, "a", "d"));
+    events.push(game("a-e", 113, "a", "e"));
+    // Phase 3 — round-robin among B, C, D, E so each reaches 5 games.
+    events.push(game("b-c", 120, "b", "c"));
+    events.push(game("b-d", 121, "b", "d"));
+    events.push(game("b-e", 122, "b", "e"));
+    events.push(game("c-d", 123, "c", "d"));
+    events.push(game("c-e", 124, "c", "e"));
+    events.push(game("d-e", 125, "d", "e"));
+    // Phase 4 — F deactivated. A's last missing target leaves the cohort.
+    events.push(deactivate("f", 200));
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const fullHouse = tt.achievements.getAchievements("a").filter((x) => x.type === "full-house");
+    expect(fullHouse).toHaveLength(1);
+    expect(fullHouse[0].earnedAt).toBe(200);
+  });
+
+  it("does NOT award when a deactivation drops the cohort below 5", () => {
+    // 5 ranked players. A beats B, C, D but loses to E, so A is missing only
+    // E. Deactivating E leaves a cohort of 4 (A, B, C, D) — below the ≥5
+    // gate — so A earns nothing despite having beaten everyone still ranked.
+    const events: EventType[] = [
+      createPlayer("a", 1),
+      createPlayer("b", 2),
+      createPlayer("c", 3),
+      createPlayer("d", 4),
+      createPlayer("e", 5),
+    ];
+    const outcomes: [string, string, string][] = [
+      ["a-b", "a", "b"], ["a-c", "a", "c"], ["a-d", "a", "d"], ["e-a", "e", "a"],
+      ["b-c", "b", "c"], ["b-d", "b", "d"], ["b-e", "b", "e"],
+      ["c-d", "c", "d"], ["c-e", "c", "e"], ["d-e", "d", "e"],
+    ];
+    let t = 100;
+    for (let round = 0; round < 2; round++) {
+      for (const [id, winner, loser] of outcomes) {
+        events.push(game(`${id}-${round}`, t++, winner, loser));
+      }
+    }
+    events.push(deactivate("e", 5000));
+
     const tt = new TennisTable({ events });
     tt.achievements.calculateAchievements();
 

--- a/frontend/src/client/client-db/__tests__/achievements/full-house-humbled.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/full-house-humbled.test.ts
@@ -209,7 +209,7 @@ describe("Full House & Humbled Achievements", () => {
     const tt = new TennisTable({ events });
     tt.achievements.calculateAchievements();
 
-    // A is ranked, so the target pool excludes A → 4 opponents.
+    // A is ranked, so the target is the 5 ranked players minus A → 4.
     const aProgress = tt.achievements.getPlayerProgression("a");
     expect(aProgress["full-house"].target).toBe(4);
     expect(aProgress["full-house"].current).toBe(4);
@@ -218,5 +218,22 @@ describe("Full House & Humbled Achievements", () => {
     const eProgress = tt.achievements.getPlayerProgression("e");
     expect(eProgress["humbled"].target).toBe(4);
     expect(eProgress["humbled"].current).toBe(4);
+  });
+
+  it("targets the full ranked count for an unranked player (no self subtraction)", () => {
+    // Z plays a single game, so Z is not ranked. The target is the total
+    // number of ranked players (5) with no minus-one, since Z isn't in the
+    // ranked cohort. Beating A once puts Z's Full House progress at 1/5.
+    const events = [
+      ...fivePlayerSetup(),
+      createPlayer("z", 50),
+      game("z-a", 5000, "z", "a"),
+    ];
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const zProgress = tt.achievements.getPlayerProgression("z");
+    expect(zProgress["full-house"].target).toBe(5);
+    expect(zProgress["full-house"].current).toBe(1);
   });
 });

--- a/frontend/src/client/client-db/__tests__/achievements/full-house-humbled.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/full-house-humbled.test.ts
@@ -1,12 +1,12 @@
 import { TennisTable } from "../../tennis-table";
 import { EventType, EventTypeEnum } from "../../event-store/event-types";
 
-// Full House: beat every currently ranked active player at least once.
-// Humbled: lose to every currently ranked active player at least once.
-// The target cohort is the CURRENT leaderboard (ranked active players now),
-// and each requires ≥5 ranked active players to be earnable — matching the
-// cohort gate used by the rank achievements. Default GuestClient has
-// gameLimitForRanked = 5.
+// Full House: beat every currently ranked player at least once.
+// Humbled: lose to every currently ranked player at least once.
+// The target cohort is the CURRENT leaderboard (ranked players now, i.e.
+// active players with enough games), and each requires ≥5 ranked players to
+// be earnable — matching the cohort gate used by the rank achievements.
+// Default GuestClient has gameLimitForRanked = 5.
 
 describe("Full House & Humbled Achievements", () => {
   const createPlayer = (id: string, time: number): EventType => ({
@@ -55,7 +55,7 @@ describe("Full House & Humbled Achievements", () => {
     return events;
   };
 
-  it("awards Full House when a player has beaten every currently ranked active player", () => {
+  it("awards Full House when a player has beaten every currently ranked player", () => {
     // In the double round-robin, A beats B, C, D and E at least once — A has
     // beaten all 4 other ranked players, so Full House fires for A.
     const events = fivePlayerSetup();
@@ -66,7 +66,7 @@ describe("Full House & Humbled Achievements", () => {
     expect(fullHouse).toHaveLength(1);
   });
 
-  it("awards Humbled when a player has lost to every currently ranked active player", () => {
+  it("awards Humbled when a player has lost to every currently ranked player", () => {
     // E loses to A, B, C and D at least once — Humbled fires for E.
     const events = fivePlayerSetup();
     const tt = new TennisTable({ events });

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -1694,8 +1694,8 @@ export class Achievements {
       "david": { current: 0, target: 30, earned: 0 },
       "goliath": { current: 0, target: 30, earned: 0 },
       "climber": { current: 0, target: 300, earned: 0 },
-      "full-house": { current: 0, target: 1, earned: 0 },
-      "humbled": { current: 0, target: 1, earned: 0 },
+      "full-house": { current: 0, target: 1, missing: new Set(), earned: 0 },
+      "humbled": { current: 0, target: 1, missing: new Set(), earned: 0 },
 
       // Game feats
       "donut-1": { current: 0, target: 1, earned: 0 },
@@ -2107,10 +2107,17 @@ export class Achievements {
       });
     }
     const rankedTarget = rankedTargetPool.size;
+    // Players still standing between you and the achievement. While the ranked
+    // field is too small (progress forced to 0) the beaten / lost-to sets are
+    // empty, so the whole target pool shows as missing.
+    const fullHouseMissing = new Set([...rankedTargetPool].filter((id) => !beatenRanked.has(id)));
+    const humbledMissing = new Set([...rankedTargetPool].filter((id) => !lostToRanked.has(id)));
     progression["full-house"].current = beatenRanked.size;
     progression["full-house"].target = rankedTarget;
+    progression["full-house"].missing = fullHouseMissing;
     progression["humbled"].current = lostToRanked.size;
     progression["humbled"].target = rankedTarget;
+    progression["humbled"].missing = humbledMissing;
 
     // Count earned achievements
     const achievements = this.getAchievements(playerId);
@@ -2246,6 +2253,12 @@ type WelcomeCommitteeProgression = ProgressionWithTarget & {
   newPlayers?: Set<string>; // List of new players this person was first opponent for
 };
 
+type MissingPlayersProgression = ProgressionWithTarget & {
+  // Currently ranked active players the player has not yet beaten (Full
+  // House) / not yet lost to (Humbled) — i.e. what's left to complete the set.
+  missing?: Set<string>;
+};
+
 type MarathonSetProgression = BaseProgression & {
   // Player's own highest winning set score from a true-deuce set
   // they won (winner ≥ 12, loser ≥ 10). 0 if they have none.
@@ -2304,6 +2317,6 @@ export type AchievementProgression = {
   "marathon-set": MarathonSetProgression;
   "streak-ender": BaseProgression;
   "group-stage-star": BaseProgression;
-  "full-house": ProgressionWithTarget;
-  "humbled": ProgressionWithTarget;
+  "full-house": MissingPlayersProgression;
+  "humbled": MissingPlayersProgression;
 };

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -519,7 +519,67 @@ export class Achievements {
     this.#checkTournamentAchievements();
     this.#checkSeasonAchievements();
     this.#calculateEloAchievements();
+    this.#checkFullHouseAndHumbledAchievements();
     this.hasCalculated = true;
+  }
+
+  // Awards "Full House" (beat every currently ranked active player at least
+  // once) and "Humbled" (lose to every currently ranked active player at
+  // least once). The target cohort is the CURRENT leaderboard — the set of
+  // ranked active players right now — so beating/losing to a player who has
+  // since dropped off the leaderboard no longer counts, while any historical
+  // result against a currently-ranked player does. Requires ≥5 ranked active
+  // players so completing the set is a real feat, matching the cohort gate
+  // used by the rank achievements. Each is awarded once, at the game that
+  // completes the set.
+  #checkFullHouseAndHumbledAchievements() {
+    const rankedActive = this.parent.leaderboard.getLeaderboard().rankedPlayers.map((p) => p.id);
+    if (rankedActive.length < 5) return;
+    const rankedSet = new Set(rankedActive);
+
+    // Per-player sets of currently-ranked-active opponents beaten / lost to.
+    const beaten = new Map<string, Set<string>>();
+    const lostTo = new Map<string, Set<string>>();
+    const fullHouseAwarded = new Set<string>();
+    const humbledAwarded = new Set<string>();
+
+    const targetSizeFor = (playerId: string) => rankedSet.size - (rankedSet.has(playerId) ? 1 : 0);
+
+    this.parent.games.forEach((game) => {
+      // Full House for the winner: they just beat a ranked active player.
+      if (rankedSet.has(game.loser) && !fullHouseAwarded.has(game.winner)) {
+        let set = beaten.get(game.winner);
+        if (!set) {
+          set = new Set();
+          beaten.set(game.winner, set);
+        }
+        set.add(game.loser);
+        if (set.size === targetSizeFor(game.winner)) {
+          fullHouseAwarded.add(game.winner);
+          this.#addAchievement(
+            game.winner,
+            this.#createAchievement("full-house", game.winner, game.playedAt, undefined),
+          );
+        }
+      }
+
+      // Humbled for the loser: they just lost to a ranked active player.
+      if (rankedSet.has(game.winner) && !humbledAwarded.has(game.loser)) {
+        let set = lostTo.get(game.loser);
+        if (!set) {
+          set = new Set();
+          lostTo.set(game.loser, set);
+        }
+        set.add(game.winner);
+        if (set.size === targetSizeFor(game.loser)) {
+          humbledAwarded.add(game.loser);
+          this.#addAchievement(
+            game.loser,
+            this.#createAchievement("humbled", game.loser, game.playedAt, undefined),
+          );
+        }
+      }
+    });
   }
 
   /**
@@ -1532,6 +1592,8 @@ export class Achievements {
       "david": { current: 0, target: 30, earned: 0 },
       "goliath": { current: 0, target: 30, earned: 0 },
       "climber": { current: 0, target: 300, earned: 0 },
+      "full-house": { current: 0, target: 1, earned: 0 },
+      "humbled": { current: 0, target: 1, earned: 0 },
 
       // Game feats
       "donut-1": { current: 0, target: 1, earned: 0 },
@@ -1924,6 +1986,24 @@ export class Achievements {
       progression["climber"].current = Math.max(0, currentElo - climberLow.elo);
     }
 
+    // Full House / Humbled progression: how many of the currently ranked
+    // active players (excluding the player themselves) this player has
+    // beaten / lost to. Target is the size of that cohort, so it always
+    // matches the set they must complete to earn the achievement.
+    const rankedActiveIds = this.parent.leaderboard.getLeaderboard().rankedPlayers.map((p) => p.id);
+    const rankedTargetPool = new Set(rankedActiveIds.filter((id) => id !== playerId));
+    const beatenRanked = new Set<string>();
+    const lostToRanked = new Set<string>();
+    this.parent.games.forEach((game) => {
+      if (game.winner === playerId && rankedTargetPool.has(game.loser)) beatenRanked.add(game.loser);
+      if (game.loser === playerId && rankedTargetPool.has(game.winner)) lostToRanked.add(game.winner);
+    });
+    const rankedTarget = Math.max(rankedTargetPool.size, 1);
+    progression["full-house"].current = beatenRanked.size;
+    progression["full-house"].target = rankedTarget;
+    progression["humbled"].current = lostToRanked.size;
+    progression["humbled"].target = rankedTarget;
+
     // Count earned achievements
     const achievements = this.getAchievements(playerId);
     achievements.forEach((achievement) => {
@@ -2005,6 +2085,8 @@ type AchievementDefinitions = {
   };
   "streak-ender": { opponent: string; gameId: string; streakLength: number };
   "group-stage-star": { tournamentId: string; wins: number };
+  "full-house": undefined;
+  "humbled": undefined;
 };
 
 type AchievementType = keyof AchievementDefinitions;
@@ -2114,4 +2196,6 @@ export type AchievementProgression = {
   "marathon-set": MarathonSetProgression;
   "streak-ender": BaseProgression;
   "group-stage-star": BaseProgression;
+  "full-house": ProgressionWithTarget;
+  "humbled": ProgressionWithTarget;
 };

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -523,13 +523,13 @@ export class Achievements {
     this.hasCalculated = true;
   }
 
-  // Awards "Full House" (beat every currently ranked active player at least
-  // once) and "Humbled" (lose to every currently ranked active player at
-  // least once). The target cohort is the set of ranked active players AT THE
-  // MOMENT being evaluated, which shifts as players cross the ranked
-  // threshold or are deactivated / reactivated. A win / loss counts whenever
-  // it happened (even before the opponent was ranked); what matters is the
-  // opponent belongs to the cohort at the time of the check.
+  // Awards "Full House" (beat every currently ranked player at least once)
+  // and "Humbled" (lose to every currently ranked player at least once). The
+  // target cohort is the set of ranked players AT THE MOMENT being evaluated,
+  // which shifts as players cross the ranked threshold or are deactivated /
+  // reactivated (a deactivated player is not ranked). A win / loss counts
+  // whenever it happened (even before the opponent was ranked); what matters
+  // is the opponent belongs to the cohort at the time of the check.
   //
   // Because the cohort shrinks when a player is deactivated, either
   // achievement can be earned by a DEACTIVATION rather than a game: if the
@@ -538,8 +538,8 @@ export class Achievements {
   // leaderboard. To catch that, games and active-state changes are replayed
   // in time order and the whole ranked cohort is re-checked after each.
   //
-  // Requires ≥5 ranked active players in the cohort so completing the set is
-  // a real feat, matching the gate used by the rank achievements. The earner
+  // Requires ≥5 ranked players in the cohort so completing the set is a real
+  // feat, matching the gate used by the rank achievements. The earner
   // does NOT need to be ranked themselves — an unranked player who has beaten
   // (or lost to) the whole ranked field still qualifies. Each is awarded
   // once, stamped at the moment the set completes, recording how many players
@@ -595,8 +595,8 @@ export class Achievements {
       set.add(value);
     };
 
-    // The ranked active cohort at `atTime`: players with ≥ gameLimit games so
-    // far who are active at that moment.
+    // The ranked cohort at `atTime`: players with ≥ gameLimit games so far
+    // who are active at that moment (a deactivated player is not ranked).
     const cohortAt = (atTime: number): Set<string> => {
       const cohort = new Set<string>();
       for (const [id, games] of totalGames) {
@@ -2089,8 +2089,8 @@ export class Achievements {
     }
 
     // Full House / Humbled progression: how many of the currently ranked
-    // active players (excluding the player themselves) this player has
-    // beaten / lost to. Target is the total number of currently ranked
+    // players (excluding the player themselves) this player has beaten /
+    // lost to. Target is the total number of currently ranked
     // players, minus one when the player is ranked themselves — i.e. the
     // exact set they must complete to earn the achievement. Neither is
     // earnable until at least 5 players are ranked, so while the ranked
@@ -2254,8 +2254,8 @@ type WelcomeCommitteeProgression = ProgressionWithTarget & {
 };
 
 type MissingPlayersProgression = ProgressionWithTarget & {
-  // Currently ranked active players the player has not yet beaten (Full
-  // House) / not yet lost to (Humbled) — i.e. what's left to complete the set.
+  // Currently ranked players the player has not yet beaten (Full House) /
+  // not yet lost to (Humbled) — i.e. what's left to complete the set.
   missing?: Set<string>;
 };
 

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -2067,8 +2067,9 @@ export class Achievements {
 
     // Full House / Humbled progression: how many of the currently ranked
     // active players (excluding the player themselves) this player has
-    // beaten / lost to. Target is the size of that cohort, so it always
-    // matches the set they must complete to earn the achievement.
+    // beaten / lost to. Target is the total number of currently ranked
+    // players, minus one when the player is ranked themselves — i.e. the
+    // exact set they must complete to earn the achievement.
     const rankedActiveIds = this.parent.leaderboard.getLeaderboard().rankedPlayers.map((p) => p.id);
     const rankedTargetPool = new Set(rankedActiveIds.filter((id) => id !== playerId));
     const beatenRanked = new Set<string>();
@@ -2077,7 +2078,7 @@ export class Achievements {
       if (game.winner === playerId && rankedTargetPool.has(game.loser)) beatenRanked.add(game.loser);
       if (game.loser === playerId && rankedTargetPool.has(game.winner)) lostToRanked.add(game.winner);
     });
-    const rankedTarget = Math.max(rankedTargetPool.size, 1);
+    const rankedTarget = rankedTargetPool.size;
     progression["full-house"].current = beatenRanked.size;
     progression["full-house"].target = rankedTarget;
     progression["humbled"].current = lostToRanked.size;

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -525,61 +525,140 @@ export class Achievements {
 
   // Awards "Full House" (beat every currently ranked active player at least
   // once) and "Humbled" (lose to every currently ranked active player at
-  // least once). The target cohort is the CURRENT leaderboard — the set of
-  // ranked active players right now — so beating/losing to a player who has
-  // since dropped off the leaderboard no longer counts, while any historical
-  // result against a currently-ranked player does. Requires ≥5 ranked active
-  // players so completing the set is a real feat, matching the cohort gate
-  // used by the rank achievements. Each is awarded once, at the game that
-  // completes the set.
+  // least once). The target cohort is the set of ranked active players AT THE
+  // MOMENT being evaluated, which shifts as players cross the ranked
+  // threshold or are deactivated / reactivated. A win / loss counts whenever
+  // it happened (even before the opponent was ranked); what matters is the
+  // opponent belongs to the cohort at the time of the check.
+  //
+  // Because the cohort shrinks when a player is deactivated, either
+  // achievement can be earned by a DEACTIVATION rather than a game: if the
+  // deactivated player was the only ranked player you had not yet beaten
+  // (or lost to), the set completes the instant they drop off the
+  // leaderboard. To catch that, games and active-state changes are replayed
+  // in time order and the whole ranked cohort is re-checked after each.
+  //
+  // Requires ≥5 ranked active players in the cohort so completing the set is
+  // a real feat, matching the gate used by the rank achievements. The earner
+  // must themselves be a ranked active player at the time. Each is awarded
+  // once, stamped at the moment the set completes.
   #checkFullHouseAndHumbledAchievements() {
-    const rankedActive = this.parent.leaderboard.getLeaderboard().rankedPlayers.map((p) => p.id);
-    if (rankedActive.length < 5) return;
-    const rankedSet = new Set(rankedActive);
+    const gameLimit = this.parent.client.gameLimitForRanked;
 
-    // Per-player sets of currently-ranked-active opponents beaten / lost to.
+    // Per-player active-status timeline (same construction as the Elo pass).
+    type Transition = { time: number; active: boolean };
+    const timelines = new Map<string, Transition[]>();
+    for (const event of this.parent.events) {
+      let transition: Transition | null = null;
+      if (event.type === EventTypeEnum.PLAYER_CREATED) {
+        transition = { time: event.time, active: true };
+      } else if (event.type === EventTypeEnum.PLAYER_DEACTIVATED) {
+        transition = { time: event.time, active: false };
+      } else if (event.type === EventTypeEnum.PLAYER_REACTIVATED) {
+        transition = { time: event.time, active: true };
+      }
+      if (transition) {
+        const list = timelines.get(event.stream);
+        if (list) list.push(transition);
+        else timelines.set(event.stream, [transition]);
+      }
+    }
+    for (const list of timelines.values()) list.sort((a, b) => a.time - b.time);
+
+    const isActiveAt = (playerId: string, atTime: number): boolean => {
+      const tl = timelines.get(playerId);
+      if (!tl || tl.length === 0) return false;
+      let active = false;
+      for (const t of tl) {
+        if (t.time > atTime) break;
+        active = t.active;
+      }
+      return active;
+    };
+
+    const totalGames = new Map<string, number>();
     const beaten = new Map<string, Set<string>>();
     const lostTo = new Map<string, Set<string>>();
     const fullHouseAwarded = new Set<string>();
     const humbledAwarded = new Set<string>();
 
-    const targetSizeFor = (playerId: string) => rankedSet.size - (rankedSet.has(playerId) ? 1 : 0);
+    const addEdge = (map: Map<string, Set<string>>, key: string, value: string) => {
+      let set = map.get(key);
+      if (!set) {
+        set = new Set();
+        map.set(key, set);
+      }
+      set.add(value);
+    };
 
-    this.parent.games.forEach((game) => {
-      // Full House for the winner: they just beat a ranked active player.
-      if (rankedSet.has(game.loser) && !fullHouseAwarded.has(game.winner)) {
-        let set = beaten.get(game.winner);
-        if (!set) {
-          set = new Set();
-          beaten.set(game.winner, set);
+    // The ranked active cohort at `atTime`: players with ≥ gameLimit games so
+    // far who are active at that moment.
+    const cohortAt = (atTime: number): Set<string> => {
+      const cohort = new Set<string>();
+      for (const [id, games] of totalGames) {
+        if (games < gameLimit) continue;
+        if (!isActiveAt(id, atTime)) continue;
+        cohort.add(id);
+      }
+      return cohort;
+    };
+
+    // Whether `playerId` has an edge to every OTHER member of `cohort`.
+    const coversCohort = (edges: Set<string> | undefined, cohort: Set<string>, playerId: string): boolean => {
+      if (!edges) return false;
+      for (const target of cohort) {
+        if (target === playerId) continue;
+        if (!edges.has(target)) return false;
+      }
+      return true;
+    };
+
+    const recheckAt = (time: number) => {
+      const cohort = cohortAt(time);
+      if (cohort.size < 5) return;
+      for (const playerId of cohort) {
+        if (!fullHouseAwarded.has(playerId) && coversCohort(beaten.get(playerId), cohort, playerId)) {
+          fullHouseAwarded.add(playerId);
+          this.#addAchievement(playerId, this.#createAchievement("full-house", playerId, time, undefined));
         }
-        set.add(game.loser);
-        if (set.size === targetSizeFor(game.winner)) {
-          fullHouseAwarded.add(game.winner);
-          this.#addAchievement(
-            game.winner,
-            this.#createAchievement("full-house", game.winner, game.playedAt, undefined),
-          );
+        if (!humbledAwarded.has(playerId) && coversCohort(lostTo.get(playerId), cohort, playerId)) {
+          humbledAwarded.add(playerId);
+          this.#addAchievement(playerId, this.#createAchievement("humbled", playerId, time, undefined));
         }
       }
+    };
 
-      // Humbled for the loser: they just lost to a ranked active player.
-      if (rankedSet.has(game.winner) && !humbledAwarded.has(game.loser)) {
-        let set = lostTo.get(game.loser);
-        if (!set) {
-          set = new Set();
-          lostTo.set(game.loser, set);
-        }
-        set.add(game.winner);
-        if (set.size === targetSizeFor(game.loser)) {
-          humbledAwarded.add(game.loser);
-          this.#addAchievement(
-            game.loser,
-            this.#createAchievement("humbled", game.loser, game.playedAt, undefined),
-          );
-        }
+    // Replay games and active-state changes in time order. Games at the same
+    // instant as a state change are applied first so the recheck sees the
+    // post-game totals. A game recheck can newly complete the winner/loser
+    // (or, via a threshold crossing, anyone); a state-change recheck can
+    // complete a player whose last missing opponent just left the cohort.
+    type Action = { kind: "game"; time: number; game: Game } | { kind: "recheck"; time: number };
+    const actions: Action[] = [];
+    for (const g of this.parent.games) {
+      actions.push({ kind: "game", time: g.playedAt, game: g });
+    }
+    for (const e of this.parent.events) {
+      if (e.type === EventTypeEnum.PLAYER_DEACTIVATED || e.type === EventTypeEnum.PLAYER_REACTIVATED) {
+        actions.push({ kind: "recheck", time: e.time });
       }
+    }
+    actions.sort((a, b) => {
+      if (a.time !== b.time) return a.time - b.time;
+      if (a.kind === b.kind) return 0;
+      return a.kind === "game" ? -1 : 1;
     });
+
+    for (const action of actions) {
+      if (action.kind === "game") {
+        const game = action.game;
+        totalGames.set(game.winner, (totalGames.get(game.winner) ?? 0) + 1);
+        totalGames.set(game.loser, (totalGames.get(game.loser) ?? 0) + 1);
+        addEdge(beaten, game.winner, game.loser);
+        addEdge(lostTo, game.loser, game.winner);
+      }
+      recheckAt(action.time);
+    }
   }
 
   /**

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -540,8 +540,11 @@ export class Achievements {
   //
   // Requires ≥5 ranked active players in the cohort so completing the set is
   // a real feat, matching the gate used by the rank achievements. The earner
-  // must themselves be a ranked active player at the time. Each is awarded
-  // once, stamped at the moment the set completes.
+  // does NOT need to be ranked themselves — an unranked player who has beaten
+  // (or lost to) the whole ranked field still qualifies. Each is awarded
+  // once, stamped at the moment the set completes, recording how many players
+  // were beaten / lost to and the player's first game (so the display can
+  // show how long it took).
   #checkFullHouseAndHumbledAchievements() {
     const gameLimit = this.parent.client.gameLimitForRanked;
 
@@ -577,6 +580,7 @@ export class Achievements {
     };
 
     const totalGames = new Map<string, number>();
+    const firstGameAt = new Map<string, number>();
     const beaten = new Map<string, Set<string>>();
     const lostTo = new Map<string, Set<string>>();
     const fullHouseAwarded = new Set<string>();
@@ -616,14 +620,31 @@ export class Achievements {
     const recheckAt = (time: number) => {
       const cohort = cohortAt(time);
       if (cohort.size < 5) return;
-      for (const playerId of cohort) {
+      // Candidates are everyone who has played a game — the earner need not
+      // be part of the ranked cohort themselves. When the earner IS ranked
+      // they are excluded from their own target (they can't beat themselves),
+      // so the number to beat / lose to is the cohort minus one.
+      for (const playerId of totalGames.keys()) {
+        const targetCount = cohort.size - (cohort.has(playerId) ? 1 : 0);
         if (!fullHouseAwarded.has(playerId) && coversCohort(beaten.get(playerId), cohort, playerId)) {
           fullHouseAwarded.add(playerId);
-          this.#addAchievement(playerId, this.#createAchievement("full-house", playerId, time, undefined));
+          this.#addAchievement(
+            playerId,
+            this.#createAchievement("full-house", playerId, time, {
+              count: targetCount,
+              firstGameAt: firstGameAt.get(playerId)!,
+            }),
+          );
         }
         if (!humbledAwarded.has(playerId) && coversCohort(lostTo.get(playerId), cohort, playerId)) {
           humbledAwarded.add(playerId);
-          this.#addAchievement(playerId, this.#createAchievement("humbled", playerId, time, undefined));
+          this.#addAchievement(
+            playerId,
+            this.#createAchievement("humbled", playerId, time, {
+              count: targetCount,
+              firstGameAt: firstGameAt.get(playerId)!,
+            }),
+          );
         }
       }
     };
@@ -654,6 +675,8 @@ export class Achievements {
         const game = action.game;
         totalGames.set(game.winner, (totalGames.get(game.winner) ?? 0) + 1);
         totalGames.set(game.loser, (totalGames.get(game.loser) ?? 0) + 1);
+        if (!firstGameAt.has(game.winner)) firstGameAt.set(game.winner, game.playedAt);
+        if (!firstGameAt.has(game.loser)) firstGameAt.set(game.loser, game.playedAt);
         addEdge(beaten, game.winner, game.loser);
         addEdge(lostTo, game.loser, game.winner);
       }
@@ -2069,15 +2092,20 @@ export class Achievements {
     // active players (excluding the player themselves) this player has
     // beaten / lost to. Target is the total number of currently ranked
     // players, minus one when the player is ranked themselves — i.e. the
-    // exact set they must complete to earn the achievement.
+    // exact set they must complete to earn the achievement. Neither is
+    // earnable until at least 5 players are ranked, so while the ranked
+    // field is smaller than that the progress is shown as 0.
     const rankedActiveIds = this.parent.leaderboard.getLeaderboard().rankedPlayers.map((p) => p.id);
     const rankedTargetPool = new Set(rankedActiveIds.filter((id) => id !== playerId));
+    const enoughRanked = rankedActiveIds.length >= 5;
     const beatenRanked = new Set<string>();
     const lostToRanked = new Set<string>();
-    this.parent.games.forEach((game) => {
-      if (game.winner === playerId && rankedTargetPool.has(game.loser)) beatenRanked.add(game.loser);
-      if (game.loser === playerId && rankedTargetPool.has(game.winner)) lostToRanked.add(game.winner);
-    });
+    if (enoughRanked) {
+      this.parent.games.forEach((game) => {
+        if (game.winner === playerId && rankedTargetPool.has(game.loser)) beatenRanked.add(game.loser);
+        if (game.loser === playerId && rankedTargetPool.has(game.winner)) lostToRanked.add(game.winner);
+      });
+    }
     const rankedTarget = rankedTargetPool.size;
     progression["full-house"].current = beatenRanked.size;
     progression["full-house"].target = rankedTarget;
@@ -2165,8 +2193,8 @@ type AchievementDefinitions = {
   };
   "streak-ender": { opponent: string; gameId: string; streakLength: number };
   "group-stage-star": { tournamentId: string; wins: number };
-  "full-house": undefined;
-  "humbled": undefined;
+  "full-house": { count: number; firstGameAt: number };
+  "humbled": { count: number; firstGameAt: number };
 };
 
 type AchievementType = keyof AchievementDefinitions;

--- a/frontend/src/pages/achievements/achievements-list.tsx
+++ b/frontend/src/pages/achievements/achievements-list.tsx
@@ -213,6 +213,18 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                       {achievement.data.wins !== 1 ? "s" : ""})
                     </span>
                   )}
+                  {(achievement.type === "full-house" || achievement.type === "humbled") &&
+                    achievement.data && (
+                      <span className="text-[11px] opacity-80">
+                        {achievement.type === "full-house" ? "Beat " : "Lost to "}
+                        {achievement.data.count} ranked player
+                        {achievement.data.count !== 1 ? "s" : ""} in{" "}
+                        {Math.round(
+                          (achievement.earnedAt - achievement.data.firstGameAt) / (24 * 60 * 60 * 1000),
+                        )}{" "}
+                        days
+                      </span>
+                    )}
                   {achievement.type === "leap-frog" && achievement.data && (
                     <span className="text-[11px] opacity-80">
                       #{achievement.data.fromRank} → #{achievement.data.toRank} (

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -748,6 +748,27 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                           </div>
                         )}
 
+                      {/* Missing players for full-house / humbled */}
+                      {(type === "full-house" || type === "humbled") &&
+                        "missing" in data &&
+                        data.missing &&
+                        data.missing.size > 0 && (
+                          <div className="mt-3 pt-3 border-t border-secondary-text/50">
+                            <p className="text-xs text-secondary-text/70 mb-2">
+                              {type === "full-house" ? "Still need to beat:" : "Still need to lose to:"}
+                            </p>
+                            <div className="flex flex-wrap gap-1">
+                              {Array.from(data.missing).map((player: string) => (
+                                <Link to={"/player/" + player} key={player}>
+                                  <span className="text-xs bg-background px-2 py-1 rounded text-secondary-text">
+                                    {context.playerName(player)}
+                                  </span>
+                                </Link>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+
                       {/* Record holder for marathon-set */}
                       {type === "marathon-set" && "recordHolder" in data && (
                         <div className="mt-2 text-xs text-secondary-text/70">

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -233,6 +233,16 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
     description: "Go undefeated in a tournament group stage",
     icon: "⭐",
   },
+  "full-house": {
+    title: "Full House",
+    description: "Beat every currently ranked active player at least once",
+    icon: "🃏",
+  },
+  "humbled": {
+    title: "Humbled",
+    description: "Lose to every currently ranked active player at least once",
+    icon: "🙇",
+  },
 };
 
 // Resolves the display label for an achievement type, filling in any

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -235,12 +235,12 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
   },
   "full-house": {
     title: "Full House",
-    description: "Beat every currently ranked active player at least once",
+    description: "Beat every currently ranked player at least once",
     icon: "🃏",
   },
   "humbled": {
     title: "Humbled",
-    description: "Lose to every currently ranked active player at least once",
+    description: "Lose to every currently ranked player at least once",
     icon: "🙇",
   },
 };

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -492,6 +492,14 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
                   </p>
                 )}
 
+                {(achievement.type === "full-house" || achievement.type === "humbled") && achievement.data && (
+                  <p className="text-xs text-secondary-text/70 mt-2">
+                    {achievement.type === "full-house" ? "Beat " : "Lost to "}
+                    {achievement.data.count} ranked player{achievement.data.count !== 1 ? "s" : ""} in{" "}
+                    {daysBetween(achievement.data.firstGameAt, achievement.earnedAt)} days
+                  </p>
+                )}
+
                 {achievement.type === "leap-frog" && achievement.data && (
                   <div className="text-xs text-secondary-text/70 mt-2 space-y-1">
                     <p>Beat {context.playerName(achievement.data.opponent)}</p>


### PR DESCRIPTION
Implements two of the shortlisted achievement suggestions:

- Full House 🃏: beat every currently ranked active player at least once
- Humbled 🙇: lose to every currently ranked active player at least once

The target cohort is the current leaderboard (ranked active players now),
so historical results against players who have since dropped off no longer
count, while any past result against a currently-ranked player does. Both
require ≥5 ranked active players to be earnable, matching the cohort gate
used by the existing rank achievements, and each is awarded once at the game
that completes the set.

Adds calculation, progression tracking, display labels, and tests. Removes
the two implemented ideas from achievement-suggestions.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UNFV69iuqVM5rHGg3JuNRk