### PR TITLE
Break Top Gaming Days ties in favour of the earlier period

### DIFF
--- a/frontend/src/pages/admin/top-days.tsx
+++ b/frontend/src/pages/admin/top-days.tsx
@@ -205,7 +205,8 @@ export const TopGamingDays: React.FC = () => {
           count: data.count,
           timestamp: data.timestamp,
         }))
-        .sort((a, b) => b.count - a.count || b.timestamp - a.timestamp);
+        // Highest count first, ties broken in favour of the earlier period.
+        .sort((a, b) => b.count - a.count || a.timestamp - b.timestamp);
 
       const currentIndex = sorted.findIndex((entry) => entry.key === currentKey);
       const current: CurrentEntry | null =


### PR DESCRIPTION
Periods with equal game counts were ordered most-recent-first, so a newer
period would outrank an older one that achieved the same count. Ties now
resolve to the earlier period.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EWXnWRoJm5R19fMVugfvp9