### PR TITLE
Implement achievement progress baseline for marathon-set

### DIFF
--- a/frontend/src/common/achievement-progress.test.ts
+++ b/frontend/src/common/achievement-progress.test.ts
@@ -1,0 +1,38 @@
+import { achievementProgressPercentage } from "./achievement-progress";
+
+describe("achievementProgressPercentage", () => {
+  it("measures achievements without a baseline from 0", () => {
+    expect(achievementProgressPercentage("close-calls", 1, 5)).toBe(20);
+    expect(achievementProgressPercentage("close-calls", 5, 5)).toBe(100);
+  });
+
+  it("measures marathon-set from 11 instead of 0", () => {
+    // Best deuce set won of 13 against a league record of 15: 2 of 4 points.
+    expect(achievementProgressPercentage("marathon-set", 13, 15)).toBe(50);
+    expect(achievementProgressPercentage("marathon-set", 12, 15)).toBe(25);
+    expect(achievementProgressPercentage("marathon-set", 14, 15)).toBe(75);
+  });
+
+  it("gives marathon-set the record holder 100%", () => {
+    expect(achievementProgressPercentage("marathon-set", 14, 14)).toBe(100);
+  });
+
+  it("gives 0% for marathon-set when the player has won no deuce set", () => {
+    expect(achievementProgressPercentage("marathon-set", 0, 15)).toBe(0);
+  });
+
+  it("returns 0 when there is no target to chase", () => {
+    expect(achievementProgressPercentage("marathon-set", 13, undefined)).toBe(0);
+    expect(achievementProgressPercentage("close-calls", 3, undefined)).toBe(0);
+  });
+
+  it("caps at 100%", () => {
+    expect(achievementProgressPercentage("marathon-set", 20, 15)).toBe(100);
+    expect(achievementProgressPercentage("close-calls", 9, 5)).toBe(100);
+  });
+
+  it("handles a target at or below the baseline as all-or-nothing", () => {
+    expect(achievementProgressPercentage("marathon-set", 12, 11)).toBe(100);
+    expect(achievementProgressPercentage("marathon-set", 10, 11)).toBe(0);
+  });
+});

--- a/frontend/src/common/achievement-progress.ts
+++ b/frontend/src/common/achievement-progress.ts
@@ -1,0 +1,35 @@
+// Progress-bar baselines for achievements whose "current" value starts from a
+// floor that every player already stands on. Measuring such a chase from 0
+// wildly overstates how close a player is.
+//
+// Marathon Set compares winning scores from true-deuce sets: 11 is an ordinary
+// set win, and the chase only begins at 12. A player whose best deuce set was
+// 13, chasing a league record of 15, is 2 points into a 4-point gap — 50%, not
+// 13/15 = 87%. So the bar measures from 11 instead of 0.
+const PROGRESS_BASELINES: Record<string, number> = {
+  "marathon-set": 11,
+};
+
+/**
+ * Percentage (0-100) to render for an achievement's progress bar, measured
+ * from the achievement's baseline rather than always from 0. Returns 0 when
+ * there is nothing to measure (no current value, or no target set yet).
+ */
+export function achievementProgressPercentage(
+  type: string,
+  current: number | undefined,
+  target: number | undefined,
+): number {
+  if (!current || !target) return 0;
+
+  const baseline = PROGRESS_BASELINES[type] ?? 0;
+
+  // A target at or below the baseline leaves no span to measure across, so
+  // it's all-or-nothing: reaching the target is done, anything less is 0.
+  if (target <= baseline) return current >= target ? 100 : 0;
+
+  // Below the baseline the chase hasn't started yet.
+  if (current <= baseline) return 0;
+
+  return Math.min(((current - baseline) / (target - baseline)) * 100, 100);
+}

--- a/frontend/src/pages/achievements/progress-list.tsx
+++ b/frontend/src/pages/achievements/progress-list.tsx
@@ -5,6 +5,7 @@ import { ACHIEVEMENT_LABELS, getAchievementLabel } from "../player/player-achiev
 import { ProfilePicture } from "../player/profile-picture";
 import { fmtNum } from "../../common/number-utils";
 import { classNames } from "../../common/class-names";
+import { achievementProgressPercentage } from "../../common/achievement-progress";
 
 interface ProgressListProps {
   selectedType: string;
@@ -57,7 +58,7 @@ export const ProgressList: React.FC<ProgressListProps> = ({ selectedType }) => {
         }
 
         if (target > 0) {
-          percent = Math.min(100, Math.round((current / target) * 100));
+          percent = Math.round(achievementProgressPercentage(selectedType, current, target));
         }
 
         return {

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Achievement, AchievementProgression } from "../../client/client-db/achievements";
 import { Link } from "react-router-dom";
 import { fmtNum } from "../../common/number-utils";
+import { achievementProgressPercentage } from "../../common/achievement-progress";
 
 type Props = {
   playerId?: string;
@@ -612,7 +613,7 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
       {progressItems.map(({ type, label, data }) => {
         const hasTarget = "target" in data && !!data.target;
         const hasCurrent = "current" in data && !!data.current;
-        const percentage = hasTarget && hasCurrent ? Math.min((data.current! / data.target!) * 100, 100) : 0;
+        const percentage = hasTarget && hasCurrent ? achievementProgressPercentage(type, data.current, data.target) : 0;
         const hasEarned = data.earned > 0;
         const isTimePeriod =
           type.startsWith("active-") || type.startsWith("back-after-") || type === "anniversary";


### PR DESCRIPTION
## Summary
Introduces a baseline-aware progress calculation for achievements, allowing certain achievements to measure progress from a non-zero starting point rather than always from 0. This prevents overstating progress when chasing records for achievements with natural minimum thresholds.

## Changes
- **New module:** `achievement-progress.ts` with `achievementProgressPercentage()` function that:
  - Measures progress from achievement-specific baselines (e.g., marathon-set starts from 11 instead of 0)
  - Handles edge cases: missing targets, values below baseline, and capping at 100%
  - Treats targets at or below the baseline as all-or-nothing achievements
  
- **Test coverage:** Comprehensive test suite in `achievement-progress.test.ts` covering:
  - Standard achievements measured from 0
  - Marathon-set baseline behavior (11-point floor)
  - Edge cases (missing targets, exceeding targets, targets at/below baseline)

- **Integration:** Updated progress bar calculations in:
  - `progress-list.tsx`: Uses new function for achievement progress percentages
  - `player-achievements.tsx`: Uses new function in the ProgressTab component

## Implementation Details
The `PROGRESS_BASELINES` map allows easy configuration of baseline values per achievement type. For marathon-set, measuring from 11 (a standard deuce set win) rather than 0 accurately reflects that a player chasing a league record of 15 with a best of 13 is 50% of the way there (2 of 4 points), not 87%.

https://claude.ai/code/session_013ejZzQAiNhNqVD9Sa4Z3P2