### PR TITLE
Add Perfect Day and Perfect Week achievements

### DIFF
--- a/achievement-suggestions.md
+++ b/achievement-suggestions.md
@@ -21,20 +21,17 @@ Climb 100 Score in a single calendar week.
 ## 6. Yin Yang ☯️
 Alternate Win/Loss/Win/Loss for 10 games straight.
 
-## 7. Perfect Day ☀️
-Go undefeated across 5+ games in a single day.
-
-## 8. Worst Day 🌧️
+## 7. Worst Day 🌧️
 Lose 5+ games in a single day without a win.
 
-## 9. Tour de Table 🚲
+## 8. Tour de Table 🚲
 Play against 5 different opponents in a single day.
 
-## 10. Late Bloomer 🌷
+## 9. Late Bloomer 🌷
 Enter a season's top 3 only in its final week.
 
-## 11. Founding Member 🪴
+## 10. Founding Member 🪴
 Be among the first 5 players ever created in the league.
 
-## 12. Block Party 🎉
+## 11. Block Party 🎉
 Play on a day where every currently active ranked player also plays.

--- a/frontend/src/client/client-db/__tests__/achievements/perfect-day.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/perfect-day.test.ts
@@ -111,18 +111,69 @@ describe("Perfect Day Achievement Tests", () => {
     expect(perfectDays).toHaveLength(2);
   });
 
-  it("tracks progression toward perfect-day (best undefeated day)", () => {
-    const events: EventType[] = [
-      ...baseEvents,
-      ...winsOnDay(2024, 0, 15, "player-1", ["player-2", "player-3", "player-2"], "g"),
-    ];
+  describe("Progression (live, resets each day)", () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
 
-    const tennisTable = new TennisTable({ events });
-    tennisTable.achievements.calculateAchievements();
+    it("tracks today's wins toward perfect-day", () => {
+      // Pretend "now" is Monday Jan 15 2024, 20:00.
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2024, 0, 15, 20));
 
-    const progression = tennisTable.achievements.getPlayerProgression("player-1");
-    expect(progression["perfect-day"].current).toBe(3);
-    expect(progression["perfect-day"].target).toBe(5);
-    expect(progression["perfect-day"].earned).toBe(0);
+      const events: EventType[] = [
+        ...baseEvents,
+        ...winsOnDay(2024, 0, 15, "player-1", ["player-2", "player-3", "player-2"], "g"),
+      ];
+
+      const tennisTable = new TennisTable({ events });
+      tennisTable.achievements.calculateAchievements();
+
+      const progression = tennisTable.achievements.getPlayerProgression("player-1");
+      expect(progression["perfect-day"].current).toBe(3);
+      expect(progression["perfect-day"].target).toBe(5);
+      expect(progression["perfect-day"].earned).toBe(0);
+    });
+
+    it("nullifies progress to 0 as soon as a game is lost today", () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2024, 0, 15, 20));
+
+      const wins = winsOnDay(2024, 0, 15, "player-1", ["player-2", "player-3", "player-2"], "g");
+      const lossAt = new Date(2024, 0, 15, 15).getTime();
+      const events: EventType[] = [
+        ...baseEvents,
+        ...wins,
+        {
+          time: lossAt,
+          stream: "g-loss",
+          type: EventTypeEnum.GAME_CREATED,
+          data: { playedAt: lossAt, winner: "player-2", loser: "player-1" },
+        },
+      ];
+
+      const tennisTable = new TennisTable({ events });
+      tennisTable.achievements.calculateAchievements();
+
+      const progression = tennisTable.achievements.getPlayerProgression("player-1");
+      expect(progression["perfect-day"].current).toBe(0);
+    });
+
+    it("resets to 0 the next day (yesterday's wins do not carry over)", () => {
+      // "now" is the day AFTER the winning day.
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2024, 0, 16, 8));
+
+      const events: EventType[] = [
+        ...baseEvents,
+        ...winsOnDay(2024, 0, 15, "player-1", ["player-2", "player-3", "player-2"], "g"),
+      ];
+
+      const tennisTable = new TennisTable({ events });
+      tennisTable.achievements.calculateAchievements();
+
+      const progression = tennisTable.achievements.getPlayerProgression("player-1");
+      expect(progression["perfect-day"].current).toBe(0);
+    });
   });
 });

