### PR TITLE
Add a new connections widget to the tournament statistics tab

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -43,8 +43,8 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
       ),
       list(
         "First-ever meetings - pairs who had never played each other before, with how many games each of them had behind them",
-        "Reunions - pairs who had not met in 90 days or more, and how long it had been",
-        "New faces - players whose first ever game came in the tournament, players back after 90 days away, and players in their first tournament",
+        "Reunions - pairs who had not met in six months or more, and how long it had been",
+        "New faces - players whose first ever game came in the tournament, players back after six months away, and players in their first tournament, longest absence first",
       ),
       text(
         "Everything is measured against the club as it stood the moment the tournament started. That single baseline is what keeps the numbers steady: a pair meeting twice, in group play and then again in the bracket, is one first meeting rather than a meeting followed by a rematch. Skipped games, byes and walkovers are left out, since nobody met over them.",

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -42,9 +42,11 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
         "New connections sits under the timeline on the Statistics tab. It answers the thing a bracket cannot: who did this tournament put in front of each other that an ordinary week never would.",
       ),
       list(
-        "First-ever meetings - pairs who had never played each other before, with how many games each of them had behind them",
+        "First-ever meetings - pairs who had never played each other before",
         "Reunions - pairs who had not met in six months or more, and how long it had been",
-        "New faces - players whose first ever game came in the tournament, players back after six months away, and players in their first tournament, longest absence first",
+        "First game ever - players who had never played in the club until this tournament",
+        "Back after a break - players returning after six months or more away, longest absence first",
+        "First tournament - players who had been playing all along, but never in a tournament",
       ),
       text(
         "Everything is measured against the club as it stood the moment the tournament started. That single baseline is what keeps the numbers steady: a pair meeting twice, in group play and then again in the bracket, is one first meeting rather than a meeting followed by a rematch. Skipped games, byes and walkovers are left out, since nobody met over them.",

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -31,15 +31,29 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
-    slug: "tournament-new-connections",
-    title: "New connections in the tournament statistics",
+    slug: "tournament-statistics-timeline",
+    title: "A Statistics tab on tournaments",
     date: "2026-07-30",
     tags: ["new-feature"],
     summary:
-      "A widget showing which pairs met for the first time, who had not played each other in months, and which players the tournament brought back or brought in.",
+      "Two widgets alongside the bracket and info tabs: a timeline of how long each part of the tournament took, and the pairs and players the tournament brought together.",
     body: [
       text(
-        "New connections sits under the timeline on the Statistics tab. It answers the thing a bracket cannot: who did this tournament put in front of each other that an ordinary week never would.",
+        "The Statistics tab sits alongside the bracket and info tabs, and holds one widget per stat.",
+      ),
+      text(
+        "The timeline draws one bar per part of the tournament, laid out over the days since it started.",
+      ),
+      list(
+        "Group play, with a bar per group",
+        "The bracket, with a bar per round",
+        "For double elimination: the winners bracket, the losers bracket and the grand final as their own sections",
+      ),
+      text(
+        "A round's clock starts when it became possible to play - the round feeding it finished, and for a losers bracket round also the winners bracket round dropping players into it - and ends at its last game. Waiting for people to show up is therefore part of how long a round took, which is usually the more interesting number. Group play is the exception: its groups run side by side from the tournament start. Rounds still being played run up against now, and rounds nobody has reached yet read as not started.",
+      ),
+      text(
+        "New connections sits under it, and answers the thing a bracket cannot: who did this tournament put in front of each other that an ordinary week never would.",
       ),
       list(
         "First-ever meetings - pairs who had never played each other before",
@@ -49,33 +63,11 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
         "First tournament - players who had been playing all along, but never in a tournament",
       ),
       text(
-        "Everything is measured against the club as it stood the moment the tournament started. That single baseline is what keeps the numbers steady: a pair meeting twice, in group play and then again in the bracket, is one first meeting rather than a meeting followed by a rematch. Skipped games, byes and walkovers are left out, since nobody met over them.",
+        "Those are measured against the club as it stood the moment the tournament started. That single baseline is what keeps the numbers steady: a pair meeting twice, in group play and then again in the bracket, is one first meeting rather than a meeting followed by a rematch. Skipped games, byes and walkovers are left out, since nobody met over them.",
       ),
       text(
-        "A tournament between regulars will show little, and saying so is the point of it: the widget reports that everyone here already plays each other, and gives the longest anyone had gone without meeting anyway.",
+        "A tournament between regulars will show little there, and saying so is the point of it: the widget reports that everyone already plays each other, and gives the longest anyone had gone without meeting anyway.",
       ),
-    ],
-  },
-  {
-    slug: "tournament-statistics-timeline",
-    title: "Tournament timeline in a new Statistics tab",
-    date: "2026-07-29",
-    tags: ["new-feature"],
-    summary:
-      "A chart on the tournament page showing how many days each part of the tournament took, from group play through to the grand final.",
-    body: [
-      text(
-        "The Statistics tab sits alongside the bracket and info tabs. Its first widget is a timeline: one bar per part of the tournament, laid out over the days since it started.",
-      ),
-      list(
-        "Group play, with a bar per group",
-        "The bracket, with a bar per round",
-        "For double elimination: the winners bracket, the losers bracket and the grand final as their own sections",
-      ),
-      text(
-        "A round's clock starts when it became possible to play - the round feeding it finished, and for a losers bracket round also the winners bracket round dropping players into it - and ends at its last game. Waiting for people to show up is therefore part of how long a round took, which is usually the more interesting number. Group play is the exception: its groups run side by side from the tournament start.",
-      ),
-      text("Rounds still being played run up against now, and rounds nobody has reached yet read as not started."),
     ],
   },
   {

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -31,6 +31,30 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "tournament-new-connections",
+    title: "New connections in the tournament statistics",
+    date: "2026-07-30",
+    tags: ["new-feature"],
+    summary:
+      "A widget showing which pairs met for the first time, who had not played each other in months, and which players the tournament brought back or brought in.",
+    body: [
+      text(
+        "New connections sits under the timeline on the Statistics tab. It answers the thing a bracket cannot: who did this tournament put in front of each other that an ordinary week never would.",
+      ),
+      list(
+        "First-ever meetings - pairs who had never played each other before, with how many games each of them had behind them",
+        "Reunions - pairs who had not met in 90 days or more, and how long it had been",
+        "New faces - players whose first ever game came in the tournament, players back after 90 days away, and players in their first tournament",
+      ),
+      text(
+        "Everything is measured against the club as it stood the moment the tournament started. That single baseline is what keeps the numbers steady: a pair meeting twice, in group play and then again in the bracket, is one first meeting rather than a meeting followed by a rematch. Skipped games, byes and walkovers are left out, since nobody met over them.",
+      ),
+      text(
+        "A tournament between regulars will show little, and saying so is the point of it: the widget reports that everyone here already plays each other, and gives the longest anyone had gone without meeting anyway.",
+      ),
+    ],
+  },
+  {
     slug: "tournament-statistics-timeline",
     title: "Tournament timeline in a new Statistics tab",
     date: "2026-07-29",

--- a/frontend/src/client/client-db/__tests__/tournaments/tournament-connections.test.ts
+++ b/frontend/src/client/client-db/__tests__/tournaments/tournament-connections.test.ts
@@ -144,7 +144,7 @@ describe("Tournament connections", () => {
       ...baseEvents(["P1", "P2", "P3", "P4"], undefined, ["H1"]),
       ...recentHistory,
       gameEvent("P1", "P2", before(9)), // Met recently
-      gameEvent("P1", "P4", before(200)), // Met, but a long time ago
+      gameEvent("P1", "P4", before(300)), // Met, but a long time ago
       ...bracketGames,
     ])!;
 
@@ -157,9 +157,9 @@ describe("Tournament connections", () => {
     expect(pair(result, "P2", "P3").gamesBefore).toBe(0);
     expect(pair(result, "P2", "P3").gap).toBeUndefined();
 
-    // P1 and P4 had met, 200 days before the tournament started
+    // P1 and P4 had met, 300 days before the tournament started
     expect(result.reunions.map((meeting) => meeting.key)).toEqual(["P1|P4"]);
-    expect(pair(result, "P1", "P4").gap).toBe(200 * ONE_DAY);
+    expect(pair(result, "P1", "P4").gap).toBe(300 * ONE_DAY);
     expect(pair(result, "P1", "P4").gamesBefore).toBe(1);
 
     // P1 and P2 play each other regularly, so the tournament brought them nothing new
@@ -247,15 +247,36 @@ describe("Tournament connections", () => {
     expect(arrival(result, "P1").returning).toBe(false);
   });
 
-  it("keeps a short break out of the returning list", () => {
+  it("keeps a break shorter than six months out of the returning list", () => {
     const result = connections([
       ...baseEvents(["P1", "P2", "P3", "P4"], undefined, ["H1"]),
       ...recentHistory.filter((event) => event.stream.includes("P4") === false),
-      gameEvent("P4", "H1", before(60)), // Away, but not for long enough to count
+      gameEvent("P4", "H1", before(150)), // Away, but not for long enough to count
       ...bracketGames,
     ])!;
 
     expect(arrival(result, "P4").returning).toBe(false);
+  });
+
+  it("sorts the new faces by how long they had been away", () => {
+    const result = connections([
+      ...baseEvents(["P1", "P2", "P3", "P4"], undefined, ["H1", "H2"]),
+      // P1 and P2 have a tournament behind them, so only their absence is new
+      ...earlierTournament(["P1", "P2", "H1", "H2"], before(700)),
+      gameEvent("P1", "H1", before(400)), // Away for over a year
+      gameEvent("P2", "H1", before(250)), // Away for eight months
+      gameEvent("P3", "H1", before(5)), // Playing as usual, but never in a tournament
+      // P4 is left out of the history entirely: they had never played at all
+      ...bracketGames,
+    ])!;
+
+    // A debut had never played, which outranks any absence. The player who never left comes last
+    expect(result.arrivals.map((candidate) => candidate.playerId)).toEqual(["P4", "P1", "P2", "P3"]);
+    expect(arrival(result, "P4").debut).toBe(true);
+    expect(arrival(result, "P1").awayFor).toBe(400 * ONE_DAY);
+    expect(arrival(result, "P2").awayFor).toBe(250 * ONE_DAY);
+    expect(arrival(result, "P3").returning).toBe(false);
+    expect(arrival(result, "P3").firstTournament).toBe(true);
   });
 
   it("marks the players who had never been in a tournament before", () => {

--- a/frontend/src/client/client-db/__tests__/tournaments/tournament-connections.test.ts
+++ b/frontend/src/client/client-db/__tests__/tournaments/tournament-connections.test.ts
@@ -1,0 +1,280 @@
+import { ONE_DAY, ONE_YEAR } from "../../../../common/time-in-ms";
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { TennisTable } from "../../tennis-table";
+import {
+  buildTournamentConnections,
+  PairMeeting,
+  PlayerArrival,
+  TournamentConnections,
+} from "../../tournaments/tournament-connections";
+
+const TOURNAMENT_ID = "tournament-1";
+const EARLIER_TOURNAMENT_ID = "tournament-0";
+/** Far enough into the past to leave room for years of club history before the tournament */
+const START = 3 * ONE_YEAR;
+
+/** Timestamps are expressed as whole days from the tournament start, which keeps them readable */
+const day = (days: number) => START + days * ONE_DAY;
+const before = (days: number) => START - days * ONE_DAY;
+
+type Options = { doubleElimination?: boolean };
+
+/**
+ * The tournament under test, plus any players who only exist in the club history so that a
+ * tournament player can be given a past without pairing them up with another participant
+ */
+function baseEvents(players: string[], options?: Options, historyOnlyPlayers: string[] = []): EventType[] {
+  const events: EventType[] = [];
+  let time = 1_000;
+  for (const player of [...players, ...historyOnlyPlayers]) {
+    events.push({ time: time++, stream: player, type: EventTypeEnum.PLAYER_CREATED, data: { name: player } });
+  }
+  events.push({
+    time: time++,
+    stream: TOURNAMENT_ID,
+    type: EventTypeEnum.TOURNAMENT_CREATED,
+    data: {
+      name: "Connections test",
+      startDate: START,
+      groupPlay: false,
+      doubleElimination: options?.doubleElimination ?? false,
+    },
+  });
+  for (const player of players) {
+    events.push({ time: time++, stream: TOURNAMENT_ID, type: EventTypeEnum.TOURNAMENT_SIGNUP, data: { player } });
+  }
+  events.push({
+    time: time++,
+    stream: TOURNAMENT_ID,
+    type: EventTypeEnum.TOURNAMENT_SET_PLAYER_ORDER,
+    data: { playerOrder: players },
+  });
+  return events;
+}
+
+/** A complete 4 player tournament held before the one under test */
+function earlierTournament(players: [string, string, string, string], startDate: number): EventType[] {
+  let time = 500;
+  const events: EventType[] = [
+    {
+      time: time++,
+      stream: EARLIER_TOURNAMENT_ID,
+      type: EventTypeEnum.TOURNAMENT_CREATED,
+      data: { name: "Last year", startDate, groupPlay: false, doubleElimination: false },
+    },
+  ];
+  for (const player of players) {
+    events.push({
+      time: time++,
+      stream: EARLIER_TOURNAMENT_ID,
+      type: EventTypeEnum.TOURNAMENT_SIGNUP,
+      data: { player },
+    });
+  }
+  events.push({
+    time: time++,
+    stream: EARLIER_TOURNAMENT_ID,
+    type: EventTypeEnum.TOURNAMENT_SET_PLAYER_ORDER,
+    data: { playerOrder: players },
+  });
+  const [p1, p2, p3, p4] = players;
+  // Seeded 1v4 and 2v3, then the final. Played out in full so no later game can fill it
+  events.push(gameEvent(p1, p4, startDate + ONE_DAY));
+  events.push(gameEvent(p2, p3, startDate + 2 * ONE_DAY));
+  events.push(gameEvent(p1, p2, startDate + 3 * ONE_DAY));
+  return events;
+}
+
+function gameEvent(winner: string, loser: string, playedAt: number): EventType {
+  return {
+    time: playedAt,
+    stream: `game-${winner}-${loser}-${playedAt}`,
+    type: EventTypeEnum.GAME_CREATED,
+    data: { playedAt, winner, loser },
+  };
+}
+
+function skipEvent(winner: string, loser: string, time: number): EventType {
+  return {
+    time,
+    stream: TOURNAMENT_ID,
+    type: EventTypeEnum.TOURNAMENT_SKIP_GAME,
+    data: { skipId: `skip-${time}`, winner, loser },
+  };
+}
+
+function connections(events: EventType[]): TournamentConnections | undefined {
+  const context = new TennisTable({ events });
+  const tournament = context.tournaments.getTournament(TOURNAMENT_ID);
+  expect(tournament).toBeDefined();
+  return buildTournamentConnections(tournament!, context);
+}
+
+function pair(result: TournamentConnections, player1: string, player2: string): PairMeeting {
+  const key = [player1, player2].sort().join("|");
+  const found = result.pairs.find((candidate) => candidate.key === key);
+  expect(found).toBeDefined();
+  return found!;
+}
+
+function arrival(result: TournamentConnections, playerId: string): PlayerArrival {
+  const found = result.arrivals.find((candidate) => candidate.playerId === playerId);
+  expect(found).toBeDefined();
+  return found!;
+}
+
+/** The semifinals of a 4 player bracket seeded P1, P2, P3, P4 are P1 vs P4 and P2 vs P3 */
+const bracketGames = [gameEvent("P1", "P4", day(1)), gameEvent("P2", "P3", day(2)), gameEvent("P1", "P2", day(3))];
+
+/** Recent games against a player outside the tournament, so nobody reads as a debut or a returner */
+const recentHistory = [
+  gameEvent("P1", "H1", before(5)),
+  gameEvent("P2", "H1", before(6)),
+  gameEvent("P3", "H1", before(7)),
+  gameEvent("P4", "H1", before(8)),
+];
+
+describe("Tournament connections", () => {
+  it("returns undefined until a game has been played", () => {
+    expect(connections(baseEvents(["P1", "P2", "P3", "P4"]))).toBeUndefined();
+  });
+
+  it("splits the pairs into first meetings, reunions and regulars", () => {
+    const result = connections([
+      ...baseEvents(["P1", "P2", "P3", "P4"], undefined, ["H1"]),
+      ...recentHistory,
+      gameEvent("P1", "P2", before(9)), // Met recently
+      gameEvent("P1", "P4", before(200)), // Met, but a long time ago
+      ...bracketGames,
+    ])!;
+
+    expect(result.gamesPlayed).toBe(3);
+    expect(result.playersPlayed).toBe(4);
+    expect(result.pairs).toHaveLength(3);
+
+    // P2 and P3 had never met
+    expect(result.firstMeetings.map((meeting) => meeting.key)).toEqual(["P2|P3"]);
+    expect(pair(result, "P2", "P3").gamesBefore).toBe(0);
+    expect(pair(result, "P2", "P3").gap).toBeUndefined();
+
+    // P1 and P4 had met, 200 days before the tournament started
+    expect(result.reunions.map((meeting) => meeting.key)).toEqual(["P1|P4"]);
+    expect(pair(result, "P1", "P4").gap).toBe(200 * ONE_DAY);
+    expect(pair(result, "P1", "P4").gamesBefore).toBe(1);
+
+    // P1 and P2 play each other regularly, so the tournament brought them nothing new
+    expect(result.regulars).toBe(1);
+    expect(pair(result, "P1", "P2").kind).toBe("regular");
+
+    // The longest gap is reported even when it is also a reunion
+    expect(result.longestGap?.key).toBe("P1|P4");
+  });
+
+  it("counts a pair that meets twice in the tournament as one meeting", () => {
+    const result = connections([
+      ...baseEvents(["P1", "P2", "P3", "P4"], { doubleElimination: true }, ["H1"]),
+      ...recentHistory,
+      gameEvent("P1", "P4", day(1)), // Winners semifinal
+      gameEvent("P2", "P3", day(2)), // Winners semifinal
+      gameEvent("P4", "P3", day(3)), // Losers round 1
+      gameEvent("P1", "P2", day(4)), // Winners final
+      gameEvent("P2", "P4", day(5)), // Losers final
+      gameEvent("P1", "P2", day(6)), // Grand final: P1 and P2 meet for the second time
+    ])!;
+
+    expect(result.gamesPlayed).toBe(6);
+    // Five distinct pairings out of six games
+    expect(result.pairs).toHaveLength(5);
+    expect(pair(result, "P1", "P2").gamesInTournament).toBe(2);
+    expect(pair(result, "P1", "P2").kind).toBe("first-meeting");
+    expect(result.firstMeetings.filter((meeting) => meeting.key === "P1|P2")).toHaveLength(1);
+  });
+
+  it("leaves out skipped games, since nobody met over them", () => {
+    const result = connections([
+      ...baseEvents(["P1", "P2", "P3", "P4"], undefined, ["H1"]),
+      ...recentHistory,
+      gameEvent("P1", "P4", day(1)),
+      skipEvent("P2", "P3", day(2)), // P2 advances without playing
+      gameEvent("P1", "P2", day(3)),
+    ])!;
+
+    expect(result.gamesPlayed).toBe(2);
+    expect(result.pairs.map((meeting) => meeting.key).sort()).toEqual(["P1|P2", "P1|P4"]);
+    // P3 never played, so the tournament says nothing about them
+    expect(result.playersPlayed).toBe(3);
+    expect(result.arrivals.some((candidate) => candidate.playerId === "P3")).toBe(false);
+  });
+
+  it("marks a player with no earlier games as a debut", () => {
+    const result = connections([
+      ...baseEvents(["P1", "P2", "P3", "P4"], undefined, ["H1"]),
+      // P4 is left out of the history: the tournament is their first ever game
+      gameEvent("P1", "H1", before(5)),
+      gameEvent("P2", "H1", before(6)),
+      gameEvent("P3", "H1", before(7)),
+      ...bracketGames,
+    ])!;
+
+    const debut = arrival(result, "P4");
+    expect(debut.debut).toBe(true);
+    expect(debut.gamesBefore).toBe(0);
+    expect(debut.lastPlayedAt).toBeUndefined();
+    expect(debut.awayFor).toBeUndefined();
+    expect(debut.gamesInTournament).toBe(1);
+    // A debut already says it was their first tournament
+    expect(debut.firstTournament).toBe(false);
+
+    expect(arrival(result, "P1").debut).toBe(false);
+    // Debuts are listed first
+    expect(result.arrivals[0].playerId).toBe("P4");
+  });
+
+  it("marks a player who had not played in a long time as returning", () => {
+    const result = connections([
+      ...baseEvents(["P1", "P2", "P3", "P4"], undefined, ["H1"]),
+      ...recentHistory.filter((event) => event.stream.includes("P4") === false),
+      gameEvent("P4", "H1", before(300)), // P4 has been away for 300 days
+      ...bracketGames,
+    ])!;
+
+    const returning = arrival(result, "P4");
+    expect(returning.returning).toBe(true);
+    expect(returning.debut).toBe(false);
+    expect(returning.awayFor).toBe(300 * ONE_DAY);
+    expect(returning.gamesBefore).toBe(1);
+
+    expect(arrival(result, "P1").returning).toBe(false);
+  });
+
+  it("keeps a short break out of the returning list", () => {
+    const result = connections([
+      ...baseEvents(["P1", "P2", "P3", "P4"], undefined, ["H1"]),
+      ...recentHistory.filter((event) => event.stream.includes("P4") === false),
+      gameEvent("P4", "H1", before(60)), // Away, but not for long enough to count
+      ...bracketGames,
+    ])!;
+
+    expect(arrival(result, "P4").returning).toBe(false);
+  });
+
+  it("marks the players who had never been in a tournament before", () => {
+    const result = connections([
+      ...baseEvents(["P1", "P2", "P5", "P6"], undefined, ["H1", "H2"]),
+      ...earlierTournament(["P1", "P2", "H1", "H2"], before(300)),
+      // Everyone has played recently, so the only thing new is the tournament itself
+      gameEvent("P1", "H1", before(5)),
+      gameEvent("P2", "H1", before(6)),
+      gameEvent("P5", "H1", before(7)),
+      gameEvent("P6", "H1", before(8)),
+      // Seeded P1, P2, P5, P6: the semifinals are P1 vs P6 and P2 vs P5
+      gameEvent("P1", "P6", day(1)),
+      gameEvent("P2", "P5", day(2)),
+    ])!;
+
+    expect(arrival(result, "P5").firstTournament).toBe(true);
+    expect(arrival(result, "P6").firstTournament).toBe(true);
+    // P1 and P2 played the earlier tournament, and nothing else about them is new
+    expect(result.arrivals.map((candidate) => candidate.playerId).sort()).toEqual(["P5", "P6"]);
+  });
+});

--- a/frontend/src/client/client-db/__tests__/tournaments/tournament-connections.test.ts
+++ b/frontend/src/client/client-db/__tests__/tournaments/tournament-connections.test.ts
@@ -218,7 +218,6 @@ describe("Tournament connections", () => {
 
     const debut = arrival(result, "P4");
     expect(debut.debut).toBe(true);
-    expect(debut.gamesBefore).toBe(0);
     expect(debut.lastPlayedAt).toBeUndefined();
     expect(debut.awayFor).toBeUndefined();
     expect(debut.gamesInTournament).toBe(1);
@@ -242,7 +241,7 @@ describe("Tournament connections", () => {
     expect(returning.returning).toBe(true);
     expect(returning.debut).toBe(false);
     expect(returning.awayFor).toBe(300 * ONE_DAY);
-    expect(returning.gamesBefore).toBe(1);
+    expect(returning.lastPlayedAt).toBe(before(300));
 
     expect(arrival(result, "P1").returning).toBe(false);
   });

--- a/frontend/src/client/client-db/tournaments/tournament-connections.ts
+++ b/frontend/src/client/client-db/tournaments/tournament-connections.ts
@@ -38,8 +38,6 @@ export type PairMeeting = {
   lastMetAt?: number;
   /** How long they had gone without meeting when the tournament started. Undefined for a first meeting */
   gap?: number;
-  /** Games each of them had played in the club before the tournament, in the same order as `players` */
-  experience: [number, number];
 };
 
 export type PlayerArrival = {
@@ -54,8 +52,6 @@ export type PlayerArrival = {
    */
   firstTournament: boolean;
   gamesInTournament: number;
-  /** Games they had played in the club before the tournament started */
-  gamesBefore: number;
   /** Their most recent game before the tournament. Undefined for a debut */
   lastPlayedAt?: number;
   /** How long they had been away when the tournament started. Undefined for a debut */
@@ -191,18 +187,13 @@ export function buildTournamentConnections(
       gamesBefore: before?.games ?? 0,
       lastMetAt: before?.lastPlayedAt,
       gap,
-      experience: [
-        history.players.get(pair.players[0])?.games ?? 0,
-        history.players.get(pair.players[1])?.games ?? 0,
-      ],
     };
   });
 
-  // Two players with a long history who had still never met is the striking case, so the pair whose
-  // less experienced half has played the most goes first
+  // Nothing separates one first meeting from another, so they read in the order they happened
   const firstMeetings = pairs
     .filter((pair) => pair.kind === "first-meeting")
-    .sort((a, b) => Math.min(...b.experience) - Math.min(...a.experience) || a.firstMetAt - b.firstMetAt);
+    .sort((a, b) => a.firstMetAt - b.firstMetAt);
 
   const reunions = pairs.filter((pair) => pair.kind === "reunion").sort((a, b) => (b.gap ?? 0) - (a.gap ?? 0));
 
@@ -227,7 +218,6 @@ export function buildTournamentConnections(
       returning,
       firstTournament,
       gamesInTournament,
-      gamesBefore: before?.games ?? 0,
       lastPlayedAt: before?.lastPlayedAt,
       awayFor: before === undefined ? undefined : baseline - before.lastPlayedAt,
     });

--- a/frontend/src/client/client-db/tournaments/tournament-connections.ts
+++ b/frontend/src/client/client-db/tournaments/tournament-connections.ts
@@ -1,4 +1,4 @@
-import { ONE_DAY } from "../../../common/time-in-ms";
+import { ONE_MONTH } from "../../../common/time-in-ms";
 import { TennisTable } from "../tennis-table";
 import { Tournament, TournamentGame } from "./tournament";
 
@@ -12,7 +12,7 @@ import { Tournament, TournamentGame } from "./tournament";
  */
 
 /** A pair, or a player, counts as away once this long has passed since they last played */
-export const LONG_ABSENCE = 90 * ONE_DAY;
+export const LONG_ABSENCE = 6 * ONE_MONTH;
 
 export type PairKind =
   /** These two had never played each other before */
@@ -77,7 +77,7 @@ export type TournamentConnections = {
    * to each other
    */
   longestGap?: PairMeeting;
-  /** Only players the tournament brought something new to. Debuts first, then longest away */
+  /** Only players the tournament brought something new to. Longest away first */
   arrivals: PlayerArrival[];
   /** Players who played at least one real game in the tournament */
   playersPlayed: number;
@@ -233,12 +233,10 @@ export function buildTournamentConnections(
     });
   }
 
-  // Debuts first, then whoever had been away longest, then the first timers
-  arrivals.sort((a, b) => {
-    const rank = (arrival: PlayerArrival) => (arrival.debut ? 0 : arrival.returning ? 1 : 2);
-    if (rank(a) !== rank(b)) return rank(a) - rank(b);
-    return (a.lastPlayedAt ?? 0) - (b.lastPlayedAt ?? 0);
-  });
+  // Longest away first. A debut had never played at all, which is as long as an absence gets, so
+  // the debuts come out on top and the first timers - who have been playing all along - at the bottom
+  const awayFor = (arrival: PlayerArrival) => arrival.awayFor ?? Number.MAX_SAFE_INTEGER;
+  arrivals.sort((a, b) => awayFor(b) - awayFor(a));
 
   return {
     baseline,

--- a/frontend/src/client/client-db/tournaments/tournament-connections.ts
+++ b/frontend/src/client/client-db/tournaments/tournament-connections.ts
@@ -1,0 +1,254 @@
+import { ONE_DAY } from "../../../common/time-in-ms";
+import { TennisTable } from "../tennis-table";
+import { Tournament, TournamentGame } from "./tournament";
+
+/**
+ * What a tournament does to the club beyond crowning a winner: it puts people in front of each
+ * other who never meet on an ordinary day, and it pulls in people who were not playing at all.
+ *
+ * Everything is measured against the club as it stood the moment the tournament started. That one
+ * baseline is what makes the numbers stable: a pair meeting twice inside the tournament (group play
+ * and then the bracket) is still one first meeting, not a first meeting followed by a rematch.
+ */
+
+/** A pair, or a player, counts as away once this long has passed since they last played */
+export const LONG_ABSENCE = 90 * ONE_DAY;
+
+export type PairKind =
+  /** These two had never played each other before */
+  | "first-meeting"
+  /** They had met, but not within LONG_ABSENCE of the tournament start */
+  | "reunion"
+  /** They play each other regularly enough that the tournament brought them nothing new */
+  | "regular";
+
+export type PairMeeting = {
+  /** Stable identity, used as the react key */
+  key: string;
+  /** Sorted, so the pair reads the same no matter which side won */
+  players: [string, string];
+  kind: PairKind;
+  /** Games the two played against each other inside the tournament */
+  gamesInTournament: number;
+  /** When they first met in the tournament */
+  firstMetAt: number;
+  /** Games between the two before the tournament started */
+  gamesBefore: number;
+  /** Their most recent game before the tournament. Undefined when they had never met */
+  lastMetAt?: number;
+  /** How long they had gone without meeting when the tournament started. Undefined for a first meeting */
+  gap?: number;
+  /** Games each of them had played in the club before the tournament, in the same order as `players` */
+  experience: [number, number];
+};
+
+export type PlayerArrival = {
+  playerId: string;
+  /** They had never played a game in the club before this tournament started */
+  debut: boolean;
+  /** They had played before, but not within LONG_ABSENCE of the tournament start */
+  returning: boolean;
+  /**
+   * They had played before but never in a tournament. Always false for a debut, where it would
+   * only repeat what `debut` already says
+   */
+  firstTournament: boolean;
+  gamesInTournament: number;
+  /** Games they had played in the club before the tournament started */
+  gamesBefore: number;
+  /** Their most recent game before the tournament. Undefined for a debut */
+  lastPlayedAt?: number;
+  /** How long they had been away when the tournament started. Undefined for a debut */
+  awayFor?: number;
+};
+
+export type TournamentConnections = {
+  /** The club as it stood at this time is what everything is measured against */
+  baseline: number;
+  /** Every pair that played at least one real game in the tournament */
+  pairs: PairMeeting[];
+  firstMeetings: PairMeeting[];
+  /** Longest time apart first */
+  reunions: PairMeeting[];
+  regulars: number;
+  /**
+   * The pair who had gone longest without meeting, even when that is short of LONG_ABSENCE. Lets
+   * the widget still say something on a tournament of regulars. Undefined when every pair was new
+   * to each other
+   */
+  longestGap?: PairMeeting;
+  /** Only players the tournament brought something new to. Debuts first, then longest away */
+  arrivals: PlayerArrival[];
+  /** Players who played at least one real game in the tournament */
+  playersPlayed: number;
+  gamesPlayed: number;
+};
+
+type PlayedGame = { player1: string; player2: string; completedAt: number };
+
+type History = { games: number; firstPlayedAt: number; lastPlayedAt: number };
+
+function pairKey(player1: string, player2: string): string {
+  return [player1, player2].sort().join("|");
+}
+
+/**
+ * The games that were actually played at a table. Skipped games carry a winner and a completion
+ * time like any other, but nobody met over them, and byes and walkovers never had two players
+ */
+function playedGames(tournament: Tournament): PlayedGame[] {
+  const games: PlayedGame[] = [];
+  const add = (game: Partial<TournamentGame>) => {
+    if (game.skipped !== undefined) return;
+    if (game.player1 === undefined || game.player2 === undefined || game.completedAt === undefined) return;
+    games.push({ player1: game.player1, player2: game.player2, completedAt: game.completedAt });
+  };
+  tournament.groupPlay?.groups.forEach((group) => group.played.forEach(add));
+  tournament.bracket?.getCompletedGames().forEach(add);
+  return games.sort((a, b) => a.completedAt - b.completedAt);
+}
+
+/** Everyone who played a game in a tournament that had already started before this one */
+function playersOfEarlierTournaments(tournament: Tournament, context: TennisTable): Set<string> {
+  const players = new Set<string>();
+  for (const other of context.tournaments.getTournaments()) {
+    if (other.id === tournament.id) continue;
+    if (other.startDate >= tournament.startDate) continue;
+    for (const game of playedGames(other)) {
+      players.add(game.player1);
+      players.add(game.player2);
+    }
+  }
+  return players;
+}
+
+/** Who had played whom, and how much, in the club before the tournament started */
+function historyBefore(context: TennisTable, baseline: number): { players: Map<string, History>; pairs: Map<string, History> } {
+  const players = new Map<string, History>();
+  const pairs = new Map<string, History>();
+
+  const record = (map: Map<string, History>, key: string, playedAt: number) => {
+    const found = map.get(key);
+    if (found === undefined) {
+      map.set(key, { games: 1, firstPlayedAt: playedAt, lastPlayedAt: playedAt });
+      return;
+    }
+    found.games++;
+    found.lastPlayedAt = playedAt;
+  };
+
+  for (const game of context.games) {
+    // The games getter hands them over oldest first, so the rest of them are all past the baseline
+    if (game.playedAt >= baseline) break;
+    record(players, game.winner, game.playedAt);
+    record(players, game.loser, game.playedAt);
+    record(pairs, pairKey(game.winner, game.loser), game.playedAt);
+  }
+
+  return { players, pairs };
+}
+
+export function buildTournamentConnections(
+  tournament: Tournament,
+  context: TennisTable,
+): TournamentConnections | undefined {
+  const games = playedGames(tournament);
+  if (games.length === 0) return undefined; // Not started, or started and nobody has played yet
+
+  const baseline = tournament.startDate;
+  const history = historyBefore(context, baseline);
+
+  // ---- Pairs ----
+
+  type Met = { players: [string, string]; games: number; firstMetAt: number };
+  const met = new Map<string, Met>();
+  const participants = new Map<string, number>();
+
+  for (const game of games) {
+    const key = pairKey(game.player1, game.player2);
+    const found = met.get(key);
+    if (found === undefined) {
+      // Sorted so the pair reads the same however the games went
+      const players = [game.player1, game.player2].sort() as [string, string];
+      met.set(key, { players, games: 1, firstMetAt: game.completedAt });
+    } else {
+      found.games++;
+    }
+    participants.set(game.player1, (participants.get(game.player1) ?? 0) + 1);
+    participants.set(game.player2, (participants.get(game.player2) ?? 0) + 1);
+  }
+
+  const pairs: PairMeeting[] = Array.from(met, ([key, pair]) => {
+    const before = history.pairs.get(key);
+    const gap = before === undefined ? undefined : baseline - before.lastPlayedAt;
+    const kind: PairKind = before === undefined ? "first-meeting" : gap! >= LONG_ABSENCE ? "reunion" : "regular";
+    return {
+      key,
+      players: pair.players,
+      kind,
+      gamesInTournament: pair.games,
+      firstMetAt: pair.firstMetAt,
+      gamesBefore: before?.games ?? 0,
+      lastMetAt: before?.lastPlayedAt,
+      gap,
+      experience: [
+        history.players.get(pair.players[0])?.games ?? 0,
+        history.players.get(pair.players[1])?.games ?? 0,
+      ],
+    };
+  });
+
+  // Two players with a long history who had still never met is the striking case, so the pair whose
+  // less experienced half has played the most goes first
+  const firstMeetings = pairs
+    .filter((pair) => pair.kind === "first-meeting")
+    .sort((a, b) => Math.min(...b.experience) - Math.min(...a.experience) || a.firstMetAt - b.firstMetAt);
+
+  const reunions = pairs.filter((pair) => pair.kind === "reunion").sort((a, b) => (b.gap ?? 0) - (a.gap ?? 0));
+
+  const longestGap = pairs
+    .filter((pair) => pair.gap !== undefined)
+    .sort((a, b) => (b.gap ?? 0) - (a.gap ?? 0))[0];
+
+  // ---- Players ----
+
+  const earlierTournamentPlayers = playersOfEarlierTournaments(tournament, context);
+
+  const arrivals: PlayerArrival[] = [];
+  for (const [playerId, gamesInTournament] of participants) {
+    const before = history.players.get(playerId);
+    const debut = before === undefined;
+    const returning = before !== undefined && baseline - before.lastPlayedAt >= LONG_ABSENCE;
+    const firstTournament = !debut && !earlierTournamentPlayers.has(playerId);
+    if (!debut && !returning && !firstTournament) continue; // The tournament was business as usual for them
+    arrivals.push({
+      playerId,
+      debut,
+      returning,
+      firstTournament,
+      gamesInTournament,
+      gamesBefore: before?.games ?? 0,
+      lastPlayedAt: before?.lastPlayedAt,
+      awayFor: before === undefined ? undefined : baseline - before.lastPlayedAt,
+    });
+  }
+
+  // Debuts first, then whoever had been away longest, then the first timers
+  arrivals.sort((a, b) => {
+    const rank = (arrival: PlayerArrival) => (arrival.debut ? 0 : arrival.returning ? 1 : 2);
+    if (rank(a) !== rank(b)) return rank(a) - rank(b);
+    return (a.lastPlayedAt ?? 0) - (b.lastPlayedAt ?? 0);
+  });
+
+  return {
+    baseline,
+    pairs,
+    firstMeetings,
+    reunions,
+    regulars: pairs.filter((pair) => pair.kind === "regular").length,
+    longestGap,
+    arrivals,
+    playersPlayed: participants.size,
+    gamesPlayed: games.length,
+  };
+}

--- a/frontend/src/pages/tournament/stats/connections-widget.tsx
+++ b/frontend/src/pages/tournament/stats/connections-widget.tsx
@@ -2,7 +2,6 @@ import { useMemo } from "react";
 import { Link } from "react-router-dom";
 import {
   buildTournamentConnections,
-  LONG_ABSENCE,
   PairMeeting,
   PlayerArrival,
 } from "../../../client/client-db/tournaments/tournament-connections";
@@ -64,7 +63,7 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
       )}
 
       {firstMeetings.length > 0 && (
-        <Section title="First-ever meetings" subtitle="They had never played each other before">
+        <Section title="First-ever meetings">
           {firstMeetings.map((pair) => (
             <PairRow key={pair.key} pair={pair} />
           ))}
@@ -72,7 +71,7 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
       )}
 
       {reunions.length > 0 && (
-        <Section title="Reunions" subtitle={`Pairs who had not met in ${formatGap(LONG_ABSENCE)} or more`}>
+        <Section title="Reunions">
           {reunions.map((pair) => (
             <PairRow key={pair.key} pair={pair}>
               First meeting in <span className="font-medium">{formatGap(pair.gap ?? 0)}</span>
@@ -82,7 +81,7 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
       )}
 
       {debuts.length > 0 && (
-        <Section title="First game ever" subtitle="The tournament was their first game in the club">
+        <Section title="First game ever">
           {debuts.map((arrival) => (
             <PlayerRow key={arrival.playerId} arrival={arrival} />
           ))}
@@ -90,7 +89,7 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
       )}
 
       {returning.length > 0 && (
-        <Section title="Back after a break" subtitle={`They had not played in ${formatGap(LONG_ABSENCE)} or more`}>
+        <Section title="Back after a break">
           {returning.map((arrival) => (
             <PlayerRow key={arrival.playerId} arrival={arrival}>
               Away for <span className="font-medium">{formatGap(arrival.awayFor ?? 0)}</span>
@@ -100,7 +99,7 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
       )}
 
       {firstTimers.length > 0 && (
-        <Section title="First tournament" subtitle="They had been playing, but never in a tournament">
+        <Section title="First tournament">
           {firstTimers.map((arrival) => (
             <PlayerRow key={arrival.playerId} arrival={arrival} />
           ))}
@@ -141,14 +140,9 @@ const Tile: React.FC<{ value: number; label: string; of: number }> = ({ value, l
   </div>
 );
 
-const Section: React.FC<{ title: string; subtitle: string; children: React.ReactNode }> = ({
-  title,
-  subtitle,
-  children,
-}) => (
+const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
   <div className="mb-6">
-    <h3 className="text-sm font-semibold">{title}</h3>
-    <p className="text-xs font-light mb-2">{subtitle}</p>
+    <h3 className="text-sm font-semibold mb-2">{title}</h3>
     <div className="space-y-1">{children}</div>
   </div>
 );

--- a/frontend/src/pages/tournament/stats/connections-widget.tsx
+++ b/frontend/src/pages/tournament/stats/connections-widget.tsx
@@ -107,11 +107,6 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
           ))}
         </Section>
       )}
-
-      <p className="mt-6 text-xs font-light leading-relaxed">
-        Measured against the club as it stood when the tournament started. Skipped games, byes and walkovers are left
-        out: nobody met over them.
-      </p>
     </WidgetFrame>
   );
 };

--- a/frontend/src/pages/tournament/stats/connections-widget.tsx
+++ b/frontend/src/pages/tournament/stats/connections-widget.tsx
@@ -77,10 +77,7 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
       )}
 
       {reunions.length > 0 && (
-        <Section
-          title="Reunions"
-          subtitle={`Pairs who had not met in ${fmtNum(LONG_ABSENCE / ONE_DAY)} days or more`}
-        >
+        <Section title="Reunions" subtitle={`Pairs who had not met in ${formatGap(LONG_ABSENCE)} or more`}>
           {reunions.map((pair) => (
             <PairRow key={pair.key} pair={pair}>
               First meeting in <span className="font-medium">{formatGap(pair.gap ?? 0)}</span> ·{" "}

--- a/frontend/src/pages/tournament/stats/connections-widget.tsx
+++ b/frontend/src/pages/tournament/stats/connections-widget.tsx
@@ -1,0 +1,226 @@
+import { useMemo } from "react";
+import { Link } from "react-router-dom";
+import {
+  buildTournamentConnections,
+  LONG_ABSENCE,
+  PairMeeting,
+  PlayerArrival,
+} from "../../../client/client-db/tournaments/tournament-connections";
+import { Tournament } from "../../../client/client-db/tournaments/tournament";
+import { classNames } from "../../../common/class-names";
+import { fmtNum } from "../../../common/number-utils";
+import { ONE_DAY, ONE_MONTH, ONE_YEAR } from "../../../common/time-in-ms";
+import { useEventDbContext } from "../../../wrappers/event-db-context";
+import { ProfilePicture } from "../../player/profile-picture";
+
+/**
+ * Who the tournament brought together. Two ledgers: the pairs who had never met or had not met in
+ * a long time, and the players who had not been playing at all
+ */
+export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> = ({ tournament }) => {
+  const context = useEventDbContext();
+  const connections = useMemo(() => buildTournamentConnections(tournament, context), [tournament, context]);
+
+  if (!connections) {
+    return (
+      <WidgetFrame>
+        <Header />
+        <p className="text-sm font-light">No games have been played yet, so there is nothing to compare against.</p>
+      </WidgetFrame>
+    );
+  }
+
+  const { firstMeetings, reunions, longestGap, arrivals, pairs, playersPlayed, gamesPlayed } = connections;
+  const debuts = arrivals.filter((arrival) => arrival.debut);
+  const returning = arrivals.filter((arrival) => arrival.returning);
+  const firstTimers = arrivals.filter((arrival) => arrival.firstTournament && !arrival.returning);
+  const nothingNew = firstMeetings.length === 0 && reunions.length === 0 && arrivals.length === 0;
+
+  return (
+    <WidgetFrame>
+      <Header>
+        {fmtNum(playersPlayed)} players · {fmtNum(gamesPlayed)} games · {fmtNum(pairs.length)} pairings
+      </Header>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mb-6">
+        <Tile value={firstMeetings.length} label="First-ever meetings" of={pairs.length} />
+        <Tile value={reunions.length} label="Reunions" of={pairs.length} />
+        <Tile value={debuts.length} label="First games ever" of={playersPlayed} />
+        <Tile value={returning.length + firstTimers.length} label="Back or new to tournaments" of={playersPlayed} />
+      </div>
+
+      {nothingNew && (
+        <p className="text-sm font-light mb-6">
+          Everyone here already plays each other regularly - the tournament put no new pairings on the table.
+          {longestGap && (
+            <>
+              {" "}
+              The longest anyone had gone without meeting was{" "}
+              <span className="font-medium">{formatGap(longestGap.gap ?? 0)}</span>, between{" "}
+              {context.playerName(longestGap.players[0])} and {context.playerName(longestGap.players[1])}.
+            </>
+          )}
+        </p>
+      )}
+
+      {firstMeetings.length > 0 && (
+        <Section
+          title="First-ever meetings"
+          subtitle="These two had never played each other before the tournament"
+        >
+          {firstMeetings.map((pair) => (
+            <PairRow key={pair.key} pair={pair}>
+              {experienceLine(pair.experience)}
+            </PairRow>
+          ))}
+        </Section>
+      )}
+
+      {reunions.length > 0 && (
+        <Section
+          title="Reunions"
+          subtitle={`Pairs who had not met in ${fmtNum(LONG_ABSENCE / ONE_DAY)} days or more`}
+        >
+          {reunions.map((pair) => (
+            <PairRow key={pair.key} pair={pair}>
+              First meeting in <span className="font-medium">{formatGap(pair.gap ?? 0)}</span> ·{" "}
+              {fmtNum(pair.gamesBefore)} earlier {pair.gamesBefore === 1 ? "game" : "games"}
+            </PairRow>
+          ))}
+        </Section>
+      )}
+
+      {arrivals.length > 0 && (
+        <Section title="New faces" subtitle="Players the tournament brought to the table">
+          {arrivals.map((arrival) => (
+            <PlayerRow key={arrival.playerId} arrival={arrival} />
+          ))}
+        </Section>
+      )}
+
+      <p className="mt-6 text-xs font-light leading-relaxed">
+        Everything is measured against the club as it stood when the tournament started, so a pair meeting twice - in
+        group play and again in the bracket - still counts as one first meeting. Skipped games, byes and walkovers are
+        left out: nobody met over them.
+      </p>
+    </WidgetFrame>
+  );
+};
+
+const WidgetFrame: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="ring-1 ring-secondary-background w-full max-w-4xl mx-auto px-4 md:px-6 py-6 text-primary-text bg-primary-background rounded-lg shadow-sm">
+    {children}
+  </div>
+);
+
+const Header: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
+  <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 mb-6">
+    <h2 className="text-xl font-bold">New connections</h2>
+    {children && <p className="text-sm">{children}</p>}
+  </div>
+);
+
+const Tile: React.FC<{ value: number; label: string; of: number }> = ({ value, label, of }) => (
+  <div
+    className={classNames(
+      "rounded-lg px-3 py-2 ring-1 ring-secondary-background",
+      value === 0 && "opacity-50",
+    )}
+  >
+    <p className="text-2xl font-bold leading-tight">{fmtNum(value)}</p>
+    <p className="text-xs font-light leading-tight">{label}</p>
+    <p className="text-[0.65rem] font-light mt-1">of {fmtNum(of)}</p>
+  </div>
+);
+
+const Section: React.FC<{ title: string; subtitle: string; children: React.ReactNode }> = ({
+  title,
+  subtitle,
+  children,
+}) => (
+  <div className="mb-6">
+    <h3 className="text-sm font-semibold">{title}</h3>
+    <p className="text-xs font-light mb-2">{subtitle}</p>
+    <div className="space-y-1">{children}</div>
+  </div>
+);
+
+const PairRow: React.FC<{ pair: PairMeeting; children: React.ReactNode }> = ({ pair, children }) => {
+  return (
+    <div className="flex items-center gap-3 rounded-lg px-3 py-2 ring-1 ring-secondary-background">
+      <div className="flex -space-x-2 shrink-0">
+        <ProfilePicture playerId={pair.players[0]} size={28} border={2} linkToPlayer />
+        <ProfilePicture playerId={pair.players[1]} size={28} border={2} linkToPlayer />
+      </div>
+      <div className="min-w-0 grow">
+        <p className="text-sm truncate">
+          <PlayerLink playerId={pair.players[0]} /> <span className="font-light">vs</span>{" "}
+          <PlayerLink playerId={pair.players[1]} />
+        </p>
+        <p className="text-xs font-light">{children}</p>
+      </div>
+      {pair.gamesInTournament > 1 && (
+        <p className="shrink-0 text-xs font-light" title={`They met ${pair.gamesInTournament} times in this tournament`}>
+          met {fmtNum(pair.gamesInTournament)}×
+        </p>
+      )}
+    </div>
+  );
+};
+
+const PlayerRow: React.FC<{ arrival: PlayerArrival }> = ({ arrival }) => {
+  return (
+    <div className="flex items-center gap-3 rounded-lg px-3 py-2 ring-1 ring-secondary-background">
+      <div className="shrink-0">
+        <ProfilePicture playerId={arrival.playerId} size={28} border={2} linkToPlayer />
+      </div>
+      <div className="min-w-0 grow">
+        <p className="text-sm truncate">
+          <PlayerLink playerId={arrival.playerId} />
+        </p>
+        <p className="text-xs font-light">
+          {arrival.debut && "Played their first ever game in this tournament"}
+          {arrival.returning && arrival.awayFor !== undefined && (
+            <>
+              Back after <span className="font-medium">{formatGap(arrival.awayFor)}</span> away ·{" "}
+              {fmtNum(arrival.gamesBefore)} games before that
+              {arrival.firstTournament && " · first tournament"}
+            </>
+          )}
+          {!arrival.debut && !arrival.returning && arrival.firstTournament && "First tournament, after playing casually"}
+        </p>
+      </div>
+      <p className="shrink-0 text-xs font-light">
+        {fmtNum(arrival.gamesInTournament)} {arrival.gamesInTournament === 1 ? "game" : "games"}
+      </p>
+    </div>
+  );
+};
+
+const PlayerLink: React.FC<{ playerId: string }> = ({ playerId }) => {
+  const context = useEventDbContext();
+  return (
+    <Link to={`/player/${playerId}`} className="font-medium hover:underline">
+      {context.playerName(playerId)}
+    </Link>
+  );
+};
+
+/**
+ * What makes a first meeting worth reading about: two players with long histories who had somehow
+ * never met says more than two players who had barely played at all
+ */
+function experienceLine([first, second]: [number, number]): string {
+  const [fewest, most] = [Math.min(first, second), Math.max(first, second)];
+  if (most === 0) return "Neither of them had played in the club before";
+  if (fewest === 0) return "One of them was new to the club";
+  return `${fmtNum(fewest)} and ${fmtNum(most)} games played, and never against each other`;
+}
+
+/** Gaps are read in months and years. Anything shorter is a curiosity, not a reunion */
+function formatGap(ms: number): string {
+  if (ms < ONE_MONTH) return `${fmtNum(ms / ONE_DAY)} days`;
+  if (ms < ONE_YEAR) return `${fmtNum(ms / ONE_MONTH)} months`;
+  const years = ms / ONE_YEAR;
+  return `${fmtNum(years, { digits: years < 10 ? 1 : 0 })} years`;
+}

--- a/frontend/src/pages/tournament/stats/connections-widget.tsx
+++ b/frontend/src/pages/tournament/stats/connections-widget.tsx
@@ -46,12 +46,12 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
         <Tile value={firstMeetings.length} label="First-ever meetings" of={pairs.length} />
         <Tile value={reunions.length} label="Reunions" of={pairs.length} />
         <Tile value={debuts.length} label="First games ever" of={playersPlayed} />
-        <Tile value={returning.length + firstTimers.length} label="Back or new to tournaments" of={playersPlayed} />
+        <Tile value={returning.length} label="Back after a break" of={playersPlayed} />
       </div>
 
       {nothingNew && (
         <p className="text-sm font-light mb-6">
-          Everyone here already plays each other regularly - the tournament put no new pairings on the table.
+          Everyone here already plays each other regularly.
           {longestGap && (
             <>
               {" "}
@@ -64,14 +64,9 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
       )}
 
       {firstMeetings.length > 0 && (
-        <Section
-          title="First-ever meetings"
-          subtitle="These two had never played each other before the tournament"
-        >
+        <Section title="First-ever meetings" subtitle="They had never played each other before">
           {firstMeetings.map((pair) => (
-            <PairRow key={pair.key} pair={pair}>
-              {experienceLine(pair.experience)}
-            </PairRow>
+            <PairRow key={pair.key} pair={pair} />
           ))}
         </Section>
       )}
@@ -80,25 +75,41 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
         <Section title="Reunions" subtitle={`Pairs who had not met in ${formatGap(LONG_ABSENCE)} or more`}>
           {reunions.map((pair) => (
             <PairRow key={pair.key} pair={pair}>
-              First meeting in <span className="font-medium">{formatGap(pair.gap ?? 0)}</span> ·{" "}
-              {fmtNum(pair.gamesBefore)} earlier {pair.gamesBefore === 1 ? "game" : "games"}
+              First meeting in <span className="font-medium">{formatGap(pair.gap ?? 0)}</span>
             </PairRow>
           ))}
         </Section>
       )}
 
-      {arrivals.length > 0 && (
-        <Section title="New faces" subtitle="Players the tournament brought to the table">
-          {arrivals.map((arrival) => (
+      {debuts.length > 0 && (
+        <Section title="First game ever" subtitle="The tournament was their first game in the club">
+          {debuts.map((arrival) => (
+            <PlayerRow key={arrival.playerId} arrival={arrival} />
+          ))}
+        </Section>
+      )}
+
+      {returning.length > 0 && (
+        <Section title="Back after a break" subtitle={`They had not played in ${formatGap(LONG_ABSENCE)} or more`}>
+          {returning.map((arrival) => (
+            <PlayerRow key={arrival.playerId} arrival={arrival}>
+              Away for <span className="font-medium">{formatGap(arrival.awayFor ?? 0)}</span>
+            </PlayerRow>
+          ))}
+        </Section>
+      )}
+
+      {firstTimers.length > 0 && (
+        <Section title="First tournament" subtitle="They had been playing, but never in a tournament">
+          {firstTimers.map((arrival) => (
             <PlayerRow key={arrival.playerId} arrival={arrival} />
           ))}
         </Section>
       )}
 
       <p className="mt-6 text-xs font-light leading-relaxed">
-        Everything is measured against the club as it stood when the tournament started, so a pair meeting twice - in
-        group play and again in the bracket - still counts as one first meeting. Skipped games, byes and walkovers are
-        left out: nobody met over them.
+        Measured against the club as it stood when the tournament started. Skipped games, byes and walkovers are left
+        out: nobody met over them.
       </p>
     </WidgetFrame>
   );
@@ -142,7 +153,7 @@ const Section: React.FC<{ title: string; subtitle: string; children: React.React
   </div>
 );
 
-const PairRow: React.FC<{ pair: PairMeeting; children: React.ReactNode }> = ({ pair, children }) => {
+const PairRow: React.FC<{ pair: PairMeeting; children?: React.ReactNode }> = ({ pair, children }) => {
   return (
     <div className="flex items-center gap-3 rounded-lg px-3 py-2 ring-1 ring-secondary-background">
       <div className="flex -space-x-2 shrink-0">
@@ -154,7 +165,7 @@ const PairRow: React.FC<{ pair: PairMeeting; children: React.ReactNode }> = ({ p
           <PlayerLink playerId={pair.players[0]} /> <span className="font-light">vs</span>{" "}
           <PlayerLink playerId={pair.players[1]} />
         </p>
-        <p className="text-xs font-light">{children}</p>
+        {children && <p className="text-xs font-light">{children}</p>}
       </div>
       {pair.gamesInTournament > 1 && (
         <p className="shrink-0 text-xs font-light" title={`They met ${pair.gamesInTournament} times in this tournament`}>
@@ -165,7 +176,7 @@ const PairRow: React.FC<{ pair: PairMeeting; children: React.ReactNode }> = ({ p
   );
 };
 
-const PlayerRow: React.FC<{ arrival: PlayerArrival }> = ({ arrival }) => {
+const PlayerRow: React.FC<{ arrival: PlayerArrival; children?: React.ReactNode }> = ({ arrival, children }) => {
   return (
     <div className="flex items-center gap-3 rounded-lg px-3 py-2 ring-1 ring-secondary-background">
       <div className="shrink-0">
@@ -175,21 +186,8 @@ const PlayerRow: React.FC<{ arrival: PlayerArrival }> = ({ arrival }) => {
         <p className="text-sm truncate">
           <PlayerLink playerId={arrival.playerId} />
         </p>
-        <p className="text-xs font-light">
-          {arrival.debut && "Played their first ever game in this tournament"}
-          {arrival.returning && arrival.awayFor !== undefined && (
-            <>
-              Back after <span className="font-medium">{formatGap(arrival.awayFor)}</span> away ·{" "}
-              {fmtNum(arrival.gamesBefore)} games before that
-              {arrival.firstTournament && " · first tournament"}
-            </>
-          )}
-          {!arrival.debut && !arrival.returning && arrival.firstTournament && "First tournament, after playing casually"}
-        </p>
+        {children && <p className="text-xs font-light">{children}</p>}
       </div>
-      <p className="shrink-0 text-xs font-light">
-        {fmtNum(arrival.gamesInTournament)} {arrival.gamesInTournament === 1 ? "game" : "games"}
-      </p>
     </div>
   );
 };
@@ -202,17 +200,6 @@ const PlayerLink: React.FC<{ playerId: string }> = ({ playerId }) => {
     </Link>
   );
 };
-
-/**
- * What makes a first meeting worth reading about: two players with long histories who had somehow
- * never met says more than two players who had barely played at all
- */
-function experienceLine([first, second]: [number, number]): string {
-  const [fewest, most] = [Math.min(first, second), Math.max(first, second)];
-  if (most === 0) return "Neither of them had played in the club before";
-  if (fewest === 0) return "One of them was new to the club";
-  return `${fmtNum(fewest)} and ${fmtNum(most)} games played, and never against each other`;
-}
 
 /** Gaps are read in months and years. Anything shorter is a curiosity, not a reunion */
 function formatGap(ms: number): string {

--- a/frontend/src/pages/tournament/stats/connections-widget.tsx
+++ b/frontend/src/pages/tournament/stats/connections-widget.tsx
@@ -41,11 +41,13 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
         {fmtNum(playersPlayed)} players · {fmtNum(gamesPlayed)} games · {fmtNum(pairs.length)} pairings
       </Header>
 
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mb-6">
+      {/* Pairs first, then players, in the same order as the sections below */}
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-2 mb-6">
         <Tile value={firstMeetings.length} label="First-ever meetings" of={pairs.length} />
         <Tile value={reunions.length} label="Reunions" of={pairs.length} />
         <Tile value={debuts.length} label="First games ever" of={playersPlayed} />
         <Tile value={returning.length} label="Back after a break" of={playersPlayed} />
+        <Tile value={firstTimers.length} label="First tournament" of={playersPlayed} />
       </div>
 
       {nothingNew && (

--- a/frontend/src/pages/tournament/stats/tournament-stats.tsx
+++ b/frontend/src/pages/tournament/stats/tournament-stats.tsx
@@ -1,13 +1,15 @@
 import { Tournament } from "../../../client/client-db/tournaments/tournament";
+import { TournamentConnectionsWidget } from "./connections-widget";
 import { TournamentTimelineWidget } from "./timeline-widget";
 
 /**
- * The statistics tab. One widget per stat, stacked. Currently only the timeline
+ * The statistics tab. One widget per stat, stacked
  */
 export const TournamentStats: React.FC<{ tournament: Tournament }> = ({ tournament }) => {
   return (
     <div className="space-y-4">
       <TournamentTimelineWidget tournament={tournament} />
+      <TournamentConnectionsWidget tournament={tournament} />
     </div>
   );
 };


### PR DESCRIPTION
Shows what a tournament does to the club beyond crowning a winner: the pairs it put in front of each other for the first time, the pairs who had not met in a long time, and the players it brought back or brought in. Sits under the timeline on the Statistics tab.

## What it shows

**Pairs** — every pair that played a real game in the tournament, classified against the club's history:
- **First-ever meetings** — they had never played each other.
- **Reunions** — they had met, but not within six months of the tournament start. Sorted by longest time apart.
- **Regulars** — counted, not listed. The tournament brought them nothing new.

**Players** — three separate sections, each stating in its title what it is:
- **First game ever** — they had never played in the club until this tournament.
- **Back after a break** — they had played before, but nothing in the six months prior. Longest absence first.
- **First tournament** — playing all along, but never in a tournament before.

A player appears in one section only, and a player's total game count is deliberately not part of the model, so it cannot surface here.

## How it is measured

Everything is judged against the club as it stood the moment the tournament started. That single baseline is what keeps the numbers steady: a pair meeting twice, in group play and then again in the bracket, is one first meeting rather than a meeting followed by a rematch.

Skipped games, byes and walkovers are left out — nobody met over them. This is why the games counted here can be fewer than the timeline's.

A tournament between regulars shows little, and saying so is the point of it: the empty state reports that everyone here already plays each other, and gives the longest anyone had gone without meeting anyway.

## Changes

- `client-db/tournaments/tournament-connections.ts` — the derivation, following the `tournament-timeline.ts` pattern
- `pages/tournament/stats/connections-widget.tsx` — stat tiles and the five lists
- `pages/tournament/stats/tournament-stats.tsx` — the widget added under the timeline
- `__tests__/tournaments/tournament-connections.test.ts` — 9 tests
- A changelog post

## Testing

9 new tests cover first meetings, reunions and regulars, a pair meeting twice in double elimination counting once, skipped games being ignored, debuts, returners, a break shorter than six months not counting, the absence ordering, and first timers against an earlier tournament.

Full suite 406 passing, `tsc` clean, lint clean, production build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9nRTxPwnNzpjq6HMACtF5