### PR TITLE
Add shortcuts between the add-game, tracking and broadcast flows

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -31,6 +31,22 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "switch-to-live-tracking-mid-flow",
+    title: "Switch to live tracking without starting over",
+    date: "2026-07-29",
+    tags: ["feature-update"],
+    summary:
+      "The Choose Winner step of Add Finished Game now offers to track the match point by point instead, with both players carried over.",
+    body: [
+      text(
+        "Picking the two players and then realising the game has not been played yet no longer means backing out and picking them again. The button under Choose Winner takes you straight to live tracking with the same two players selected.",
+      ),
+      text(
+        "Admins get the same shortcut one step further along: while tracking a match, a button at the bottom hands it over to the broadcasted live game, keeping the sets and the current score. Scoring continues on the live game admin page and the match shows up on the public live game page and the TV overlay.",
+      ),
+    ],
+  },
+  {
     slug: "player-pairings-widget",
     title: "Player pairings on the player page",
     date: "2026-07-28",

--- a/frontend/src/pages/add-game/step-select-winner.tsx
+++ b/frontend/src/pages/add-game/step-select-winner.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { Elo } from "../../client/client-db/elo";
 import { classNames } from "../../common/class-names";
 import { fmtNum } from "../../common/number-utils";
@@ -43,6 +44,17 @@ export const StepSelectWinner: React.FC<{
           }
         />
       </div>
+
+      {/* Escape hatch for when the game has not actually been played yet. */}
+      <Link
+        to={`/add-game-track?player1=${encodeURIComponent(player1)}&player2=${encodeURIComponent(player2)}`}
+        className="block w-full py-3 px-4 rounded-lg text-center bg-secondary-background text-secondary-text hover:opacity-80 transition-opacity"
+      >
+        <div className="font-semibold">🏓 Track as live game instead</div>
+        <div className="text-sm opacity-80 mt-0.5">
+          Score {context.playerName(player1)} vs {context.playerName(player2)} point by point
+        </div>
+      </Link>
     </div>
   );
 };

--- a/frontend/src/pages/add-game/track-game.tsx
+++ b/frontend/src/pages/add-game/track-game.tsx
@@ -15,6 +15,8 @@ import { stringToColor } from "../../common/string-to-color";
 import { getServeInfo, Server } from "../../common/serve-tracker";
 import { ServeTrackerDisplay } from "../../common/serve-tracker-display";
 import { LiveGamePredictionCard } from "../live-game/live-game-prediction-card";
+import { session } from "../../services/auth";
+import { useLiveGameQuery, useUpdateLiveGameMutation } from "../live-game/use-live-game";
 
 interface SetPoint {
   player1: number;
@@ -51,6 +53,11 @@ export const TrackGamePage: React.FC = () => {
   const [firstServer, setFirstServer] = useState<Server>(1);
   const [validationError, setValidationError] = useState<string>("");
   const [gameSuccessfullyAdded, setGameSuccessfullyAdded] = useState(false);
+
+  const isAdmin = session.isAuthenticated && session.sessionData?.role === "admin";
+  // Only fetched to warn before overwriting a broadcast that is already running.
+  const liveGameQuery = useLiveGameQuery({ enabled: isAdmin });
+  const updateLiveGame = useUpdateLiveGameMutation();
 
   const addPoint = (player: number) => {
     setCurrentSetScore((prev) => ({
@@ -180,6 +187,48 @@ export const TrackGamePage: React.FC = () => {
 
     submitGame(winner, loser);
   };
+
+  /**
+   * Hands the match over to the broadcasted live game, keeping the score so far.
+   * From there the admin page is in charge of scoring, the public /live-game page
+   * follows along, and the game is saved from that flow instead of this one.
+   */
+  async function convertToBroadcastedLiveGame() {
+    if (!player1 || !player2) return;
+    setValidationError("");
+
+    const running = liveGameQuery.data;
+    const isRunning = !!running?.player1Id && !!running?.player2Id && running.startedAt !== null && !running.finishedAt;
+    if (
+      isRunning &&
+      !window.confirm(
+        `${context.playerName(running.player1Id)} vs ${context.playerName(
+          running.player2Id,
+        )} is being broadcasted right now. Replace it with this match?`,
+      )
+    ) {
+      return;
+    }
+
+    const now = Date.now();
+    try {
+      await updateLiveGame.mutateAsync({
+        player1Id: player1,
+        player2Id: player2,
+        setsWon: { ...matchData.setsWon },
+        currentSet: { ...currentSetScore },
+        completedSets: matchData.setPoints ?? [],
+        firstServer,
+        startedAt: now,
+        finishedAt: null,
+        updatedAt: now,
+      });
+    } catch (error) {
+      setValidationError(error instanceof Error ? error.message : "Could not start the broadcasted live game");
+      return;
+    }
+    navigate("/live-game/admin");
+  }
 
   const cancelMatch = () => {
     setStage("player-selection");
@@ -402,6 +451,12 @@ export const TrackGamePage: React.FC = () => {
             />
           </div>
 
+          {validationError && (
+            <div className="mb-4 p-3 bg-red-100 border border-red-400 text-red-700 rounded-lg text-sm">
+              {validationError}
+            </div>
+          )}
+
           {/* Sets History */}
           {matchData.setPoints && matchData.setPoints.length > 0 && (
             <div className="bg-white rounded-xl shadow-lg p-4">
@@ -434,6 +489,22 @@ export const TrackGamePage: React.FC = () => {
                 })}
               </div>
             </div>
+          )}
+
+          {/* Hand the match over to the broadcasted live game */}
+          {isAdmin && (
+            <button
+              onClick={convertToBroadcastedLiveGame}
+              disabled={updateLiveGame.isPending}
+              className="w-full mt-4 py-3 px-4 rounded-lg bg-secondary-background text-secondary-text hover:opacity-80 transition-opacity disabled:opacity-50"
+            >
+              <div className="font-semibold">
+                {updateLiveGame.isPending ? "Starting broadcast…" : "📺 Convert to broadcasted live game"}
+              </div>
+              <div className="text-sm opacity-80 mt-0.5">
+                Keeps the score so far and continues on the live game admin page
+              </div>
+            </button>
           )}
         </div>
       </div>

--- a/frontend/src/pages/live-game/use-live-game.ts
+++ b/frontend/src/pages/live-game/use-live-game.ts
@@ -5,8 +5,9 @@ import { queryClient } from "../../common/query-client";
 
 const LIVE_GAME_QUERY_KEY = ["live-game"];
 
-export function useLiveGameQuery(options?: { refetchIntervalMs?: number | false }) {
+export function useLiveGameQuery(options?: { refetchIntervalMs?: number | false; enabled?: boolean }) {
   return useQuery<LiveGameState | null>({
+    enabled: options?.enabled ?? true,
     queryKey: LIVE_GAME_QUERY_KEY,
     queryFn: async () => {
       const res = await fetch(`${process.env.REACT_APP_API_BASE_URL}/live-game`);


### PR DESCRIPTION
The Choose Winner step of Add Finished Game links to live tracking with
both players carried over, for when the game has not been played yet.

While tracking a match, admins can hand it over to the broadcasted live
game: the players, completed sets, current set and first server are
pushed to /live-game and scoring continues on the live game admin page.
Warns first when another live game is already being broadcasted.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012fKQXb4J1tXeBFn8FzRbb1