--- a/frontend/src/client/client-db/__tests__/achievements/perfect-day.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/perfect-day.test.ts
@@ -1,0 +1,128 @@
+import { TennisTable } from "../../tennis-table";
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+
+describe("Perfect Day Achievement Tests", () => {
+  let baseEvents: EventType[];
+
+  beforeEach(() => {
+    baseEvents = [
+      { time: 1000, stream: "player-1", type: EventTypeEnum.PLAYER_CREATED, data: { name: "Alice" } },
+      { time: 2000, stream: "player-2", type: EventTypeEnum.PLAYER_CREATED, data: { name: "Bob" } },
+      { time: 3000, stream: "player-3", type: EventTypeEnum.PLAYER_CREATED, data: { name: "Charlie" } },
+    ];
+  });
+
+  // Games at 09:00, 10:00, ... on the given local calendar day.
+  function winsOnDay(
+    year: number,
+    month: number,
+    day: number,
+    winner: string,
+    losers: string[],
+    streamPrefix: string,
+  ): EventType[] {
+    return losers.map((loser, i) => {
+      const playedAt = new Date(year, month, day, 9 + i).getTime();
+      return {
+        time: playedAt,
+        stream: `${streamPrefix}-${i}`,
+        type: EventTypeEnum.GAME_CREATED,
+        data: { playedAt, winner, loser },
+      };
+    });
+  }
+
+  it("awards perfect-day for 5 undefeated games in a single day", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      ...winsOnDay(2024, 0, 15, "player-1", ["player-2", "player-3", "player-2", "player-3", "player-2"], "g"),
+    ];
+
+    const tennisTable = new TennisTable({ events });
+    tennisTable.achievements.calculateAchievements();
+
+    const perfectDays = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-day");
+    expect(perfectDays).toHaveLength(1);
+    expect(perfectDays[0].data.wins).toBe(5);
+    // Earned at the last (5th) win of the day: 09:00 + 4 hours = 13:00.
+    expect(perfectDays[0].earnedAt).toBe(new Date(2024, 0, 15, 13).getTime());
+  });
+
+  it("does NOT award for only 4 wins in a day", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      ...winsOnDay(2024, 0, 15, "player-1", ["player-2", "player-3", "player-2", "player-3"], "g"),
+    ];
+
+    const tennisTable = new TennisTable({ events });
+    tennisTable.achievements.calculateAchievements();
+
+    const perfectDays = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-day");
+    expect(perfectDays).toHaveLength(0);
+  });
+
+  it("does NOT award if the player loses a game that same day", () => {
+    const wins = winsOnDay(2024, 0, 15, "player-1", ["player-2", "player-3", "player-2", "player-3", "player-2"], "g");
+    // One loss the same day (17:00).
+    const lossAt = new Date(2024, 0, 15, 17).getTime();
+    const events: EventType[] = [
+      ...baseEvents,
+      ...wins,
+      {
+        time: lossAt,
+        stream: "g-loss",
+        type: EventTypeEnum.GAME_CREATED,
+        data: { playedAt: lossAt, winner: "player-2", loser: "player-1" },
+      },
+    ];
+
+    const tennisTable = new TennisTable({ events });
+    tennisTable.achievements.calculateAchievements();
+
+    const perfectDays = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-day");
+    expect(perfectDays).toHaveLength(0);
+  });
+
+  it("does NOT award when 5 wins are spread across two days", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      ...winsOnDay(2024, 0, 15, "player-1", ["player-2", "player-3", "player-2"], "d1"),
+      ...winsOnDay(2024, 0, 16, "player-1", ["player-3", "player-2"], "d2"),
+    ];
+
+    const tennisTable = new TennisTable({ events });
+    tennisTable.achievements.calculateAchievements();
+
+    const perfectDays = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-day");
+    expect(perfectDays).toHaveLength(0);
+  });
+
+  it("awards perfect-day once per qualifying day (earnable multiple times)", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      ...winsOnDay(2024, 0, 15, "player-1", ["player-2", "player-3", "player-2", "player-3", "player-2"], "d1"),
+      ...winsOnDay(2024, 0, 20, "player-1", ["player-3", "player-2", "player-3", "player-2", "player-3"], "d2"),
+    ];
+
+    const tennisTable = new TennisTable({ events });
+    tennisTable.achievements.calculateAchievements();
+
+    const perfectDays = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-day");
+    expect(perfectDays).toHaveLength(2);
+  });
+
+  it("tracks progression toward perfect-day (best undefeated day)", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      ...winsOnDay(2024, 0, 15, "player-1", ["player-2", "player-3", "player-2"], "g"),
+    ];
+
+    const tennisTable = new TennisTable({ events });
+    tennisTable.achievements.calculateAchievements();
+
+    const progression = tennisTable.achievements.getPlayerProgression("player-1");
+    expect(progression["perfect-day"].current).toBe(3);
+    expect(progression["perfect-day"].target).toBe(5);
+    expect(progression["perfect-day"].earned).toBe(0);
+  });
+});

