### PR TITLE
Add player pairings widget to the player statistics tab

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -31,6 +31,25 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "player-pairings-widget",
+    title: "Player pairings on the player page",
+    date: "2026-07-28",
+    tags: ["new-feature"],
+    summary:
+      "A widget in the Statistics tab that groups everyone else by how many players it takes to connect you through games played.",
+    body: [
+      text(
+        "The first column is the players you have played, most games first. The next column is the players you have not played but share an opponent with, then the ones two steps away, and so on. A final column collects anyone with no chain of games leading to you at all.",
+      ),
+      text(
+        "Where several equally short chains exist, the one with the most games on its last hop wins, and that count is what orders the column. Hover a tag to see the route.",
+      ),
+      text(
+        "Only games between two active players count as links, so a retired player does not keep bridging the people who used to play through them.",
+      ),
+    ],
+  },
+  {
     slug: "earliest-and-latest-game-achievements",
     title: "2 new achievements: Earliest and Latest Game",
     date: "2026-07-27",

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -42,7 +42,10 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
         "The first column is the players you have played, most games first. The next column is the players you have not played but share an opponent with, then the ones two steps away, and so on. A final column collects anyone with no chain of games leading to you at all.",
       ),
       text(
-        "Where several equally short chains exist, the one with the most games on its last hop wins, and that count is what orders the column. Hover a tag to see the route.",
+        "Hover anyone in an in-between column and the widget draws the chain back to the player you have actually played, arrows pointing your way, with everybody else faded out.",
+      ),
+      text(
+        "Where several equally short chains exist, the one with the most games on its last hop wins - picked hop by hop working back from the player you hover. That same count is what orders each column.",
       ),
       text(
         "Only games between two active players count as links, so a retired player does not keep bridging the people who used to play through them.",

--- a/frontend/src/client/client-db/__tests__/player-pairings.test.ts
+++ b/frontend/src/client/client-db/__tests__/player-pairings.test.ts
@@ -1,0 +1,174 @@
+import { TennisTable } from "../tennis-table";
+import { EventType, EventTypeEnum } from "../event-store/event-types";
+
+let time = 0;
+const nextTime = () => ++time;
+
+function player(id: string): EventType {
+  return { time: nextTime(), stream: id, type: EventTypeEnum.PLAYER_CREATED, data: { name: id } };
+}
+
+function deactivate(id: string): EventType {
+  return { time: nextTime(), stream: id, type: EventTypeEnum.PLAYER_DEACTIVATED, data: null };
+}
+
+function games(winner: string, loser: string, count = 1): EventType[] {
+  return Array.from({ length: count }, (_, index) => {
+    const playedAt = nextTime();
+    return {
+      time: playedAt,
+      stream: `game-${winner}-${loser}-${index}-${playedAt}`,
+      type: EventTypeEnum.GAME_CREATED,
+      data: { playedAt, winner, loser },
+    };
+  });
+}
+
+function pairings(events: EventType[], playerId: string) {
+  const result = new TennisTable({ events }).playerPairings.get(playerId);
+  return {
+    columns: result.columns.map((column) => ({
+      degree: column.degree,
+      players: column.players.map((p) => p.playerId),
+    })),
+    unreachable: result.unreachable,
+  };
+}
+
+describe("PlayerPairings", () => {
+  beforeEach(() => {
+    time = 0;
+  });
+
+  it("sorts played opponents by games played, most first", () => {
+    const events = [
+      player("me"),
+      player("a"),
+      player("b"),
+      player("c"),
+      ...games("me", "a", 1),
+      ...games("me", "b", 3),
+      ...games("c", "me", 2),
+    ];
+
+    expect(pairings(events, "me")).toEqual({
+      columns: [{ degree: 1, players: ["b", "c", "a"] }],
+      unreachable: [],
+    });
+  });
+
+  it("groups players by the number of intermediaries between them", () => {
+    const events = [
+      player("me"),
+      player("a"),
+      player("b"),
+      player("c"),
+      ...games("me", "a"),
+      ...games("a", "b"),
+      ...games("b", "c"),
+    ];
+
+    expect(pairings(events, "me")).toEqual({
+      columns: [
+        { degree: 1, players: ["a"] },
+        { degree: 2, players: ["b"] },
+        { degree: 3, players: ["c"] },
+      ],
+      unreachable: [],
+    });
+  });
+
+  it("sorts indirect players by the games on the last hop", () => {
+    const events = [
+      player("me"),
+      player("hub"),
+      player("few"),
+      player("many"),
+      ...games("me", "hub"),
+      ...games("hub", "few", 1),
+      ...games("hub", "many", 5),
+    ];
+
+    expect(pairings(events, "me").columns[1]).toEqual({ degree: 2, players: ["many", "few"] });
+  });
+
+  it("picks the path with the most games on the last hop when several are equally long", () => {
+    const events = [
+      player("me"),
+      player("weak-hub"),
+      player("strong-hub"),
+      player("target"),
+      ...games("me", "weak-hub", 10),
+      ...games("me", "strong-hub", 1),
+      ...games("weak-hub", "target", 2),
+      ...games("strong-hub", "target", 7),
+    ];
+
+    const result = new TennisTable({ events }).playerPairings.get("me");
+    const target = result.columns[1].players[0];
+
+    expect(target.playerId).toBe("target");
+    expect(target.games).toBe(7);
+    expect(target.path).toEqual(["strong-hub", "target"]);
+  });
+
+  it("lists players with no connecting games as unreachable", () => {
+    const events = [
+      player("me"),
+      player("a"),
+      player("lonely"),
+      player("island-1"),
+      player("island-2"),
+      ...games("me", "a"),
+      ...games("island-1", "island-2"),
+    ];
+
+    expect(pairings(events, "me")).toEqual({
+      columns: [{ degree: 1, players: ["a"] }],
+      unreachable: ["island-1", "island-2", "lonely"],
+    });
+  });
+
+  it("excludes retired players and does not route paths through them", () => {
+    const events = [
+      player("me"),
+      player("retired"),
+      player("behind-retired"),
+      ...games("me", "retired"),
+      ...games("retired", "behind-retired"),
+      deactivate("retired"),
+    ];
+
+    expect(pairings(events, "me")).toEqual({
+      columns: [],
+      unreachable: ["behind-retired"],
+    });
+  });
+
+  it("still connects a retired player through their own games", () => {
+    const events = [
+      player("me"),
+      player("a"),
+      player("b"),
+      ...games("me", "a"),
+      ...games("a", "b"),
+      deactivate("me"),
+    ];
+
+    expect(pairings(events, "me")).toEqual({
+      columns: [
+        { degree: 1, players: ["a"] },
+        { degree: 2, players: ["b"] },
+      ],
+      unreachable: [],
+    });
+  });
+
+  it("never includes the player themselves", () => {
+    const events = [player("me"), player("a"), ...games("me", "a")];
+    const result = pairings(events, "me");
+
+    expect(result.columns.flatMap((c) => c.players)).not.toContain("me");
+    expect(result.unreachable).not.toContain("me");
+  });
+});

--- a/frontend/src/client/client-db/player-pairings.ts
+++ b/frontend/src/client/client-db/player-pairings.ts
@@ -1,0 +1,91 @@
+import { TennisTable } from "./tennis-table";
+
+export type PairedPlayer = {
+  playerId: string;
+  /** Games played on the last hop of the shortest path. For degree 1 that is games against the player themselves. */
+  games: number;
+  /** The path from the player to this player, excluding the player itself. Last entry is `playerId`. */
+  path: string[];
+};
+
+export type PlayerPairingsColumn = {
+  /** 1 = played each other, 2 = one intermediary, 3 = two intermediaries, ... */
+  degree: number;
+  players: PairedPlayer[];
+};
+
+export type PlayerPairingsDTO = {
+  columns: PlayerPairingsColumn[];
+  /** Active players with no path of games connecting them to the player. */
+  unreachable: string[];
+};
+
+/**
+ * Groups every other active player by how many intermediaries it takes to connect them to a
+ * player through games played. Only games between two active players count as connections, so
+ * retiring a player breaks the paths that ran through them.
+ */
+export class PlayerPairings {
+  private parent: TennisTable;
+
+  constructor(parent: TennisTable) {
+    this.parent = parent;
+  }
+
+  get(playerId: string): PlayerPairingsDTO {
+    // The player themselves may be retired, but their own games still connect them to the graph.
+    const nodes = new Set<string>(this.parent.players.map((player) => player.id));
+    nodes.add(playerId);
+
+    const games = new Map<string, Map<string, number>>();
+    const addGame = (from: string, to: string) => {
+      const opponents = games.get(from) ?? new Map<string, number>();
+      opponents.set(to, (opponents.get(to) ?? 0) + 1);
+      games.set(from, opponents);
+    };
+    for (const { winner, loser } of this.parent.games) {
+      if (winner === loser || !nodes.has(winner) || !nodes.has(loser)) continue;
+      addGame(winner, loser);
+      addGame(loser, winner);
+    }
+
+    const degrees = new Map<string, number>([[playerId, 0]]);
+    const columns: PlayerPairingsColumn[] = [];
+
+    let previous: PairedPlayer[] = [{ playerId, games: 0, path: [] }];
+    while (previous.length > 0) {
+      const degree = columns.length + 1;
+      const found = new Map<string, PairedPlayer>();
+
+      for (const from of previous) {
+        for (const [to, gamesPlayed] of games.get(from.playerId) ?? []) {
+          if (degrees.has(to)) continue; // Already reached on a shorter path
+          const existing = found.get(to);
+          // Multiple paths of the same length: keep the one with the most games on the last hop.
+          if (existing && existing.games >= gamesPlayed) continue;
+          found.set(to, { playerId: to, games: gamesPlayed, path: [...from.path, to] });
+        }
+      }
+
+      for (const foundId of found.keys()) {
+        degrees.set(foundId, degree);
+      }
+
+      previous = Array.from(found.values()).sort(
+        (a, b) =>
+          b.games - a.games ||
+          this.parent.playerName(a.playerId).localeCompare(this.parent.playerName(b.playerId)),
+      );
+      if (previous.length > 0) {
+        columns.push({ degree, players: previous });
+      }
+    }
+
+    const unreachable = this.parent.players
+      .filter((player) => !degrees.has(player.id))
+      .map((player) => player.id)
+      .sort((a, b) => this.parent.playerName(a).localeCompare(this.parent.playerName(b)));
+
+    return { columns, unreachable };
+  }
+}

--- a/frontend/src/client/client-db/tennis-table.ts
+++ b/frontend/src/client/client-db/tennis-table.ts
@@ -8,6 +8,7 @@ import { EventStore } from "./event-store/event-store";
 import { IndividualPoints } from "./individual-points";
 import { LeaderboardChanges } from "./leaderboard-changes";
 import { PlayerOponentDistribution } from "./playerOponentDistribution";
+import { PlayerPairings } from "./player-pairings";
 import { Achievements } from "./achievements";
 import { Seasons } from "./seasons/seasons";
 import { PredictionsHistory } from "./predictions-history";
@@ -41,6 +42,7 @@ export class TennisTable {
   simulations: Simulations;
   individualPoints: IndividualPoints;
   playerOponentDistribution: PlayerOponentDistribution;
+  playerPairings: PlayerPairings;
   achievements: Achievements;
   seasons: Seasons;
   predictions: Predictions;
@@ -61,6 +63,7 @@ export class TennisTable {
     this.simulations = new Simulations(this);
     this.individualPoints = new IndividualPoints(this);
     this.playerOponentDistribution = new PlayerOponentDistribution(this);
+    this.playerPairings = new PlayerPairings(this);
     this.achievements = new Achievements(this);
     this.seasons = new Seasons(this);
     this.predictions = new Predictions(this, data.referenceTime);

--- a/frontend/src/hooks/use-player-link-search.ts
+++ b/frontend/src/hooks/use-player-link-search.ts
@@ -1,0 +1,12 @@
+import { useSearchParams } from "react-router-dom";
+
+/**
+ * Query string to hand a link pointing at another player's page. Carries the tab you are already
+ * on, so following an opponent out of a tab keeps you in that tab instead of dropping you on
+ * their Overview.
+ */
+export function usePlayerLinkSearch(): string {
+  const [searchParams] = useSearchParams();
+  const tab = searchParams.get("tab");
+  return tab ? `?tab=${tab}` : "";
+}

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { Achievement, AchievementProgression } from "../../client/client-db/achievements";
 import { Link } from "react-router-dom";
 import { fmtNum } from "../../common/number-utils";
+import { usePlayerLinkSearch } from "../../hooks/use-player-link-search";
 import { achievementProgressPercentage } from "../../common/achievement-progress";
 
 type Props = {
@@ -598,6 +599,7 @@ type ProgressTabProps = {
 
 const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
   const context = useEventDbContext();
+  const search = usePlayerLinkSearch();
   const progressItems = Object.entries(progression).map(([type, data]) => {
     const label = getAchievementLabel(type, context.client.gameLimitForRanked);
 
@@ -720,7 +722,7 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                                       streak >= data.target && "line-through",
                                     )}
                                   >
-                                    <Link to={"/player/" + opponent}>
+                                    <Link to={{ pathname: "/player/" + opponent, search }}>
                                       <span className="text-secondary-text">{context.playerName(opponent)}</span>
                                     </Link>
                                     <span className="font-medium ml-2">
@@ -767,7 +769,7 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                                         alreadyEarned && "line-through",
                                       )}
                                     >
-                                      <Link to={"/player/" + opponent}>
+                                      <Link to={{ pathname: "/player/" + opponent, search }}>
                                         <span className="text-secondary-text">{context.playerName(opponent)}</span>
                                       </Link>
                                       <span className="font-medium">
@@ -789,7 +791,7 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                             <p className="text-xs text-secondary-text/70 mb-2">First opponent for:</p>
                             <div className="flex flex-wrap gap-1">
                               {Array.from(data.newPlayers).map((player: string) => (
-                                <Link to={"/player/" + player} key={player}>
+                                <Link to={{ pathname: "/player/" + player, search }} key={player}>
                                   <span className="text-xs bg-background px-2 py-1 rounded text-secondary-text">
                                     {context.playerName(player)}
                                   </span>
@@ -810,7 +812,7 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                             </p>
                             <div className="flex flex-wrap gap-1">
                               {Array.from(data.missing).map((player: string) => (
-                                <Link to={"/player/" + player} key={player}>
+                                <Link to={{ pathname: "/player/" + player, search }} key={player}>
                                   <span className="text-xs bg-background px-2 py-1 rounded text-secondary-text">
                                     {context.playerName(player)}
                                   </span>
@@ -826,7 +828,7 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                           {data.recordHolder ? (
                             <>
                               League record held by{" "}
-                              <Link to={"/player/" + data.recordHolder}>
+                              <Link to={{ pathname: "/player/" + data.recordHolder, search }}>
                                 <span className="text-secondary-text underline">
                                   {context.playerName(data.recordHolder)}
                                 </span>
@@ -845,7 +847,7 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                           {data.recordHolder ? (
                             <>
                               League record held by{" "}
-                              <Link to={"/player/" + data.recordHolder}>
+                              <Link to={{ pathname: "/player/" + data.recordHolder, search }}>
                                 <span className="text-secondary-text underline">
                                   {context.playerName(data.recordHolder)}
                                 </span>

--- a/frontend/src/pages/player/player-games-distribution.tsx
+++ b/frontend/src/pages/player/player-games-distribution.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { useEventDbContext } from "../../wrappers/event-db-context";
 import { classNames } from "../../common/class-names";
 import { stringToColor } from "../../common/string-to-color";
+import { usePlayerLinkSearch } from "../../hooks/use-player-link-search";
 
 type Props = {
   playerId?: string;
@@ -9,6 +10,7 @@ type Props = {
 
 export const PlayerGamesDistrubution: React.FC<Props> = ({ playerId }) => {
   const context = useEventDbContext();
+  const search = usePlayerLinkSearch();
   const summary = context.leaderboard.getPlayerSummary(playerId || "");
   const mostGames = summary?.gamesDistribution[0]?.games || 0;
 
@@ -17,7 +19,7 @@ export const PlayerGamesDistrubution: React.FC<Props> = ({ playerId }) => {
       {summary?.gamesDistribution.map(({ oponentId, games }, index) => {
         const fraction = games / mostGames;
         return (
-          <Link to={`/player/${oponentId}`} className="group" key={index}>
+          <Link to={{ pathname: `/player/${oponentId}`, search }} className="group" key={index}>
             <div className="relative w-full h-6 group-hover:bg-primary-text/5">
               <div
                 className={classNames(

--- a/frontend/src/pages/player/player-page.tsx
+++ b/frontend/src/pages/player/player-page.tsx
@@ -14,6 +14,7 @@ import { session } from "../../services/auth";
 import { PlayerAchievements } from "./player-achievements";
 import { PlayerPredictionsPage } from "./player-predictions-page";
 import { PlayerSeasonStats } from "./player-season-stats";
+import { PlayerPairings } from "./player-pairings";
 
 type TabType = "overview" | "games" | "statistics" | "achievements" | "predictions" | "season";
 const tabs: { id: TabType; label: string }[] = [
@@ -362,6 +363,12 @@ export const PlayerPage: React.FC = () => {
               {playerId && (
                 <ContentCard title="Oponent scores" description="Relative score of oponents you play">
                   <OponentsScores playerId={playerId} />
+                </ContentCard>
+              )}
+
+              {playerId && (
+                <ContentCard title="Player pairings" description="How many players it takes to connect you">
+                  <PlayerPairings playerId={playerId} />
                 </ContentCard>
               )}
             </div>

--- a/frontend/src/pages/player/player-page.tsx
+++ b/frontend/src/pages/player/player-page.tsx
@@ -15,6 +15,7 @@ import { PlayerAchievements } from "./player-achievements";
 import { PlayerPredictionsPage } from "./player-predictions-page";
 import { PlayerSeasonStats } from "./player-season-stats";
 import { PlayerPairings } from "./player-pairings";
+import { usePlayerLinkSearch } from "../../hooks/use-player-link-search";
 
 type TabType = "overview" | "games" | "statistics" | "achievements" | "predictions" | "season";
 const tabs: { id: TabType; label: string }[] = [
@@ -49,6 +50,7 @@ export const PlayerPage: React.FC = () => {
   const hasParticipatedInAnySeason = seasons.some((s) => s.getLeaderboard().some((p) => p.playerId === playerId));
 
   const activeTab = (searchParams.get("tab") as TabType) || "overview";
+  const playerLinkSearch = usePlayerLinkSearch();
 
   const setActiveTab = (tab: TabType) => {
     setSearchParams((prev) => {
@@ -282,7 +284,7 @@ export const PlayerPage: React.FC = () => {
                   .map((game) => (
                     <tr key={game.time} className="border-b border-primary-text hover:brightness-110 transition-colors">
                       <td className="py-1 px-1 md:px-4">
-                        <Link to={"/player/" + game.oponent}>
+                        <Link to={{ pathname: "/player/" + game.oponent, search: playerLinkSearch }}>
                           <span className="font-medium truncate max-w-[70px] md:max-w-none inline-block">{context.playerName(game.oponent)}</span>
                         </Link>
                       </td>

--- a/frontend/src/pages/player/player-pairings.tsx
+++ b/frontend/src/pages/player/player-pairings.tsx
@@ -1,8 +1,9 @@
-import { Link, useSearchParams } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useEventDbContext } from "../../wrappers/event-db-context";
 import { stringToColor } from "../../common/string-to-color";
 import { classNames } from "../../common/class-names";
+import { usePlayerLinkSearch } from "../../hooks/use-player-link-search";
 
 type Props = {
   playerId: string;
@@ -82,9 +83,7 @@ const PairingsColumn: React.FC<{ title: string; count: number; children: React.R
 
 export const PlayerPairings: React.FC<Props> = ({ playerId }) => {
   const context = useEventDbContext();
-  const [searchParams] = useSearchParams();
-  const tab = searchParams.get("tab");
-  const search = tab ? `?tab=${tab}` : "";
+  const search = usePlayerLinkSearch();
 
   const { columns, unreachable } = useMemo(
     () => context.playerPairings.get(playerId),

--- a/frontend/src/pages/player/player-pairings.tsx
+++ b/frontend/src/pages/player/player-pairings.tsx
@@ -1,11 +1,17 @@
 import { Link } from "react-router-dom";
-import { useMemo } from "react";
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useEventDbContext } from "../../wrappers/event-db-context";
 import { stringToColor } from "../../common/string-to-color";
+import { classNames } from "../../common/class-names";
 
 type Props = {
   playerId: string;
 };
+
+/** A line drawn across one hop of a highlighted path, pointing towards the player. */
+type PathLine = { key: string; x1: number; y1: number; x2: number; y2: number };
+
+const ARROW_MARKER_ID = "player-pairings-arrow";
 
 function columnTitle(degree: number): string {
   if (degree === 1) return "Played";
@@ -25,14 +31,30 @@ function textColor(background: string): string {
   return luminance > 0.6 ? "#000000" : "#ffffff";
 }
 
-const PlayerTag: React.FC<{ playerId: string; title?: string }> = ({ playerId, title }) => {
+type TagProps = {
+  playerId: string;
+  title?: string;
+  dimmed: boolean;
+  onRef: (playerId: string, element: HTMLAnchorElement | null) => void;
+  onHighlight: (playerId: string | undefined) => void;
+};
+
+const PlayerTag: React.FC<TagProps> = ({ playerId, title, dimmed, onRef, onHighlight }) => {
   const context = useEventDbContext();
   const background = stringToColor(playerId);
   return (
     <Link
+      ref={(element) => onRef(playerId, element)}
       to={`/player/${playerId}`}
       title={title}
-      className="block rounded-full px-3 py-1 text-sm font-medium whitespace-nowrap hover:brightness-110 transition-all"
+      onMouseEnter={() => onHighlight(playerId)}
+      onMouseLeave={() => onHighlight(undefined)}
+      onFocus={() => onHighlight(playerId)}
+      onBlur={() => onHighlight(undefined)}
+      className={classNames(
+        "block rounded-full px-3 py-1 text-sm font-medium whitespace-nowrap hover:brightness-110 transition-all",
+        dimmed && "opacity-25",
+      )}
       style={{ backgroundColor: background, color: textColor(background) }}
     >
       {context.playerName(playerId)}
@@ -63,19 +85,83 @@ export const PlayerPairings: React.FC<Props> = ({ playerId }) => {
     [context.playerPairings, playerId],
   );
 
+  const paths = useMemo(() => {
+    const map = new Map<string, string[]>();
+    for (const column of columns) {
+      for (const player of column.players) {
+        map.set(player.playerId, player.path);
+      }
+    }
+    return map;
+  }, [columns]);
+
+  const contentRef = useRef<HTMLDivElement>(null);
+  const tagRefs = useRef(new Map<string, HTMLAnchorElement>());
+  const [highlighted, setHighlighted] = useState<string>();
+  const [lines, setLines] = useState<PathLine[]>([]);
+
+  const registerTag = useCallback((id: string, element: HTMLAnchorElement | null) => {
+    if (element) tagRefs.current.set(id, element);
+    else tagRefs.current.delete(id);
+  }, []);
+
+  /** The hovered player and every player between them and you. Empty unless there is a hop to draw. */
+  const path = useMemo(() => {
+    const found = highlighted ? paths.get(highlighted) : undefined;
+    return found && found.length > 1 ? found : [];
+  }, [highlighted, paths]);
+
+  useLayoutEffect(() => {
+    if (path.length < 2) {
+      setLines([]);
+      return;
+    }
+    const measure = () => {
+      const content = contentRef.current;
+      if (!content) return;
+      const origin = content.getBoundingClientRect();
+      const drawn: PathLine[] = [];
+      // Walk from the hovered player back towards you, one column at a time.
+      for (let index = path.length - 1; index > 0; index--) {
+        const from = tagRefs.current.get(path[index]);
+        const towards = tagRefs.current.get(path[index - 1]);
+        if (!from || !towards) continue;
+        const fromRect = from.getBoundingClientRect();
+        const towardsRect = towards.getBoundingClientRect();
+        drawn.push({
+          key: `${path[index - 1]}-${path[index]}`,
+          x1: fromRect.left - origin.left,
+          y1: fromRect.top - origin.top + fromRect.height / 2,
+          x2: towardsRect.right - origin.left,
+          y2: towardsRect.top - origin.top + towardsRect.height / 2,
+        });
+      }
+      setLines(drawn);
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [path]);
+
   if (columns.length === 0 && unreachable.length === 0) {
     return <p className="text-sm opacity-70">No other players to connect to.</p>;
   }
 
+  const onPath = new Set(path);
+  const dimmed = (id: string) => path.length > 0 && !onPath.has(id);
+
   return (
     <div className="overflow-x-auto -mx-1 px-1">
-      <div className="flex gap-4 items-start w-max">
+      <div ref={contentRef} className="relative flex gap-6 items-start w-max">
         {columns.map((column) => (
           <PairingsColumn key={column.degree} title={columnTitle(column.degree)} count={column.players.length}>
             {column.players.map((player) => (
               <PlayerTag
                 key={player.playerId}
                 playerId={player.playerId}
+                dimmed={dimmed(player.playerId)}
+                onRef={registerTag}
+                onHighlight={setHighlighted}
                 title={
                   column.degree === 1
                     ? `${player.games} game${player.games === 1 ? "" : "s"} together`
@@ -91,9 +177,45 @@ export const PlayerPairings: React.FC<Props> = ({ playerId }) => {
         {unreachable.length > 0 && (
           <PairingsColumn title="No connection" count={unreachable.length}>
             {unreachable.map((id) => (
-              <PlayerTag key={id} playerId={id} />
+              <PlayerTag
+                key={id}
+                playerId={id}
+                dimmed={dimmed(id)}
+                onRef={registerTag}
+                onHighlight={setHighlighted}
+              />
             ))}
           </PairingsColumn>
+        )}
+        {lines.length > 0 && (
+          <svg className="absolute inset-0 w-full h-full overflow-visible pointer-events-none">
+            <defs>
+              <marker
+                id={ARROW_MARKER_ID}
+                markerWidth={5}
+                markerHeight={5}
+                refX={4}
+                refY={2}
+                orient="auto"
+                fill="rgb(var(--color-primary-text))"
+              >
+                <path d="M 0 0 L 4 2 L 0 4 z" />
+              </marker>
+            </defs>
+            {lines.map((line) => (
+              <line
+                key={line.key}
+                x1={line.x1}
+                y1={line.y1}
+                x2={line.x2}
+                y2={line.y2}
+                stroke="rgb(var(--color-primary-text))"
+                strokeWidth={2}
+                strokeLinecap="round"
+                markerEnd={`url(#${ARROW_MARKER_ID})`}
+              />
+            ))}
+          </svg>
         )}
       </div>
     </div>

--- a/frontend/src/pages/player/player-pairings.tsx
+++ b/frontend/src/pages/player/player-pairings.tsx
@@ -1,5 +1,5 @@
-import { Link } from "react-router-dom";
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useEventDbContext } from "../../wrappers/event-db-context";
 import { stringToColor } from "../../common/string-to-color";
 import { classNames } from "../../common/class-names";
@@ -35,17 +35,19 @@ type TagProps = {
   playerId: string;
   title?: string;
   dimmed: boolean;
+  /** Query string to keep, so clicking through lands on the tab you are already on. */
+  search: string;
   onRef: (playerId: string, element: HTMLAnchorElement | null) => void;
   onHighlight: (playerId: string | undefined) => void;
 };
 
-const PlayerTag: React.FC<TagProps> = ({ playerId, title, dimmed, onRef, onHighlight }) => {
+const PlayerTag: React.FC<TagProps> = ({ playerId, title, dimmed, search, onRef, onHighlight }) => {
   const context = useEventDbContext();
   const background = stringToColor(playerId);
   return (
     <Link
       ref={(element) => onRef(playerId, element)}
-      to={`/player/${playerId}`}
+      to={{ pathname: `/player/${playerId}`, search }}
       title={title}
       onMouseEnter={() => onHighlight(playerId)}
       onMouseLeave={() => onHighlight(undefined)}
@@ -80,6 +82,10 @@ const PairingsColumn: React.FC<{ title: string; count: number; children: React.R
 
 export const PlayerPairings: React.FC<Props> = ({ playerId }) => {
   const context = useEventDbContext();
+  const [searchParams] = useSearchParams();
+  const tab = searchParams.get("tab");
+  const search = tab ? `?tab=${tab}` : "";
+
   const { columns, unreachable } = useMemo(
     () => context.playerPairings.get(playerId),
     [context.playerPairings, playerId],
@@ -104,6 +110,10 @@ export const PlayerPairings: React.FC<Props> = ({ playerId }) => {
     if (element) tagRefs.current.set(id, element);
     else tagRefs.current.delete(id);
   }, []);
+
+  // Clicking a tag keeps this widget mounted on the next player's page, where a highlight left
+  // over from the tag under the cursor would belong to the wrong path.
+  useEffect(() => setHighlighted(undefined), [playerId]);
 
   /** The hovered player and every player between them and you. Empty unless there is a hop to draw. */
   const path = useMemo(() => {
@@ -160,6 +170,7 @@ export const PlayerPairings: React.FC<Props> = ({ playerId }) => {
                 key={player.playerId}
                 playerId={player.playerId}
                 dimmed={dimmed(player.playerId)}
+                search={search}
                 onRef={registerTag}
                 onHighlight={setHighlighted}
                 title={
@@ -181,6 +192,7 @@ export const PlayerPairings: React.FC<Props> = ({ playerId }) => {
                 key={id}
                 playerId={id}
                 dimmed={dimmed(id)}
+                search={search}
                 onRef={registerTag}
                 onHighlight={setHighlighted}
               />

--- a/frontend/src/pages/player/player-pairings.tsx
+++ b/frontend/src/pages/player/player-pairings.tsx
@@ -1,0 +1,101 @@
+import { Link } from "react-router-dom";
+import { useMemo } from "react";
+import { useEventDbContext } from "../../wrappers/event-db-context";
+import { stringToColor } from "../../common/string-to-color";
+
+type Props = {
+  playerId: string;
+};
+
+function columnTitle(degree: number): string {
+  if (degree === 1) return "Played";
+  if (degree === 2) return "1 in between";
+  return `${degree - 1} in between`;
+}
+
+/**
+ * Reads a `#rrggbb` colour and picks black or white text for it, so names stay legible on both
+ * the dark and the light player colours.
+ */
+function textColor(background: string): string {
+  const hex = background.replace("#", "");
+  if (hex.length !== 6) return "#ffffff";
+  const [r, g, b] = [0, 2, 4].map((offset) => parseInt(hex.slice(offset, offset + 2), 16));
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.6 ? "#000000" : "#ffffff";
+}
+
+const PlayerTag: React.FC<{ playerId: string; title?: string }> = ({ playerId, title }) => {
+  const context = useEventDbContext();
+  const background = stringToColor(playerId);
+  return (
+    <Link
+      to={`/player/${playerId}`}
+      title={title}
+      className="block rounded-full px-3 py-1 text-sm font-medium whitespace-nowrap hover:brightness-110 transition-all"
+      style={{ backgroundColor: background, color: textColor(background) }}
+    >
+      {context.playerName(playerId)}
+    </Link>
+  );
+};
+
+const PairingsColumn: React.FC<{ title: string; count: number; children: React.ReactNode }> = ({
+  title,
+  count,
+  children,
+}) => (
+  <div className="flex flex-col gap-1 shrink-0">
+    <div className="mb-1">
+      <h4 className="text-sm font-semibold whitespace-nowrap">{title}</h4>
+      <p className="text-xs opacity-70">
+        {count} player{count === 1 ? "" : "s"}
+      </p>
+    </div>
+    {children}
+  </div>
+);
+
+export const PlayerPairings: React.FC<Props> = ({ playerId }) => {
+  const context = useEventDbContext();
+  const { columns, unreachable } = useMemo(
+    () => context.playerPairings.get(playerId),
+    [context.playerPairings, playerId],
+  );
+
+  if (columns.length === 0 && unreachable.length === 0) {
+    return <p className="text-sm opacity-70">No other players to connect to.</p>;
+  }
+
+  return (
+    <div className="overflow-x-auto -mx-1 px-1">
+      <div className="flex gap-4 items-start w-max">
+        {columns.map((column) => (
+          <PairingsColumn key={column.degree} title={columnTitle(column.degree)} count={column.players.length}>
+            {column.players.map((player) => (
+              <PlayerTag
+                key={player.playerId}
+                playerId={player.playerId}
+                title={
+                  column.degree === 1
+                    ? `${player.games} game${player.games === 1 ? "" : "s"} together`
+                    : `Via ${player.path
+                        .slice(0, -1)
+                        .map((id) => context.playerName(id))
+                        .join(" → ")}`
+                }
+              />
+            ))}
+          </PairingsColumn>
+        ))}
+        {unreachable.length > 0 && (
+          <PairingsColumn title="No connection" count={unreachable.length}>
+            {unreachable.map((id) => (
+              <PlayerTag key={id} playerId={id} />
+            ))}
+          </PairingsColumn>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/player/player-points-distribution.tsx
+++ b/frontend/src/pages/player/player-points-distribution.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { useEventDbContext } from "../../wrappers/event-db-context";
 import { classNames } from "../../common/class-names";
 import { stringToColor } from "../../common/string-to-color";
+import { usePlayerLinkSearch } from "../../hooks/use-player-link-search";
 
 type Props = {
   playerId?: string;
@@ -9,6 +10,7 @@ type Props = {
 
 export const PlayerPointsDistrubution: React.FC<Props> = ({ playerId }) => {
   const context = useEventDbContext();
+  const search = usePlayerLinkSearch();
   const summary = context.leaderboard.getPlayerSummary(playerId || "");
   const highestPoints = summary?.pointsDistrubution[0]?.points || 0;
   const lowestPoints = summary?.pointsDistrubution[summary.pointsDistrubution.length - 1]?.points || 0;
@@ -19,7 +21,7 @@ export const PlayerPointsDistrubution: React.FC<Props> = ({ playerId }) => {
       {summary?.pointsDistrubution.map(({ oponentId, points }, index) => {
         const fraction = points / range;
         return (
-          <Link to={`/player/${oponentId}`} className="group" key={index}>
+          <Link to={{ pathname: `/player/${oponentId}`, search }} className="group" key={index}>
             <div className="relative w-full h-6 group-hover:bg-primary-text/5">
               <div
                 className={classNames(


### PR DESCRIPTION
Groups every other active player into columns by how many intermediaries
it takes to connect them to the player through games played: column 1 is
the players you have played (most games first), column 2 the players one
step away, and so on, with a final column for players with no connecting
chain at all.

Where several equally short paths exist, the one with the most games on
its last hop is chosen, and that count orders the column. Only games
between two active players count as links, so retiring a player breaks
the paths that ran through them - though the viewed player's own games
still connect them even if they are retired themselves.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RrxuWGPMXDMUVHLxuD8ciQ