### PR TITLE
Persist achievements filter and view state in URL

### DIFF
--- a/frontend/src/pages/achievements/achievements-page.tsx
+++ b/frontend/src/pages/achievements/achievements-page.tsx
@@ -1,4 +1,5 @@
-import { useState, useMemo } from "react";
+import { useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
 import { classNames } from "../../common/class-names";
 import { useEventDbContext } from "../../wrappers/event-db-context";
 import { Achievement } from "../../client/client-db/achievements";
@@ -6,9 +7,47 @@ import { ACHIEVEMENT_LABELS } from "../player/player-achievements";
 import { AchievementsList } from "./achievements-list";
 import { ProgressList } from "./progress-list";
 
+const FILTER_PARAM = "filter";
+const VIEW_PARAM = "view";
+const PROGRESS_VIEW = "progress";
+
 export const AchievementsPage: React.FC = () => {
   const context = useEventDbContext();
-  const [selectedType, setSelectedType] = useState<string>("all");
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Filter and view live in the url so they survive reloads and can be shared
+  const selectedType = searchParams.get(FILTER_PARAM) ?? "all";
+  const showProgress = searchParams.get(VIEW_PARAM) === PROGRESS_VIEW;
+
+  const setSelectedType = (type: string) => {
+    setSearchParams(
+      (previous) => {
+        const params = new URLSearchParams(previous);
+        if (type === "all") {
+          params.delete(FILTER_PARAM);
+        } else {
+          params.set(FILTER_PARAM, type);
+        }
+        return params;
+      },
+      { replace: true },
+    );
+  };
+
+  const setShowProgress = (progress: boolean) => {
+    setSearchParams(
+      (previous) => {
+        const params = new URLSearchParams(previous);
+        if (progress) {
+          params.set(VIEW_PARAM, PROGRESS_VIEW);
+        } else {
+          params.delete(VIEW_PARAM);
+        }
+        return params;
+      },
+      { replace: true },
+    );
+  };
 
   context.achievements.calculateAchievements();
 
@@ -39,9 +78,6 @@ export const AchievementsPage: React.FC = () => {
       return countB - countA; // Sort by count descending
     });
   }, [achievementCounts]);
-
-  // State for toggling the progress view
-  const [showProgress, setShowProgress] = useState(false);
 
   // Filter and sort achievements
   const filteredAchievements = useMemo(() => {
@@ -102,6 +138,7 @@ export const AchievementsPage: React.FC = () => {
 
           <button
             onClick={() => setShowProgress(!showProgress)}
+            type="button"
             className={classNames(
               "px-4 py-2 rounded text-sm font-medium border transition-colors",
               showProgress

--- a/frontend/src/wrappers/theme-provider.tsx
+++ b/frontend/src/wrappers/theme-provider.tsx
@@ -5,9 +5,47 @@ import { classNames } from "../common/class-names";
 
 export const OVERRIDE_THEME_KEY = "override-theme";
 
+// Max delay (ms) between the two "S" presses for it to count as a double-tap.
+const DOUBLE_TAP_DELAY_MS = 400;
+
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { theme } = getClientConfig();
-  const [overrideTheme] = useLocalStorage(OVERRIDE_THEME_KEY, "");
+  const [overrideTheme, setOverrideTheme] = useLocalStorage(OVERRIDE_THEME_KEY, "");
+
+  const lastSPressRef = React.useRef(0);
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() !== "s" || event.repeat) {
+        return;
+      }
+
+      // Ignore key presses while typing in inputs, textareas or editable elements.
+      const target = event.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)
+      ) {
+        return;
+      }
+
+      // Ignore when a modifier is held so we don't hijack shortcuts like Cmd/Ctrl+S.
+      if (event.metaKey || event.ctrlKey || event.altKey) {
+        return;
+      }
+
+      const now = event.timeStamp;
+      if (now - lastSPressRef.current <= DOUBLE_TAP_DELAY_MS) {
+        lastSPressRef.current = 0;
+        setOverrideTheme((current) => (current === Theme.STEALTH ? "" : Theme.STEALTH));
+      } else {
+        lastSPressRef.current = now;
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [setOverrideTheme]);
 
   let themeToUse: string = theme;
   if (overrideTheme && overrideTheme !== "No override") {


### PR DESCRIPTION
## Summary
This PR improves the achievements page by persisting the filter and view state in the URL, allowing users to share links and have their preferences survive page reloads. Additionally, a keyboard shortcut (double-tap "S") is added to toggle the stealth theme.

## Key Changes

**Achievements Page (`achievements-page.tsx`):**
- Replaced local state (`useState`) with URL search parameters for filter and view preferences
- Added `useSearchParams` hook from react-router-dom to manage `filter` and `view` query parameters
- Implemented `setSelectedType` and `setShowProgress` functions that update URL parameters instead of local state
- Added `type="button"` attribute to the progress view toggle button for semantic correctness

**Theme Provider (`theme-provider.tsx`):**
- Added keyboard event listener to detect double-tap of "S" key to toggle stealth theme
- Implemented safeguards to prevent hijacking the shortcut when:
  - User is typing in input fields, textareas, or contenteditable elements
  - Modifier keys (Cmd/Ctrl/Alt) are held (to avoid interfering with system shortcuts like Cmd+S)
  - Key repeat events are triggered
- Uses a ref to track the timestamp of the last "S" press with a 400ms window for double-tap detection
- Made `setOverrideTheme` available from `useLocalStorage` hook to enable theme toggling

## Implementation Details
- Filter and view state now survive page reloads and can be shared via URL
- The "all" filter value is omitted from the URL for cleaner query strings
- The stealth theme toggle is non-intrusive and respects user input contexts

https://claude.ai/code/session_01EFQPYkREebZzzZHW1gnLuU