--- a/frontend/src/client/client-db/__tests__/achievements/perfect-week.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/perfect-week.test.ts
@@ -1,0 +1,159 @@
+import { TennisTable } from "../../tennis-table";
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+
+// Jan 15 2024 is a Monday, so 15=Mon, 16=Tue, 17=Wed, 18=Thu, 19=Fri,
+// 20=Sat, 21=Sun. Jan 22 2024 is the following Monday.
+describe("Perfect Week Achievement Tests", () => {
+  let baseEvents: EventType[];
+
+  beforeEach(() => {
+    baseEvents = [
+      { time: 1000, stream: "player-1", type: EventTypeEnum.PLAYER_CREATED, data: { name: "Alice" } },
+      { time: 2000, stream: "player-2", type: EventTypeEnum.PLAYER_CREATED, data: { name: "Bob" } },
+    ];
+  });
+
+  // A win for `winner` at 12:00 on the given local calendar day.
+  function win(year: number, month: number, day: number, winner: string, loser: string, stream: string): EventType {
+    const playedAt = new Date(year, month, day, 12).getTime();
+    return {
+      time: playedAt,
+      stream,
+      type: EventTypeEnum.GAME_CREATED,
+      data: { playedAt, winner, loser },
+    };
+  }
+
+  it("awards perfect-week for a win on every weekday Mon–Fri", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      win(2024, 0, 15, "player-1", "player-2", "mon"),
+      win(2024, 0, 16, "player-1", "player-2", "tue"),
+      win(2024, 0, 17, "player-1", "player-2", "wed"),
+      win(2024, 0, 18, "player-1", "player-2", "thu"),
+      win(2024, 0, 19, "player-1", "player-2", "fri"),
+    ];
+
+    const tennisTable = new TennisTable({ events });
+    tennisTable.achievements.calculateAchievements();
+
+    const perfectWeeks = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-week");
+    expect(perfectWeeks).toHaveLength(1);
+    expect(perfectWeeks[0].data.weekStart).toBe(new Date(2024, 0, 15).getTime());
+    // Earned at the Friday win that completed the set.
+    expect(perfectWeeks[0].earnedAt).toBe(new Date(2024, 0, 19, 12).getTime());
+  });
+
+  it("does NOT award when only Mon–Thu are won", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      win(2024, 0, 15, "player-1", "player-2", "mon"),
+      win(2024, 0, 16, "player-1", "player-2", "tue"),
+      win(2024, 0, 17, "player-1", "player-2", "wed"),
+      win(2024, 0, 18, "player-1", "player-2", "thu"),
+    ];
+
+    const tennisTable = new TennisTable({ events });
+    tennisTable.achievements.calculateAchievements();
+
+    const perfectWeeks = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-week");
+    expect(perfectWeeks).toHaveLength(0);
+  });
+
+  it("does NOT count weekend wins toward the working week", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      win(2024, 0, 15, "player-1", "player-2", "mon"),
+      win(2024, 0, 16, "player-1", "player-2", "tue"),
+      win(2024, 0, 17, "player-1", "player-2", "wed"),
+      win(2024, 0, 18, "player-1", "player-2", "thu"),
+      // Saturday + Sunday wins — do not substitute for Friday.
+      win(2024, 0, 20, "player-1", "player-2", "sat"),
+      win(2024, 0, 21, "player-1", "player-2", "sun"),
+    ];
+
+    const tennisTable = new TennisTable({ events });
+    tennisTable.achievements.calculateAchievements();
+
+    const perfectWeeks = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-week");
+    expect(perfectWeeks).toHaveLength(0);
+  });
+
+  it("does NOT award when weekday wins are split across two different weeks", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      // Week 1: Mon, Tue, Wed
+      win(2024, 0, 15, "player-1", "player-2", "w1-mon"),
+      win(2024, 0, 16, "player-1", "player-2", "w1-tue"),
+      win(2024, 0, 17, "player-1", "player-2", "w1-wed"),
+      // Week 2: Thu, Fri
+      win(2024, 0, 25, "player-1", "player-2", "w2-thu"),
+      win(2024, 0, 26, "player-1", "player-2", "w2-fri"),
+    ];
+
+    const tennisTable = new TennisTable({ events });
+    tennisTable.achievements.calculateAchievements();
+
+    const perfectWeeks = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-week");
+    expect(perfectWeeks).toHaveLength(0);
+  });
+
+  it("awards a separate perfect-week for each qualifying week", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      // Week of Jan 15
+      win(2024, 0, 15, "player-1", "player-2", "w1-mon"),
+      win(2024, 0, 16, "player-1", "player-2", "w1-tue"),
+      win(2024, 0, 17, "player-1", "player-2", "w1-wed"),
+      win(2024, 0, 18, "player-1", "player-2", "w1-thu"),
+      win(2024, 0, 19, "player-1", "player-2", "w1-fri"),
+      // Week of Jan 22
+      win(2024, 0, 22, "player-1", "player-2", "w2-mon"),
+      win(2024, 0, 23, "player-1", "player-2", "w2-tue"),
+      win(2024, 0, 24, "player-1", "player-2", "w2-wed"),
+      win(2024, 0, 25, "player-1", "player-2", "w2-thu"),
+      win(2024, 0, 26, "player-1", "player-2", "w2-fri"),
+    ];
+
+    const tennisTable = new TennisTable({ events });
+    tennisTable.achievements.calculateAchievements();
+
+    const perfectWeeks = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-week");
+    expect(perfectWeeks).toHaveLength(2);
+  });
+
+  it("only counts wins, not losses, toward a weekday", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      win(2024, 0, 15, "player-1", "player-2", "mon"),
+      win(2024, 0, 16, "player-1", "player-2", "tue"),
+      win(2024, 0, 17, "player-1", "player-2", "wed"),
+      win(2024, 0, 18, "player-1", "player-2", "thu"),
+      // Friday: player-1 LOSES — does not count as a Friday win.
+      win(2024, 0, 19, "player-2", "player-1", "fri"),
+    ];
+
+    const tennisTable = new TennisTable({ events });
+    tennisTable.achievements.calculateAchievements();
+
+    const perfectWeeks = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-week");
+    expect(perfectWeeks).toHaveLength(0);
+  });
+
+  it("tracks progression toward perfect-week (distinct weekdays won)", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      win(2024, 0, 15, "player-1", "player-2", "mon"),
+      win(2024, 0, 17, "player-1", "player-2", "wed"),
+      win(2024, 0, 19, "player-1", "player-2", "fri"),
+    ];
+
+    const tennisTable = new TennisTable({ events });
+    tennisTable.achievements.calculateAchievements();
+
+    const progression = tennisTable.achievements.getPlayerProgression("player-1");
+    expect(progression["perfect-week"].current).toBe(3);
+    expect(progression["perfect-week"].target).toBe(5);
+    expect(progression["perfect-week"].earned).toBe(0);
+  });
+});

