### PR TITLE
Add admin-only tournament stats tab with a timeline widget

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -31,6 +31,28 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "tournament-statistics-timeline",
+    title: "Tournament timeline in a new Statistics tab",
+    date: "2026-07-29",
+    tags: ["new-feature"],
+    summary:
+      "A chart on the tournament page showing how many days each part of the tournament took, from group play through to the grand final.",
+    body: [
+      text(
+        "The Statistics tab sits alongside the bracket and info tabs. Its first widget is a timeline: one bar per part of the tournament, laid out over the days since it started.",
+      ),
+      list(
+        "Group play, with a bar per group",
+        "The bracket, with a bar per round",
+        "For double elimination: the winners bracket, the losers bracket and the grand final as their own sections",
+      ),
+      text(
+        "A round's clock starts when it became possible to play - the round feeding it finished, and for a losers bracket round also the winners bracket round dropping players into it - and ends at its last game. Waiting for people to show up is therefore part of how long a round took, which is usually the more interesting number. Group play is the exception: its groups run side by side from the tournament start.",
+      ),
+      text("Rounds still being played run up against now, and rounds nobody has reached yet read as not started."),
+    ],
+  },
+  {
     slug: "switch-to-live-tracking-mid-flow",
     title: "Switch to live tracking without starting over",
     date: "2026-07-29",

--- a/frontend/src/client/client-db/__tests__/tournaments/tournament-timeline.test.ts
+++ b/frontend/src/client/client-db/__tests__/tournaments/tournament-timeline.test.ts
@@ -1,0 +1,245 @@
+import { ONE_DAY } from "../../../../common/time-in-ms";
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { TennisTable } from "../../tennis-table";
+import { Tournament } from "../../tournaments/tournament";
+import { buildTournamentTimeline, TimelineSection } from "../../tournaments/tournament-timeline";
+
+const TOURNAMENT_ID = "tournament-1";
+const START = 10 * ONE_DAY; // Far in the past so the tournament has started
+
+/** Timestamps are expressed as whole days after the tournament start, which keeps them readable */
+const day = (days: number) => START + days * ONE_DAY;
+
+type Options = { groupPlay?: boolean; doubleElimination?: boolean; overridePreferredGroupSize?: number };
+
+function baseEvents(players: string[], options?: Options): EventType[] {
+  const events: EventType[] = [];
+  let time = 1_000;
+  for (const player of players) {
+    events.push({ time: time++, stream: player, type: EventTypeEnum.PLAYER_CREATED, data: { name: player } });
+  }
+  events.push({
+    time: time++,
+    stream: TOURNAMENT_ID,
+    type: EventTypeEnum.TOURNAMENT_CREATED,
+    data: {
+      name: "Timeline test",
+      startDate: START,
+      groupPlay: options?.groupPlay ?? false,
+      doubleElimination: options?.doubleElimination ?? false,
+      overridePreferredGroupSize: options?.overridePreferredGroupSize,
+    },
+  });
+  for (const player of players) {
+    events.push({ time: time++, stream: TOURNAMENT_ID, type: EventTypeEnum.TOURNAMENT_SIGNUP, data: { player } });
+  }
+  events.push({
+    time: time++,
+    stream: TOURNAMENT_ID,
+    type: EventTypeEnum.TOURNAMENT_SET_PLAYER_ORDER,
+    data: { playerOrder: players },
+  });
+  return events;
+}
+
+function gameEvent(winner: string, loser: string, playedAt: number): EventType {
+  return {
+    time: playedAt,
+    stream: `game-${winner}-${loser}-${playedAt}`,
+    type: EventTypeEnum.GAME_CREATED,
+    data: { playedAt, winner, loser },
+  };
+}
+
+function getTournament(events: EventType[]): Tournament {
+  const tournament = new TennisTable({ events }).tournaments.getTournament(TOURNAMENT_ID);
+  expect(tournament).toBeDefined();
+  return tournament!;
+}
+
+function section(sections: TimelineSection[], key: string): TimelineSection {
+  const found = sections.find((s) => s.key === key);
+  expect(found).toBeDefined();
+  return found!;
+}
+
+/** Compact view of a segment as whole days from the tournament start, for readable assertions */
+function span(segment: { start: number; lastGameAt?: number }): [number, number | undefined] {
+  return [(segment.start - START) / ONE_DAY, segment.lastGameAt && (segment.lastGameAt - START) / ONE_DAY];
+}
+
+describe("Tournament timeline", () => {
+  it("returns undefined for a tournament that has not started", () => {
+    const events = baseEvents(["P1", "P2"]);
+    // Move the start date into the future
+    events.push({
+      time: 100_000,
+      stream: TOURNAMENT_ID,
+      type: EventTypeEnum.TOURNAMENT_UPDATED,
+      data: { startDate: Date.now() + 10 * ONE_DAY },
+    });
+    expect(buildTournamentTimeline(getTournament(events))).toBeUndefined();
+  });
+
+  it("times each bracket round from when the previous round finished", () => {
+    // 4 players, no group play. Semifinals are P1 vs P4 and P2 vs P3
+    const timeline = buildTournamentTimeline(
+      getTournament([
+        ...baseEvents(["P1", "P2", "P3", "P4"]),
+        gameEvent("P1", "P4", day(1)),
+        gameEvent("P2", "P3", day(3)),
+        gameEvent("P1", "P2", day(4)),
+      ]),
+    )!;
+
+    expect(timeline.sections.map((s) => s.key)).toEqual(["winners"]);
+    expect(span(timeline)).toEqual([0, 4]);
+    expect(timeline.completed).toBe(true);
+    expect(timeline.gamesPlayed).toBe(3);
+    expect(timeline.gamesTotal).toBe(3);
+
+    const bracket = section(timeline.sections, "winners");
+    expect(span(bracket)).toEqual([0, 4]);
+    // Semifinals first (deepest layer), then the final
+    expect(bracket.subSections.map((sub) => sub.ref)).toEqual([
+      { kind: "winners-layer", layerIndex: 1 },
+      { kind: "winners-layer", layerIndex: 0 },
+    ]);
+    // The semifinals own the wait from the tournament start until the second one was played
+    expect(span(bracket.subSections[0])).toEqual([0, 3]);
+    // The final's clock starts when the semifinals finished, not when the tournament started
+    expect(span(bracket.subSections[1])).toEqual([3, 4]);
+  });
+
+  it("runs group play groups in parallel from the tournament start", () => {
+    // Two groups of two, so each group is a single game and all four players advance
+    const timeline = buildTournamentTimeline(
+      getTournament([
+        ...baseEvents(["P1", "P2", "P3", "P4"], { groupPlay: true, overridePreferredGroupSize: 2 }),
+        gameEvent("P1", "P4", day(1)), // Group 1
+        gameEvent("P2", "P3", day(2)), // Group 2
+        gameEvent("P1", "P4", day(3)), // Semifinal
+        gameEvent("P2", "P3", day(4)), // Semifinal
+        gameEvent("P1", "P2", day(5)), // Final
+      ]),
+    )!;
+
+    expect(timeline.sections.map((s) => s.key)).toEqual(["group-play", "winners"]);
+    expect(span(timeline)).toEqual([0, 5]);
+    expect(timeline.completed).toBe(true);
+
+    const groupPlay = section(timeline.sections, "group-play");
+    expect(groupPlay.parallelSubSections).toBe(true);
+    expect(span(groupPlay)).toEqual([0, 2]);
+    // Both groups start at the tournament start and end at their own last game
+    expect(span(groupPlay.subSections[0])).toEqual([0, 1]);
+    expect(span(groupPlay.subSections[1])).toEqual([0, 2]);
+
+    // The bracket takes over when group play ended
+    const bracket = section(timeline.sections, "winners");
+    expect(span(bracket)).toEqual([2, 5]);
+    expect(span(bracket.subSections[0])).toEqual([2, 4]); // Semifinals
+    expect(span(bracket.subSections[1])).toEqual([4, 5]); // Final
+  });
+
+  it("splits a double elimination tournament into winners, losers and grand final", () => {
+    const timeline = buildTournamentTimeline(
+      getTournament([
+        ...baseEvents(["P1", "P2", "P3", "P4"], { doubleElimination: true }),
+        gameEvent("P1", "P4", day(1)), // Winners semifinal
+        gameEvent("P2", "P3", day(2)), // Winners semifinal
+        gameEvent("P4", "P3", day(3)), // Losers round 1
+        gameEvent("P1", "P2", day(4)), // Winners final
+        gameEvent("P2", "P4", day(5)), // Losers final
+        gameEvent("P2", "P1", day(6)), // Grand final won by the losers bracket champion
+        gameEvent("P1", "P2", day(7)), // Bracket reset
+      ]),
+    )!;
+
+    expect(timeline.sections.map((s) => s.key)).toEqual(["winners", "losers", "grand-final"]);
+    expect(span(timeline)).toEqual([0, 7]);
+    expect(timeline.completed).toBe(true);
+    expect(timeline.gamesPlayed).toBe(7);
+    expect(timeline.gamesTotal).toBe(7);
+
+    expect(span(section(timeline.sections, "winners"))).toEqual([0, 4]);
+
+    // Losers round 1 can only start once the winners semifinals produced its two players
+    const losers = section(timeline.sections, "losers");
+    expect(span(losers)).toEqual([2, 5]);
+    expect(span(losers.subSections[0])).toEqual([2, 3]); // Losers round 1
+    // The losers final waits for the winners final loser, not just for the previous losers round
+    expect(span(losers.subSections[1])).toEqual([4, 5]);
+
+    // The grand final waits for both bracket champions, and the reset follows it
+    const grandFinal = section(timeline.sections, "grand-final");
+    expect(span(grandFinal)).toEqual([5, 7]);
+    expect(grandFinal.subSections.map((sub) => sub.ref)).toEqual([{ kind: "grand-final-game" }, { kind: "bracket-reset" }]);
+    expect(span(grandFinal.subSections[0])).toEqual([5, 6]);
+    expect(span(grandFinal.subSections[1])).toEqual([6, 7]);
+  });
+
+  it("leaves out the bracket reset when the winners bracket champion holds on", () => {
+    const timeline = buildTournamentTimeline(
+      getTournament([
+        ...baseEvents(["P1", "P2", "P3", "P4"], { doubleElimination: true }),
+        gameEvent("P1", "P4", day(1)),
+        gameEvent("P2", "P3", day(2)),
+        gameEvent("P4", "P3", day(3)),
+        gameEvent("P1", "P2", day(4)),
+        gameEvent("P2", "P4", day(5)),
+        gameEvent("P1", "P2", day(6)), // Grand final won by the winners bracket champion
+      ]),
+    )!;
+
+    const grandFinal = section(timeline.sections, "grand-final");
+    expect(grandFinal.subSections.map((sub) => sub.ref)).toEqual([{ kind: "grand-final-game" }]);
+    expect(timeline.gamesTotal).toBe(6);
+    expect(timeline.completed).toBe(true);
+  });
+
+  it("marks the rounds still being played as not completed", () => {
+    const timeline = buildTournamentTimeline(
+      getTournament([
+        ...baseEvents(["P1", "P2", "P3", "P4"]),
+        gameEvent("P1", "P4", day(1)), // Only one of the two semifinals is played
+      ]),
+    )!;
+
+    const bracket = section(timeline.sections, "winners");
+    expect(timeline.completed).toBe(false);
+    expect(timeline.gamesPlayed).toBe(1);
+    expect(timeline.gamesTotal).toBe(3);
+
+    const semiFinals = bracket.subSections[0];
+    expect(semiFinals.completed).toBe(false);
+    expect(span(semiFinals)).toEqual([0, 1]);
+
+    // The final has not been reachable yet, so it has no games and falls back to the last known boundary
+    const final = bracket.subSections[1];
+    expect(final.completed).toBe(false);
+    expect(final.gamesPlayed).toBe(0);
+    expect(final.lastGameAt).toBeUndefined();
+    expect(span(final)).toEqual([0, undefined]);
+  });
+
+  it("skips losers bracket rounds that only hold walkovers", () => {
+    // 3 players: only one winners first round game is played, so losers round 1 is a walkover
+    const timeline = buildTournamentTimeline(
+      getTournament([
+        ...baseEvents(["P1", "P2", "P3"], { doubleElimination: true }),
+        gameEvent("P2", "P3", day(1)), // Winners first round
+        gameEvent("P1", "P2", day(2)), // Winners final
+        gameEvent("P3", "P2", day(3)), // Losers final: P3 took the walkover, P2 dropped down
+        gameEvent("P1", "P3", day(4)), // Grand final
+      ]),
+    )!;
+
+    const losers = section(timeline.sections, "losers");
+    // Only the losers final is a real game. Round 1 is a walkover and never shows up
+    expect(losers.subSections.map((sub) => sub.ref)).toEqual([{ kind: "losers-layer", layerIndex: 0, totalLayers: 2 }]);
+    expect(span(losers)).toEqual([2, 3]);
+    expect(timeline.completed).toBe(true);
+    expect(timeline.gamesTotal).toBe(4);
+  });
+});

--- a/frontend/src/client/client-db/tournaments/tournament-timeline.ts
+++ b/frontend/src/client/client-db/tournaments/tournament-timeline.ts
@@ -1,0 +1,234 @@
+import { Tournament, TournamentGame } from "./tournament";
+
+/**
+ * How long each part of a tournament took, laid out as a sequence of segments that can be drawn as
+ * a Gantt style timeline.
+ *
+ * A segment's clock starts when it became possible to play it, not when its first game happened:
+ * waiting for players to show up is part of how long a round took. Concretely that means the round
+ * before it finished (its `anchor`), and for a losers bracket round also that the winners bracket
+ * round feeding it finished. Group play is the exception - all groups run in parallel from the
+ * tournament start.
+ *
+ * A segment ends at its last completed game. Segments that still have games left to play report
+ * `completed: false` and the consumer decides what to draw them up against (usually "now").
+ */
+
+export type TimelineRef =
+  | { kind: "group"; groupIndex: number }
+  | { kind: "winners-layer"; layerIndex: number }
+  | { kind: "losers-layer"; layerIndex: number; totalLayers: number }
+  | { kind: "grand-final-game" }
+  | { kind: "bracket-reset" };
+
+export type TimelineSectionKind = "group-play" | "winners" | "losers" | "grand-final";
+
+type TimelineSegment = {
+  /** Stable identity, used as the react key */
+  key: string;
+  /** When this segment's clock started */
+  start: number;
+  /** Completion time of the last game played in it. Undefined until a game has been completed */
+  lastGameAt?: number;
+  /** Every game in the segment has been completed */
+  completed: boolean;
+  gamesPlayed: number;
+  gamesTotal: number;
+};
+
+export type TimelineSubSection = TimelineSegment & { ref: TimelineRef };
+
+export type TimelineSection = TimelineSegment & {
+  kind: TimelineSectionKind;
+  /** Group play runs its groups side by side. Bracket rounds follow each other */
+  parallelSubSections: boolean;
+  subSections: TimelineSubSection[];
+};
+
+export type TournamentTimeline = TimelineSegment & { sections: TimelineSection[] };
+
+/** Games that are structurally never played: empty byes and walkovers (a lone player, no game) */
+function isPlayableGame(game: Partial<TournamentGame>): boolean {
+  return game.isBye !== true && game.walkover !== true;
+}
+
+function completionTimes(games: Partial<TournamentGame>[]): number[] {
+  return games.map((game) => game.completedAt).filter((time): time is number => time !== undefined);
+}
+
+/**
+ * A segment starts at its anchor - unless a game in it was somehow completed before that, in which
+ * case the earliest game wins so the segment never starts after its own first game
+ */
+function segment(
+  key: string,
+  anchor: number,
+  times: number[],
+  gamesTotal: number,
+): TimelineSegment {
+  const gamesPlayed = times.length;
+  return {
+    key,
+    start: gamesPlayed > 0 ? Math.min(anchor, Math.min(...times)) : anchor,
+    lastGameAt: gamesPlayed > 0 ? Math.max(...times) : undefined,
+    completed: gamesPlayed >= gamesTotal,
+    gamesPlayed,
+    gamesTotal,
+  };
+}
+
+/**
+ * Roll a list of sub sections up into the totals of the section holding them. A section starts
+ * where its first sub section starts, which for the losers bracket is later than the bracket
+ * itself: it can only get going once the first winners round has produced someone to drop down
+ */
+function aggregate(subSections: TimelineSegment[], anchor: number): Omit<TimelineSegment, "key"> {
+  const ends = subSections.map((sub) => sub.lastGameAt).filter((time): time is number => time !== undefined);
+  return {
+    start: subSections.length > 0 ? Math.min(...subSections.map((sub) => sub.start)) : anchor,
+    lastGameAt: ends.length > 0 ? Math.max(...ends) : undefined,
+    completed: subSections.every((sub) => sub.completed),
+    gamesPlayed: subSections.reduce((sum, sub) => sum + sub.gamesPlayed, 0),
+    gamesTotal: subSections.reduce((sum, sub) => sum + sub.gamesTotal, 0),
+  };
+}
+
+/** The time a segment handed over to the next one, or undefined while it is still being played */
+function handoverTime(sub: TimelineSegment | undefined): number | undefined {
+  return sub?.completed ? sub.lastGameAt : undefined;
+}
+
+export function buildTournamentTimeline(tournament: Tournament): TournamentTimeline | undefined {
+  const bracket = tournament.bracket;
+  const groupPlay = tournament.groupPlay;
+  if (!groupPlay && !bracket) return undefined; // Tournament has not started
+
+  const sections: TimelineSection[] = [];
+
+  if (groupPlay) {
+    // All groups start together at the tournament start and are played in parallel
+    const subSections: TimelineSubSection[] = groupPlay.groups.map((group, groupIndex) => ({
+      ...segment(`group-${groupIndex}`, tournament.startDate, completionTimes(group.groupGames), group.groupGames.length),
+      ref: { kind: "group", groupIndex },
+    }));
+    sections.push({
+      key: "group-play",
+      kind: "group-play",
+      parallelSubSections: true,
+      subSections,
+      ...aggregate(subSections, tournament.startDate),
+    });
+  }
+
+  if (bracket) {
+    const winnersSubSections: TimelineSubSection[] = [];
+    // Layer indexes are inverted: the deepest layer is played first, layer 0 is the final
+    const deepestLayer = bracket.bracket.length - 1;
+    let anchor = bracket.bracketStarted;
+    for (let layerIndex = deepestLayer; layerIndex >= 0; layerIndex--) {
+      const layer = bracket.bracket[layerIndex];
+      // Only the deepest layer can hold structural byes: empty qualifier slots no one reaches.
+      // Every game in a shallower layer is either seeded or fed by the layer below it
+      const gamesTotal =
+        layerIndex === deepestLayer
+          ? layer.filter((game) => game.player1 !== undefined && game.player2 !== undefined).length
+          : layer.length;
+      if (gamesTotal === 0) continue;
+      const sub: TimelineSubSection = {
+        ...segment(`winners-${layerIndex}`, anchor, completionTimes(bracket.bracketGames[layerIndex].played), gamesTotal),
+        ref: { kind: "winners-layer", layerIndex },
+      };
+      winnersSubSections.push(sub);
+      anchor = handoverTime(sub) ?? anchor;
+    }
+    if (winnersSubSections.length > 0) {
+      sections.push({
+        key: "winners",
+        kind: "winners",
+        parallelSubSections: false,
+        subSections: winnersSubSections,
+        ...aggregate(winnersSubSections, bracket.bracketStarted),
+      });
+    }
+
+    const losersBracket = bracket.losersBracket;
+    if (losersBracket && losersBracket.length > 0) {
+      const totalLayers = losersBracket.length;
+      const winnersLayerCount = bracket.bracket.length;
+      const losersSubSections: TimelineSubSection[] = [];
+      let losersAnchor = bracket.bracketStarted;
+      for (let layerIndex = totalLayers - 1; layerIndex >= 0; layerIndex--) {
+        const gamesTotal = losersBracket[layerIndex].filter(isPlayableGame).length;
+        if (gamesTotal === 0) continue; // Round holds only byes and walkovers, so it is never played
+        // A losers round can only start once the winners round that drops players into it is done.
+        // Round 1 takes the first winners round's losers, later even ("major") rounds take the
+        // losers of one winners round each. Odd rounds are played among losers only
+        const round = totalLayers - layerIndex;
+        const feederLayerIndex =
+          round === 1 ? winnersLayerCount - 1 : round % 2 === 0 ? winnersLayerCount - 1 - round / 2 : undefined;
+        const feederEnd =
+          feederLayerIndex === undefined
+            ? undefined
+            : handoverTime(winnersSubSections.find((sub) => sub.key === `winners-${feederLayerIndex}`));
+        const sub: TimelineSubSection = {
+          ...segment(
+            `losers-${layerIndex}`,
+            Math.max(losersAnchor, feederEnd ?? losersAnchor),
+            completionTimes(bracket.losersBracketGames?.[layerIndex].played ?? []),
+            gamesTotal,
+          ),
+          ref: { kind: "losers-layer", layerIndex, totalLayers },
+        };
+        losersSubSections.push(sub);
+        losersAnchor = handoverTime(sub) ?? losersAnchor;
+      }
+      if (losersSubSections.length > 0) {
+        sections.push({
+          key: "losers",
+          kind: "losers",
+          parallelSubSections: false,
+          subSections: losersSubSections,
+          ...aggregate(losersSubSections, bracket.bracketStarted),
+        });
+      }
+    }
+
+    const grandFinal = bracket.grandFinal;
+    if (grandFinal) {
+      // The grand final waits for both bracket champions
+      const bracketChampionsReady = ["winners", "losers"]
+        .map((key) => sections.find((section) => section.key === key))
+        .map((section) => handoverTime(section) ?? bracket.bracketStarted);
+      const grandFinalAnchor = Math.max(bracket.bracketStarted, ...bracketChampionsReady);
+
+      const subSections: TimelineSubSection[] = [
+        {
+          ...segment("grand-final-game", grandFinalAnchor, completionTimes([grandFinal]), 1),
+          ref: { kind: "grand-final-game" },
+        },
+      ];
+      // The bracket reset is only played if the losers bracket champion won the grand final
+      const bracketReset = bracket.bracketReset;
+      if (bracketReset?.player1 !== undefined) {
+        subSections.push({
+          ...segment(
+            "bracket-reset",
+            handoverTime(subSections[0]) ?? grandFinalAnchor,
+            completionTimes([bracketReset]),
+            1,
+          ),
+          ref: { kind: "bracket-reset" },
+        });
+      }
+      sections.push({
+        key: "grand-final",
+        kind: "grand-final",
+        parallelSubSections: false,
+        subSections,
+        ...aggregate(subSections, grandFinalAnchor),
+      });
+    }
+  }
+
+  return { key: "tournament", ...aggregate(sections, tournament.startDate), sections };
+}

--- a/frontend/src/pages/tournament/stats/timeline-widget.tsx
+++ b/frontend/src/pages/tournament/stats/timeline-widget.tsx
@@ -58,9 +58,8 @@ export const TournamentTimelineWidget: React.FC<{ tournament: Tournament }> = ({
   if (!timeline) {
     return (
       <WidgetFrame>
-        <p className="text-sm text-primary-text/70">
-          The tournament has not started yet, so there is nothing on the timeline.
-        </p>
+        <Header />
+        <p className="text-sm font-light">The tournament has not started yet, so there is nothing on the timeline.</p>
       </WidgetFrame>
     );
   }
@@ -102,14 +101,11 @@ export const TournamentTimelineWidget: React.FC<{ tournament: Tournament }> = ({
 
   return (
     <WidgetFrame>
-      <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 mb-6">
-        <h2 className="text-xl font-bold">Timeline</h2>
-        <p className="text-sm text-primary-text/70">
-          {timeline.completed ? "Ran for" : "Running for"} <span className="font-semibold">{formatSpan(total)}</span>
-          {" · "}
-          {fmtNum(timeline.gamesPlayed)} of {fmtNum(timeline.gamesTotal)} games played
-        </p>
-      </div>
+      <Header>
+        {timeline.completed ? "Ran for" : "Running for"} <span className="font-bold">{formatSpan(total)}</span>
+        {" · "}
+        {fmtNum(timeline.gamesPlayed)} of {fmtNum(timeline.gamesTotal)} games played
+      </Header>
 
       <div className="overflow-x-auto pb-1">
         <div className={classNames("space-y-1", CHART_MIN_WIDTH)}>
@@ -121,7 +117,7 @@ export const TournamentTimelineWidget: React.FC<{ tournament: Tournament }> = ({
               {ticks.map((tick) => (
                 <div
                   key={tick.at}
-                  className="absolute bottom-0 text-[0.6rem] leading-none text-primary-text/50 -translate-x-1/2"
+                  className="absolute bottom-0 text-[0.65rem] leading-none font-light -translate-x-1/2"
                   style={{ left: `${(tick.at / total) * 100}%` }}
                 >
                   {tick.label}
@@ -143,7 +139,7 @@ export const TournamentTimelineWidget: React.FC<{ tournament: Tournament }> = ({
         </div>
       </div>
 
-      <p className="mt-6 text-xs text-primary-text/50 leading-relaxed">
+      <p className="mt-6 text-xs font-light leading-relaxed">
         A round's clock starts when it became possible to play - when the round feeding it finished - and ends at its
         last game, so the waiting counts towards how long it took. The groups of the group play all start together at
         the tournament start.
@@ -155,6 +151,13 @@ export const TournamentTimelineWidget: React.FC<{ tournament: Tournament }> = ({
 const WidgetFrame: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <div className="ring-1 ring-secondary-background w-full max-w-4xl mx-auto px-4 md:px-6 py-6 text-primary-text bg-primary-background rounded-lg shadow-sm">
     {children}
+  </div>
+);
+
+const Header: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
+  <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 mb-6">
+    <h2 className="text-xl font-bold">Timeline</h2>
+    {children && <p className="text-sm">{children}</p>}
   </div>
 );
 
@@ -184,48 +187,47 @@ const TimelineRow: React.FC<{
       }
     >
       <div className={classNames(LABEL_COLUMN, "shrink-0", isSection ? "" : "pl-3")}>
-        <p
-          className={classNames(
-            "truncate",
-            isSection ? "text-sm font-semibold" : "text-xs text-primary-text/80",
-            notStarted && "text-primary-text/40",
-          )}
-        >
+        <p className={classNames("truncate", isSection ? "text-sm font-semibold" : "text-xs font-normal")}>
           {row.label}
         </p>
-        {row.sublabel && <p className="truncate text-[0.6rem] font-light text-primary-text/50">{row.sublabel}</p>}
+        {row.sublabel && <p className="truncate text-[0.65rem] font-light">{row.sublabel}</p>}
       </div>
 
       {/* Kept left of the bar so the durations stay readable when the chart scrolls sideways */}
       <div className={classNames(DURATION_COLUMN, "shrink-0 text-right")}>
-        <p className={classNames(isSection ? "text-sm font-medium" : "text-xs", notStarted && "text-primary-text/40")}>
+        <p
+          className={classNames(
+            isSection ? "text-sm font-medium" : "text-xs",
+            notStarted && "font-light italic",
+            ongoing && !notStarted && "italic",
+          )}
+        >
           {notStarted ? "not started" : formatSpan(span)}
         </p>
-        <p className="text-[0.6rem] font-light text-primary-text/50">
+        <p className="text-[0.65rem] font-light">
           {fmtNum(row.gamesPlayed)}/{fmtNum(row.gamesTotal)} games
         </p>
       </div>
 
-      <div
-        className={classNames(
-          "relative grow overflow-hidden rounded bg-secondary-background/15",
-          isSection ? "h-5" : "h-3.5",
-        )}
-      >
+      {/* Everything here is the secondary background on the widget's primary one - the contrast
+          every card in the app already relies on, so it holds up in every theme. The lane is only a
+          hairline and the axis grid thin ticks, leaving the played span as the one solid block */}
+      <div className={classNames("relative grow", isSection ? "h-5" : "h-3")}>
+        <div className="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-secondary-background" />
         {gridLines.map((at) => (
           <div
             key={at}
-            className="absolute inset-y-0 w-px bg-primary-text/10"
+            className="absolute inset-y-0 w-px bg-secondary-background"
             style={{ left: `${(at / total) * 100}%` }}
           />
         ))}
-        {/* A round with no games played has no span to draw: the empty track says it all */}
+        {/* A round with no games played has no span to draw: the bare lane says it all */}
         {notStarted === false && (
           <div
             className={classNames(
-              "absolute inset-y-0 rounded",
-              isSection ? "bg-secondary-background" : "bg-secondary-background/60",
-              ongoing && "ring-1 ring-tertiary-background",
+              "absolute inset-y-0 rounded bg-secondary-background",
+              // An unfinished span runs up against now rather than a game, marked with a torn edge
+              ongoing && "border-r-2 border-dashed border-primary-background",
             )}
             style={{ left: `${leftPercent}%`, width: `max(${widthPercent}%, 3px)` }}
           />

--- a/frontend/src/pages/tournament/stats/timeline-widget.tsx
+++ b/frontend/src/pages/tournament/stats/timeline-widget.tsx
@@ -1,0 +1,285 @@
+import { useMemo } from "react";
+import { Tournament } from "../../../client/client-db/tournaments/tournament";
+import {
+  buildTournamentTimeline,
+  TimelineRef,
+  TimelineSection,
+} from "../../../client/client-db/tournaments/tournament-timeline";
+import { classNames } from "../../../common/class-names";
+import { fmtNum } from "../../../common/number-utils";
+import { ONE_DAY, ONE_HOUR, ONE_MINUTE } from "../../../common/time-in-ms";
+import { layerIndexToTournamentRound, losersRoundLabel } from "../../leaderboard/tournament-pending-games";
+
+type Row = {
+  key: string;
+  label: string;
+  sublabel?: string;
+  depth: 0 | 1;
+  start: number;
+  /** Undefined while the row still has games left to play */
+  end?: number;
+  gamesPlayed: number;
+  gamesTotal: number;
+};
+
+/**
+ * The three columns of every row: what it is, how long it took, and the bar showing when. Fixed
+ * widths with a minimum for the bars, so the chart scrolls sideways on a narrow screen instead of
+ * squeezing the bars and the axis labels into each other
+ */
+const LABEL_COLUMN = "w-52";
+const DURATION_COLUMN = "w-24";
+const CHART_MIN_WIDTH = "min-w-[35rem]";
+
+const DAY_STEPS = [0.5, 1, 2, 3, 5, 7, 14, 30, 60, 90, 180, 365];
+const HOUR_STEPS = [1, 2, 3, 6, 12];
+
+/** Axis ticks measured from the tournament start, in days unless the whole thing fits in a day */
+function buildTicks(total: number): { at: number; label: string }[] {
+  const ticks: { at: number; label: string }[] = [];
+  const unit = total < ONE_DAY ? ONE_HOUR : ONE_DAY;
+  const suffix = unit === ONE_HOUR ? "h" : "d";
+  const steps = unit === ONE_HOUR ? HOUR_STEPS : DAY_STEPS;
+  const totalUnits = total / unit;
+  const step = steps.find((candidate) => totalUnits / candidate <= 6) ?? Math.ceil(totalUnits / 6);
+  for (let value = 0; value <= totalUnits + 1e-9; value += step) {
+    // A tick right at the end would be cut off by the edge of the chart
+    if (value / totalUnits > 0.96) break;
+    ticks.push({ at: value * unit, label: `${fmtNum(value, { digits: step < 1 ? 1 : 0 })}${suffix}` });
+  }
+  return ticks;
+}
+
+export const TournamentTimelineWidget: React.FC<{ tournament: Tournament }> = ({ tournament }) => {
+  const timeline = useMemo(() => buildTournamentTimeline(tournament), [tournament]);
+  // A tournament that is still running is drawn up against now, so the last bar keeps growing
+  const now = Date.now();
+
+  if (!timeline) {
+    return (
+      <WidgetFrame>
+        <p className="text-sm text-primary-text/70">
+          The tournament has not started yet, so there is nothing on the timeline.
+        </p>
+      </WidgetFrame>
+    );
+  }
+
+  const doubleElimination = tournament.tournamentConfig.doubleElimination;
+  const rows: Row[] = [];
+  for (const section of timeline.sections) {
+    rows.push({
+      key: section.key,
+      label: sectionLabel(section, doubleElimination),
+      depth: 0,
+      start: section.start,
+      end: section.completed ? section.lastGameAt : undefined,
+      gamesPlayed: section.gamesPlayed,
+      gamesTotal: section.gamesTotal,
+    });
+    // A single sub section would just repeat its section
+    if (section.subSections.length <= 1) continue;
+    for (const sub of section.subSections) {
+      const { label, sublabel } = refLabel(sub.ref);
+      rows.push({
+        key: `${section.key}-${sub.key}`,
+        label,
+        sublabel,
+        depth: 1,
+        start: sub.start,
+        end: sub.completed ? sub.lastGameAt : undefined,
+        gamesPlayed: sub.gamesPlayed,
+        gamesTotal: sub.gamesTotal,
+      });
+    }
+  }
+
+  const start = timeline.start;
+  const end = timeline.completed ? timeline.lastGameAt ?? start : now;
+  const total = Math.max(end - start, ONE_MINUTE); // Never divide by zero on a same-minute tournament
+
+  const ticks = buildTicks(total);
+
+  return (
+    <WidgetFrame>
+      <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 mb-6">
+        <h2 className="text-xl font-bold">Timeline</h2>
+        <p className="text-sm text-primary-text/70">
+          {timeline.completed ? "Ran for" : "Running for"} <span className="font-semibold">{formatSpan(total)}</span>
+          {" · "}
+          {fmtNum(timeline.gamesPlayed)} of {fmtNum(timeline.gamesTotal)} games played
+        </p>
+      </div>
+
+      <div className="overflow-x-auto pb-1">
+        <div className={classNames("space-y-1", CHART_MIN_WIDTH)}>
+          {/* Axis, days from the tournament start */}
+          <div className="flex items-end gap-2">
+            <div className={classNames(LABEL_COLUMN, "shrink-0")} />
+            <div className={classNames(DURATION_COLUMN, "shrink-0")} />
+            <div className="relative grow h-4">
+              {ticks.map((tick) => (
+                <div
+                  key={tick.at}
+                  className="absolute bottom-0 text-[0.6rem] leading-none text-primary-text/50 -translate-x-1/2"
+                  style={{ left: `${(tick.at / total) * 100}%` }}
+                >
+                  {tick.label}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {rows.map((row) => (
+            <TimelineRow
+              key={row.key}
+              row={row}
+              timelineStart={start}
+              total={total}
+              now={now}
+              gridLines={ticks.map((tick) => tick.at)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <p className="mt-6 text-xs text-primary-text/50 leading-relaxed">
+        A round's clock starts when it became possible to play - when the round feeding it finished - and ends at its
+        last game, so the waiting counts towards how long it took. The groups of the group play all start together at
+        the tournament start.
+      </p>
+    </WidgetFrame>
+  );
+};
+
+const WidgetFrame: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="ring-1 ring-secondary-background w-full max-w-4xl mx-auto px-4 md:px-6 py-6 text-primary-text bg-primary-background rounded-lg shadow-sm">
+    {children}
+  </div>
+);
+
+const TimelineRow: React.FC<{
+  row: Row;
+  timelineStart: number;
+  total: number;
+  now: number;
+  gridLines: number[];
+}> = ({ row, timelineStart, total, now, gridLines }) => {
+  const isSection = row.depth === 0;
+  const ongoing = row.end === undefined;
+  const notStarted = ongoing && row.gamesPlayed === 0;
+  const barEnd = row.end ?? now;
+  const span = Math.max(0, barEnd - row.start);
+
+  const leftPercent = ((row.start - timelineStart) / total) * 100;
+  const widthPercent = (span / total) * 100;
+
+  return (
+    <div
+      className={classNames("flex items-center gap-2", isSection && "pt-2")}
+      title={
+        notStarted
+          ? "No games played yet"
+          : `${formatDateTime(row.start)} → ${ongoing ? "ongoing" : formatDateTime(barEnd)}`
+      }
+    >
+      <div className={classNames(LABEL_COLUMN, "shrink-0", isSection ? "" : "pl-3")}>
+        <p
+          className={classNames(
+            "truncate",
+            isSection ? "text-sm font-semibold" : "text-xs text-primary-text/80",
+            notStarted && "text-primary-text/40",
+          )}
+        >
+          {row.label}
+        </p>
+        {row.sublabel && <p className="truncate text-[0.6rem] font-light text-primary-text/50">{row.sublabel}</p>}
+      </div>
+
+      {/* Kept left of the bar so the durations stay readable when the chart scrolls sideways */}
+      <div className={classNames(DURATION_COLUMN, "shrink-0 text-right")}>
+        <p className={classNames(isSection ? "text-sm font-medium" : "text-xs", notStarted && "text-primary-text/40")}>
+          {notStarted ? "not started" : formatSpan(span)}
+        </p>
+        <p className="text-[0.6rem] font-light text-primary-text/50">
+          {fmtNum(row.gamesPlayed)}/{fmtNum(row.gamesTotal)} games
+        </p>
+      </div>
+
+      <div
+        className={classNames(
+          "relative grow overflow-hidden rounded bg-secondary-background/15",
+          isSection ? "h-5" : "h-3.5",
+        )}
+      >
+        {gridLines.map((at) => (
+          <div
+            key={at}
+            className="absolute inset-y-0 w-px bg-primary-text/10"
+            style={{ left: `${(at / total) * 100}%` }}
+          />
+        ))}
+        {/* A round with no games played has no span to draw: the empty track says it all */}
+        {notStarted === false && (
+          <div
+            className={classNames(
+              "absolute inset-y-0 rounded",
+              isSection ? "bg-secondary-background" : "bg-secondary-background/60",
+              ongoing && "ring-1 ring-tertiary-background",
+            )}
+            style={{ left: `${leftPercent}%`, width: `max(${widthPercent}%, 3px)` }}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+function sectionLabel(section: TimelineSection, doubleElimination: boolean): string {
+  switch (section.kind) {
+    case "group-play":
+      return "Group play";
+    case "winners":
+      return doubleElimination ? "Winners bracket" : "Bracket";
+    case "losers":
+      return "Losers bracket";
+    case "grand-final":
+      return "Grand Final";
+  }
+}
+
+function refLabel(ref: TimelineRef): { label: string; sublabel?: string } {
+  switch (ref.kind) {
+    case "group":
+      return { label: `Group ${ref.groupIndex + 1}` };
+    case "winners-layer":
+      return { label: layerIndexToTournamentRound(ref.layerIndex) ?? `Layer ${ref.layerIndex}` };
+    case "losers-layer": {
+      const { title, subtitle } = losersRoundLabel(ref.layerIndex, ref.totalLayers);
+      return { label: title, sublabel: subtitle };
+    }
+    case "grand-final-game":
+      return { label: "Grand Final" };
+    case "bracket-reset":
+      return { label: "Bracket Reset" };
+  }
+}
+
+/** Durations are read in days, but sub-day spans would all collapse to "0 days" */
+function formatSpan(ms: number): string {
+  if (ms < ONE_MINUTE) return "< 1 min";
+  if (ms < ONE_HOUR) return `${fmtNum(ms / ONE_MINUTE)} min`;
+  if (ms < ONE_DAY) return `${fmtNum(ms / ONE_HOUR, { digits: 1 })} hours`;
+  const days = ms / ONE_DAY;
+  return `${fmtNum(days, { digits: days < 10 ? 1 : 0 })} days`;
+}
+
+function formatDateTime(time: number): string {
+  return new Intl.DateTimeFormat("en-US", {
+    minute: "numeric",
+    hour: "numeric",
+    hour12: false,
+    day: "numeric",
+    month: "short",
+  }).format(new Date(time));
+}

--- a/frontend/src/pages/tournament/stats/tournament-stats.tsx
+++ b/frontend/src/pages/tournament/stats/tournament-stats.tsx
@@ -2,7 +2,7 @@ import { Tournament } from "../../../client/client-db/tournaments/tournament";
 import { TournamentTimelineWidget } from "./timeline-widget";
 
 /**
- * Admin only stats tab. One widget per stat, stacked. Currently only the timeline
+ * The statistics tab. One widget per stat, stacked. Currently only the timeline
  */
 export const TournamentStats: React.FC<{ tournament: Tournament }> = ({ tournament }) => {
   return (

--- a/frontend/src/pages/tournament/stats/tournament-stats.tsx
+++ b/frontend/src/pages/tournament/stats/tournament-stats.tsx
@@ -1,0 +1,13 @@
+import { Tournament } from "../../../client/client-db/tournaments/tournament";
+import { TournamentTimelineWidget } from "./timeline-widget";
+
+/**
+ * Admin only stats tab. One widget per stat, stacked. Currently only the timeline
+ */
+export const TournamentStats: React.FC<{ tournament: Tournament }> = ({ tournament }) => {
+  return (
+    <div className="space-y-4">
+      <TournamentTimelineWidget tournament={tournament} />
+    </div>
+  );
+};

--- a/frontend/src/pages/tournament/tournament-page.tsx
+++ b/frontend/src/pages/tournament/tournament-page.tsx
@@ -11,9 +11,19 @@ import { TournamentBracket } from "./tournament-bracket";
 import { TournamentLosersBracket } from "./tournament-losers-bracket";
 import { TournamentGrandFinal } from "./tournament-grand-final";
 import { TournamentAvailablePlayers } from "./tournament-available-players";
+import { TournamentStats } from "./stats/tournament-stats";
 import { session } from "../../services/auth/session";
 
-type TabType = "grand-final" | "finals" | "losers" | "group-play" | "signup" | "info" | "predictions" | "available";
+type TabType =
+  | "grand-final"
+  | "finals"
+  | "losers"
+  | "group-play"
+  | "signup"
+  | "info"
+  | "predictions"
+  | "available"
+  | "stats";
 
 export const TournamentPage: React.FC = () => {
   const { tournament: tournamentId, player1, player2 } = useTennisParams();
@@ -42,6 +52,7 @@ export const TournamentPage: React.FC = () => {
       visible: tournament !== undefined && tournament.startDate < Date.now(),
     },
     { id: "available", label: "Available today", visible: isAdmin && tournament?.hasPendingGames === true },
+    { id: "stats", label: "Stats", visible: isAdmin },
   ];
   const visibleTabs = tabs.filter((t) => t.visible);
   const isVisibleTab = (id: string | null | undefined): id is TabType => visibleTabs.some((t) => t.id === id);
@@ -150,6 +161,7 @@ export const TournamentPage: React.FC = () => {
       {activeTab === "signup" && <TournamentSignup tournament={tournament} />}
       {activeTab === "predictions" && <TournamentPredictions tournament={tournament} />}
       {activeTab === "available" && <TournamentAvailablePlayers tournament={tournament} />}
+      {activeTab === "stats" && <TournamentStats tournament={tournament} />}
     </div>
   );
 };

--- a/frontend/src/pages/tournament/tournament-page.tsx
+++ b/frontend/src/pages/tournament/tournament-page.tsx
@@ -52,7 +52,7 @@ export const TournamentPage: React.FC = () => {
       visible: tournament !== undefined && tournament.startDate < Date.now(),
     },
     { id: "available", label: "Available today", visible: isAdmin && tournament?.hasPendingGames === true },
-    { id: "stats", label: "Stats", visible: isAdmin },
+    { id: "stats", label: "Statistics", visible: true },
   ];
   const visibleTabs = tabs.filter((t) => t.visible);
   const isVisibleTab = (id: string | null | undefined): id is TabType => visibleTabs.some((t) => t.id === id);


### PR DESCRIPTION
The timeline lays the tournament out as a Gantt style chart: group play with
one bar per group, the bracket with one bar per round, and for double
elimination the winners bracket, losers bracket and grand final as their own
sections.

A round's clock starts when it became possible to play it - the round feeding
it finished, and for a losers bracket round also the winners bracket round
dropping players into it - and ends at its last game, so the waiting is part
of how long the round took. Group play is the exception: its groups run in
parallel from the tournament start.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Vnm6XGPavmU1xdWM8BGHPF