### PR TITLE
Fix timezone mismatch in day-period key for Top Gaming tables

### DIFF
--- a/frontend/src/pages/admin/top-days.tsx
+++ b/frontend/src/pages/admin/top-days.tsx
@@ -61,7 +61,7 @@ const getISOWeek = (date: Date): number => {
 const getPeriodKey = (date: Date, period: Period): string => {
   switch (period) {
     case "day":
-      return date.toISOString().split("T")[0];
+      return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
     case "week": {
       const ws = getWeekStart(date);
       return `W-${ws.getFullYear()}-${String(ws.getMonth() + 1).padStart(2, "0")}-${String(ws.getDate()).padStart(2, "0")}`;


### PR DESCRIPTION
## Summary

Follow-up fix to the zero-game-period work in the admin **Top Gaming tables**. A zero-game current day was not appearing at the bottom of the "Days" table as `456 / 456`, due to a timezone inconsistency in how day-period keys were generated.

## The bug

`getPeriodKey` computed the `"day"` key from **UTC**:

```js
case "day":
  return date.toISOString().split("T")[0]; // UTC date
```

but `getPeriodTimestamp`, `getPeriodStart`, and `advancePeriod` all use **local** date components (`getFullYear/getMonth/getDate`).

In a timezone ahead of UTC (e.g. Norway, UTC+1/+2):
- The seeding loop advances a cursor at **local midnight** of each day.
- Local midnight July 18 is July 17, 22:00–23:00 **UTC**, so `toISOString()` keyed that day as `"2026-07-17"`.
- Meanwhile `currentKey = getPeriodKey(new Date())` for today was `"2026-07-18"`.

So today's seeded zero-game entry was filed under the previous day's key and never matched `currentKey`. `current` resolved to `null`, and the `rank / total` row for the current empty day was never rendered. It also silently mis-grouped games played near midnight.

## The fix

Generate the day key from local date components, consistent with the other period helpers:

```js
case "day":
  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
```

Now keys, timestamps, seeding, and current-period detection all agree on local day boundaries, so a zero-game today correctly appears as `456 / 456`. The week/month/year views were already fully local and are unaffected.

## Testing

- `tsc` and `eslint` could not be run in the environment (pre-existing ESLint version mismatch; `node_modules` not installed). The change adds no new imports and is a self-contained one-line adjustment matching the file's existing local-time convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019VJdpvttnP5ADL6KDdWDiP)_