--- a/frontend/src/client/client-db/__tests__/achievements/perfect-week.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/perfect-week.test.ts
@@ -140,20 +140,80 @@ describe("Perfect Week Achievement Tests", () => {
     expect(perfectWeeks).toHaveLength(0);
   });
 
-  it("tracks progression toward perfect-week (distinct weekdays won)", () => {
-    const events: EventType[] = [
-      ...baseEvents,
-      win(2024, 0, 15, "player-1", "player-2", "mon"),
-      win(2024, 0, 17, "player-1", "player-2", "wed"),
-      win(2024, 0, 19, "player-1", "player-2", "fri"),
-    ];
+  describe("Progression (live, resets on a missed weekday)", () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
 
-    const tennisTable = new TennisTable({ events });
-    tennisTable.achievements.calculateAchievements();
+    it("a Monday win reads 1/5 and holds through Tuesday", () => {
+      // "now" is Tuesday afternoon; only Monday has been won so far.
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2024, 0, 16, 15));
 
-    const progression = tennisTable.achievements.getPlayerProgression("player-1");
-    expect(progression["perfect-week"].current).toBe(3);
-    expect(progression["perfect-week"].target).toBe(5);
-    expect(progression["perfect-week"].earned).toBe(0);
+      const events: EventType[] = [...baseEvents, win(2024, 0, 15, "player-1", "player-2", "mon")];
+
+      const tennisTable = new TennisTable({ events });
+      tennisTable.achievements.calculateAchievements();
+
+      const progression = tennisTable.achievements.getPlayerProgression("player-1");
+      expect(progression["perfect-week"].current).toBe(1);
+      expect(progression["perfect-week"].target).toBe(5);
+      expect(progression["perfect-week"].earned).toBe(0);
+    });
+
+    it("counts the current weekday once it is won (Mon+Tue on Tuesday = 2/5)", () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2024, 0, 16, 20));
+
+      const events: EventType[] = [
+        ...baseEvents,
+        win(2024, 0, 15, "player-1", "player-2", "mon"),
+        win(2024, 0, 16, "player-1", "player-2", "tue"),
+      ];
+
+      const tennisTable = new TennisTable({ events });
+      tennisTable.achievements.calculateAchievements();
+
+      const progression = tennisTable.achievements.getPlayerProgression("player-1");
+      expect(progression["perfect-week"].current).toBe(2);
+    });
+
+    it("drops to 0 on Wednesday when Tuesday passed with no win", () => {
+      // "now" is Wednesday; Monday and Wednesday won, but Tuesday was missed.
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2024, 0, 17, 12));
+
+      const events: EventType[] = [
+        ...baseEvents,
+        win(2024, 0, 15, "player-1", "player-2", "mon"),
+        win(2024, 0, 17, "player-1", "player-2", "wed"),
+      ];
+
+      const tennisTable = new TennisTable({ events });
+      tennisTable.achievements.calculateAchievements();
+
+      const progression = tennisTable.achievements.getPlayerProgression("player-1");
+      expect(progression["perfect-week"].current).toBe(0);
+    });
+
+    it("resets to 0 the following week (last week's wins do not carry over)", () => {
+      // "now" is the Monday after a fully-won week — new attempt, no games yet.
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2024, 0, 22, 8));
+
+      const events: EventType[] = [
+        ...baseEvents,
+        win(2024, 0, 15, "player-1", "player-2", "mon"),
+        win(2024, 0, 16, "player-1", "player-2", "tue"),
+        win(2024, 0, 17, "player-1", "player-2", "wed"),
+        win(2024, 0, 18, "player-1", "player-2", "thu"),
+      ];
+
+      const tennisTable = new TennisTable({ events });
+      tennisTable.achievements.calculateAchievements();
+
+      const progression = tennisTable.achievements.getPlayerProgression("player-1");
+      expect(progression["perfect-week"].current).toBe(0);
+    });
   });
 });

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -520,7 +520,123 @@ export class Achievements {
     this.#checkSeasonAchievements();
     this.#calculateEloAchievements();
     this.#checkFullHouseAndHumbledAchievements();
+    this.#checkPerfectDayAndWeekAchievements();
     this.hasCalculated = true;
+  }
+
+  // Awards "Perfect Day" and "Perfect Week".
+  //
+  // Perfect Day: for every calendar day (local time) on which a player
+  // played 5 or more games and won every single one of them (zero losses
+  // that day). Stamped at the day's last (winning) game.
+  //
+  // Perfect Week: for every working week (Monday–Friday, local time) in
+  // which a player won at least one game on each of the five weekdays.
+  // Wins on Saturday / Sunday do not count. Stamped at the game that
+  // completed the fifth distinct weekday.
+  //
+  // Both are earnable multiple times — once per qualifying day / week.
+  // Games are already time-ordered, so the completing win's timestamp is
+  // the natural earned-at moment.
+  #checkPerfectDayAndWeekAchievements() {
+    // Local midnight of the day containing `ms`.
+    const dayStartOf = (ms: number): number => {
+      const d = new Date(ms);
+      d.setHours(0, 0, 0, 0);
+      return d.getTime();
+    };
+    // Local Monday-midnight of the working week containing `ms`.
+    const weekStartOf = (ms: number): number => {
+      const d = new Date(ms);
+      d.setHours(0, 0, 0, 0);
+      const daysSinceMonday = (d.getDay() + 6) % 7; // getDay: 0=Sun..6=Sat
+      d.setDate(d.getDate() - daysSinceMonday);
+      return d.getTime();
+    };
+
+    type DayStats = { wins: number; losses: number; lastWinAt: number };
+    const perDay = new Map<string, Map<number, DayStats>>();
+    type WeekStats = { weekdaysWon: Set<number>; completedAt: number | null };
+    const perWeek = new Map<string, Map<number, WeekStats>>();
+
+    const getDayStats = (playerId: string, day: number): DayStats => {
+      let days = perDay.get(playerId);
+      if (!days) {
+        days = new Map();
+        perDay.set(playerId, days);
+      }
+      let stats = days.get(day);
+      if (!stats) {
+        stats = { wins: 0, losses: 0, lastWinAt: 0 };
+        days.set(day, stats);
+      }
+      return stats;
+    };
+    const getWeekStats = (playerId: string, week: number): WeekStats => {
+      let weeks = perWeek.get(playerId);
+      if (!weeks) {
+        weeks = new Map();
+        perWeek.set(playerId, weeks);
+      }
+      let stats = weeks.get(week);
+      if (!stats) {
+        stats = { weekdaysWon: new Set(), completedAt: null };
+        weeks.set(week, stats);
+      }
+      return stats;
+    };
+
+    this.parent.games.forEach((game) => {
+      const day = dayStartOf(game.playedAt);
+      const winnerDay = getDayStats(game.winner, day);
+      winnerDay.wins++;
+      winnerDay.lastWinAt = game.playedAt;
+      getDayStats(game.loser, day).losses++;
+
+      // Perfect Week only counts wins on Monday–Friday.
+      const weekday = new Date(game.playedAt).getDay(); // 0=Sun..6=Sat
+      if (weekday >= 1 && weekday <= 5) {
+        const week = weekStartOf(game.playedAt);
+        const winnerWeek = getWeekStats(game.winner, week);
+        if (!winnerWeek.weekdaysWon.has(weekday)) {
+          winnerWeek.weekdaysWon.add(weekday);
+          if (winnerWeek.weekdaysWon.size === 5 && winnerWeek.completedAt === null) {
+            winnerWeek.completedAt = game.playedAt;
+          }
+        }
+      }
+    });
+
+    // Award Perfect Day for each undefeated 5+ game day, in day order.
+    for (const [playerId, days] of perDay) {
+      const sortedDays = Array.from(days.entries()).sort((a, b) => a[0] - b[0]);
+      for (const [day, stats] of sortedDays) {
+        if (stats.losses === 0 && stats.wins >= 5) {
+          this.#addAchievement(
+            playerId,
+            this.#createAchievement("perfect-day", playerId, stats.lastWinAt, {
+              day,
+              wins: stats.wins,
+            }),
+          );
+        }
+      }
+    }
+
+    // Award Perfect Week for each week won on all five weekdays, in week order.
+    for (const [playerId, weeks] of perWeek) {
+      const sortedWeeks = Array.from(weeks.entries()).sort((a, b) => a[0] - b[0]);
+      for (const [week, stats] of sortedWeeks) {
+        if (stats.completedAt !== null) {
+          this.#addAchievement(
+            playerId,
+            this.#createAchievement("perfect-week", playerId, stats.completedAt, {
+              weekStart: week,
+            }),
+          );
+        }
+      }
+    }
   }
 
   // Awards "Full House" (beat every currently ranked player at least once)
@@ -1677,6 +1793,8 @@ export class Achievements {
       "streak-player-10": { current: 0, target: 10, perOpponent: new Map(), earned: 0 },
       "streak-player-20": { current: 0, target: 20, perOpponent: new Map(), earned: 0 },
       "hat-trick": { current: 0, target: 3, earned: 0 },
+      "perfect-day": { current: 0, target: 5, earned: 0 },
+      "perfect-week": { current: 0, target: 5, earned: 0 },
       "streak-ender": { earned: 0 },
 
       // Resilience
@@ -1751,6 +1869,10 @@ export class Achievements {
     let consistencyCount = 0;
     let bestDeuceSetWon = 0;
     const streaksPerOpponent = new Map<string, number>();
+    // Perfect Day progression: wins / losses grouped by local calendar day.
+    const perfectDayStats = new Map<number, { wins: number; losses: number }>();
+    // Perfect Week progression: distinct weekdays (Mon–Fri) won per working week.
+    const perfectWeekWeekdays = new Map<number, Set<number>>();
     const opponentsPlayed = new Set<string>();
     const gamesPerOpponent = new Map<string, { count: number; firstGame: number; lastGame: number }>();
     const firstOpponentForSet = new Set<string>();
@@ -1796,6 +1918,36 @@ export class Achievements {
 
       // Track last active time
       lastActiveAt = game.playedAt;
+
+      // Perfect Day progression: tally wins / losses per local calendar day.
+      const dayStart = new Date(game.playedAt);
+      dayStart.setHours(0, 0, 0, 0);
+      const dayKey = dayStart.getTime();
+      let dayStat = perfectDayStats.get(dayKey);
+      if (!dayStat) {
+        dayStat = { wins: 0, losses: 0 };
+        perfectDayStats.set(dayKey, dayStat);
+      }
+      if (isWinner) {
+        dayStat.wins++;
+      } else {
+        dayStat.losses++;
+      }
+
+      // Perfect Week progression: collect distinct Mon–Fri weekdays won.
+      const weekday = new Date(game.playedAt).getDay(); // 0=Sun..6=Sat
+      if (isWinner && weekday >= 1 && weekday <= 5) {
+        const weekDate = new Date(game.playedAt);
+        weekDate.setHours(0, 0, 0, 0);
+        weekDate.setDate(weekDate.getDate() - ((weekDate.getDay() + 6) % 7));
+        const weekKey = weekDate.getTime();
+        let weekdaysWon = perfectWeekWeekdays.get(weekKey);
+        if (!weekdaysWon) {
+          weekdaysWon = new Set();
+          perfectWeekWeekdays.set(weekKey, weekdaysWon);
+        }
+        weekdaysWon.add(weekday);
+      }
 
       // Track opponents
       const opponent = isWinner ? game.loser : game.winner;
@@ -1889,6 +2041,26 @@ export class Achievements {
     progression["global-player"].opponents = opponentsPlayed;
     progression["punching-bag"].current = currentLoseStreakAll;
     progression["never-give-up"].current = currentLoseStreakAll;
+
+    // Perfect Day progression: best undefeated day so far (most wins on a
+    // day with zero losses), capped at the target so it never reads > 5/5.
+    let bestUndefeatedDayWins = 0;
+    perfectDayStats.forEach((stat) => {
+      if (stat.losses === 0 && stat.wins > bestUndefeatedDayWins) {
+        bestUndefeatedDayWins = stat.wins;
+      }
+    });
+    progression["perfect-day"].current = Math.min(bestUndefeatedDayWins, 5);
+
+    // Perfect Week progression: most distinct Mon–Fri weekdays won within a
+    // single working week so far.
+    let bestWeekdaysWon = 0;
+    perfectWeekWeekdays.forEach((weekdays) => {
+      if (weekdays.size > bestWeekdaysWon) {
+        bestWeekdaysWon = weekdays.size;
+      }
+    });
+    progression["perfect-week"].current = bestWeekdaysWon;
 
     // Calculate hat-trick progression (wins within last 90 minutes)
     const NINETY_MINUTES = 90 * 60 * 1000;
@@ -2166,6 +2338,8 @@ type AchievementDefinitions = {
   "comeback-kid": { opponent: string };
   "unbreakable-spirit": { opponent: string };
   "hat-trick": { firstWinAt: number; thirdWinAt: number };
+  "perfect-day": { day: number; wins: number };
+  "perfect-week": { weekStart: number };
   "kingslayer": { opponent: string; gameId: string };
   "king-maker": { newKing: string; netScoreGained: number };
   "touched-the-throne": { elo: number; firstGameAt: number; dethroned?: string };
@@ -2305,6 +2479,8 @@ export type AchievementProgression = {
   "comeback-kid": BaseProgression;
   "unbreakable-spirit": BaseProgression;
   "hat-trick": ProgressionWithTarget;
+  "perfect-day": ProgressionWithTarget;
+  "perfect-week": ProgressionWithTarget;
   "kingslayer": BaseProgression;
   "king-maker": BaseProgression;
   "touched-the-throne": BaseProgression;

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -2042,25 +2042,42 @@ export class Achievements {
     progression["punching-bag"].current = currentLoseStreakAll;
     progression["never-give-up"].current = currentLoseStreakAll;
 
-    // Perfect Day progression: best undefeated day so far (most wins on a
-    // day with zero losses), capped at the target so it never reads > 5/5.
-    let bestUndefeatedDayWins = 0;
-    perfectDayStats.forEach((stat) => {
-      if (stat.losses === 0 && stat.wins > bestUndefeatedDayWins) {
-        bestUndefeatedDayWins = stat.wins;
-      }
-    });
-    progression["perfect-day"].current = Math.min(bestUndefeatedDayWins, 5);
+    // Perfect Day progression tracks TODAY's live attempt: the number of
+    // games won today with zero losses so far. A single loss today nullifies
+    // it — progress drops to 0 and the player must try again tomorrow. No
+    // games today → 0.
+    const nowMs = Date.now();
+    const todayStart = new Date(nowMs);
+    todayStart.setHours(0, 0, 0, 0);
+    const todayStat = perfectDayStats.get(todayStart.getTime());
+    progression["perfect-day"].current =
+      todayStat && todayStat.losses === 0 ? Math.min(todayStat.wins, 5) : 0;
 
-    // Perfect Week progression: most distinct Mon–Fri weekdays won within a
-    // single working week so far.
-    let bestWeekdaysWon = 0;
-    perfectWeekWeekdays.forEach((weekdays) => {
-      if (weekdays.size > bestWeekdaysWon) {
-        bestWeekdaysWon = weekdays.size;
+    // Perfect Week progression tracks THIS working week's live attempt: the
+    // run of consecutive weekdays from Monday, each with at least one win.
+    // A weekday that has fully elapsed without a win breaks the run to 0 (try
+    // again next Monday); the current weekday only counts once it has a win.
+    // E.g. a Monday win reads 1/5 all through Tuesday; if Tuesday then passes
+    // with no win, Wednesday starts the player at 0/5.
+    const weekStartNow = new Date(nowMs);
+    weekStartNow.setHours(0, 0, 0, 0);
+    const daysSinceMonday = (weekStartNow.getDay() + 6) % 7; // 0=Mon..6=Sun
+    weekStartNow.setDate(weekStartNow.getDate() - daysSinceMonday);
+    const weekdaysWonThisWeek = perfectWeekWeekdays.get(weekStartNow.getTime()) ?? new Set<number>();
+    // Weekdays (1=Mon..5=Fri) that have fully elapsed must each carry a win.
+    const passedWeekdays = Math.min(daysSinceMonday, 5);
+    let perfectWeekProgress = passedWeekdays;
+    for (let weekday = 1; weekday <= passedWeekdays; weekday++) {
+      if (!weekdaysWonThisWeek.has(weekday)) {
+        perfectWeekProgress = 0;
+        break;
       }
-    });
-    progression["perfect-week"].current = bestWeekdaysWon;
+    }
+    // The current weekday (Mon–Fri) counts only once it has a win.
+    if (perfectWeekProgress !== 0 && daysSinceMonday <= 4 && weekdaysWonThisWeek.has(daysSinceMonday + 1)) {
+      perfectWeekProgress += 1;
+    }
+    progression["perfect-week"].current = perfectWeekProgress;
 
     // Calculate hat-trick progression (wins within last 90 minutes)
     const NINETY_MINUTES = 90 * 60 * 1000;

--- a/frontend/src/pages/achievements/achievements-list.tsx
+++ b/frontend/src/pages/achievements/achievements-list.tsx
@@ -207,6 +207,16 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                       Ended {achievement.data.streakLength}-game streak
                     </span>
                   )}
+                  {achievement.type === "perfect-day" && achievement.data && (
+                    <span className="text-[11px] opacity-80">
+                      {achievement.data.wins} wins, 0 losses
+                    </span>
+                  )}
+                  {achievement.type === "perfect-week" && achievement.data && (
+                    <span className="text-[11px] opacity-80">
+                      Week of {dateString(achievement.data.weekStart)}
+                    </span>
+                  )}
                   {achievement.type === "group-stage-star" && achievement.data && (
                     <span className="text-[11px] opacity-80">
                       Undefeated ({achievement.data.wins} win

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -173,6 +173,16 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
     description: "Win 3 games in under 90 minutes",
     icon: "🎩",
   },
+  "perfect-day": {
+    title: "Perfect Day",
+    description: "Go undefeated across 5 or more games in a single day",
+    icon: "☀️",
+  },
+  "perfect-week": {
+    title: "Perfect Week",
+    description: "Win a game on every day of a working week (Mon–Fri)",
+    icon: "🗓️",
+  },
   "kingslayer": {
     title: "Kingslayer",
     description: "Beat the player ranked #1 on the leaderboard",
@@ -483,6 +493,18 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
                 {achievement.type === "streak-ender" && achievement.data && (
                   <p className="text-xs text-secondary-text/70 mt-2">
                     Ended {context.playerName(achievement.data.opponent)}'s {achievement.data.streakLength}-game win streak
+                  </p>
+                )}
+
+                {achievement.type === "perfect-day" && achievement.data && (
+                  <p className="text-xs text-secondary-text/70 mt-2">
+                    {achievement.data.wins} wins, 0 losses on {dateString(achievement.data.day)}
+                  </p>
+                )}
+
+                {achievement.type === "perfect-week" && achievement.data && (
+                  <p className="text-xs text-secondary-text/70 mt-2">
+                    Working week of {dateString(achievement.data.weekStart)}
                   </p>
                 )}
 


### PR DESCRIPTION
Perfect Day: awarded for each calendar day a player wins 5+ games with
zero losses. Perfect Week: awarded for each working week (Mon–Fri) a
player wins at least one game on all five weekdays. Both are earnable
multiple times, computed in a dedicated pass over time-ordered games and
surfaced in the progress views. Includes labels, detail rendering, and
tests, and removes the now-implemented Perfect Day from the suggestions.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FXjrSwo6ttW19xChHJTaWx