### PR TITLE
Perfect Day awarded only after the day ends

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -31,6 +31,25 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "perfect-day-awarded-when-the-day-ends",
+    title: "Perfect Day is awarded once the day is over",
+    date: "2026-07-30",
+    tags: ["bug-fix"],
+    summary:
+      "Five undefeated games no longer earns Perfect Day on the spot - it lands after midnight, once the day can no longer be spoilt by a loss.",
+    body: [
+      text(
+        "An undefeated day now shows as a complete 5/5 attempt until the day ends, and the achievement is granted when the next day starts.",
+      ),
+      text(
+        "Previously the fifth win awarded it immediately, which was wrong: a loss later the same afternoon disqualifies the day, so the achievement would appear and then vanish from your profile. If you saw a Perfect Day you later lost, that is why.",
+      ),
+      text(
+        "Perfect Week is unaffected and is still awarded the moment you win on the Friday. Losses never count against a perfect week, so nothing later in the week can take it back.",
+      ),
+    ],
+  },
+  {
     slug: "tournament-statistics-timeline",
     title: "A Statistics tab on tournaments",
     date: "2026-07-30",

--- a/frontend/src/client/client-db/__tests__/achievements/perfect-day.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/perfect-day.test.ts
@@ -111,6 +111,87 @@ describe("Perfect Day Achievement Tests", () => {
     expect(perfectDays).toHaveLength(2);
   });
 
+  describe("Only awarded once the day is over", () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("does NOT award while the undefeated day is still in progress", () => {
+      // "now" is the evening of the winning day — a loss could still come.
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2024, 0, 15, 20));
+
+      const events: EventType[] = [
+        ...baseEvents,
+        ...winsOnDay(2024, 0, 15, "player-1", ["player-2", "player-3", "player-2", "player-3", "player-2"], "g"),
+      ];
+
+      const tennisTable = new TennisTable({ events });
+      tennisTable.achievements.calculateAchievements();
+
+      const perfectDays = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-day");
+      expect(perfectDays).toHaveLength(0);
+      // The attempt is complete but pending the end of the day.
+      const progression = tennisTable.achievements.getPlayerProgression("player-1");
+      expect(progression["perfect-day"].current).toBe(5);
+      expect(progression["perfect-day"].earned).toBe(0);
+    });
+
+    it("awards it once the next day has started", () => {
+      // Same games, but "now" is just past midnight into the next day.
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2024, 0, 16, 0, 1));
+
+      const events: EventType[] = [
+        ...baseEvents,
+        ...winsOnDay(2024, 0, 15, "player-1", ["player-2", "player-3", "player-2", "player-3", "player-2"], "g"),
+      ];
+
+      const tennisTable = new TennisTable({ events });
+      tennisTable.achievements.calculateAchievements();
+
+      const perfectDays = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-day");
+      expect(perfectDays).toHaveLength(1);
+      expect(perfectDays[0].earnedAt).toBe(new Date(2024, 0, 15, 13).getTime());
+    });
+
+    it("still awards earlier completed days while today is in progress", () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2024, 0, 16, 20));
+
+      const events: EventType[] = [
+        ...baseEvents,
+        // Yesterday: a completed perfect day.
+        ...winsOnDay(2024, 0, 15, "player-1", ["player-2", "player-3", "player-2", "player-3", "player-2"], "d1"),
+        // Today: undefeated so far, but the day is not over.
+        ...winsOnDay(2024, 0, 16, "player-1", ["player-3", "player-2", "player-3", "player-2", "player-3"], "d2"),
+      ];
+
+      const tennisTable = new TennisTable({ events });
+      tennisTable.achievements.calculateAchievements();
+
+      const perfectDays = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-day");
+      expect(perfectDays).toHaveLength(1);
+      expect(perfectDays[0].data.day).toBe(new Date(2024, 0, 15).getTime());
+    });
+
+    it("does NOT award for games dated in the future", () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2024, 0, 15, 12));
+
+      const events: EventType[] = [
+        ...baseEvents,
+        ...winsOnDay(2024, 0, 20, "player-1", ["player-2", "player-3", "player-2", "player-3", "player-2"], "g"),
+      ];
+
+      const tennisTable = new TennisTable({ events });
+      tennisTable.achievements.calculateAchievements();
+
+      const perfectDays = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-day");
+      expect(perfectDays).toHaveLength(0);
+    });
+  });
+
   describe("Progression (live, resets each day)", () => {
     afterEach(() => {
       jest.useRealTimers();

--- a/frontend/src/client/client-db/__tests__/achievements/perfect-week.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/perfect-week.test.ts
@@ -140,6 +140,32 @@ describe("Perfect Week Achievement Tests", () => {
     expect(perfectWeeks).toHaveLength(0);
   });
 
+  it("awards immediately on the Friday win, without waiting for the week to end", () => {
+    // "now" is Friday afternoon, right after the fifth weekday win. Unlike
+    // Perfect Day, nothing later in the week can disqualify it — losses do not
+    // count against a perfect week — so it is awarded on the spot.
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2024, 0, 19, 13));
+
+    const events: EventType[] = [
+      ...baseEvents,
+      win(2024, 0, 15, "player-1", "player-2", "mon"),
+      win(2024, 0, 16, "player-1", "player-2", "tue"),
+      win(2024, 0, 17, "player-1", "player-2", "wed"),
+      win(2024, 0, 18, "player-1", "player-2", "thu"),
+      win(2024, 0, 19, "player-1", "player-2", "fri"),
+    ];
+
+    const tennisTable = new TennisTable({ events });
+    tennisTable.achievements.calculateAchievements();
+
+    const perfectWeeks = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-week");
+    expect(perfectWeeks).toHaveLength(1);
+    expect(perfectWeeks[0].earnedAt).toBe(new Date(2024, 0, 19, 12).getTime());
+
+    jest.useRealTimers();
+  });
+
   describe("Progression (live, resets on a missed weekday)", () => {
     afterEach(() => {
       jest.useRealTimers();

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -554,12 +554,17 @@ export class Achievements {
   //
   // Perfect Day: for every calendar day (local time) on which a player
   // played 5 or more games and won every single one of them (zero losses
-  // that day). Stamped at the day's last (winning) game.
+  // that day). Stamped at the day's last (winning) game. Only awarded once
+  // the day is OVER — a loss later the same day would disqualify it, so an
+  // undefeated day still in progress stays a pending attempt (tracked by
+  // progression) until local midnight passes.
   //
   // Perfect Week: for every working week (Monday–Friday, local time) in
   // which a player won at least one game on each of the five weekdays.
   // Wins on Saturday / Sunday do not count. Stamped at the game that
-  // completed the fifth distinct weekday.
+  // completed the fifth distinct weekday. Unlike Perfect Day this is awarded
+  // immediately: losses never disqualify a week, so nothing later in the week
+  // can take it away.
   //
   // Both are earnable multiple times — once per qualifying day / week.
   // Games are already time-ordered, so the completing win's timestamp is
@@ -633,10 +638,14 @@ export class Achievements {
       }
     });
 
-    // Award Perfect Day for each undefeated 5+ game day, in day order.
+    // Award Perfect Day for each undefeated 5+ game day, in day order. Days
+    // that have not fully elapsed are skipped: more games can still be played,
+    // and a single loss would nullify the day.
+    const todayStart = dayStartOf(Date.now());
     for (const [playerId, days] of perDay) {
       const sortedDays = Array.from(days.entries()).sort((a, b) => a[0] - b[0]);
       for (const [day, stats] of sortedDays) {
+        if (day >= todayStart) continue;
         if (stats.losses === 0 && stats.wins >= 5) {
           this.#addAchievement(
             playerId,
@@ -2173,7 +2182,8 @@ export class Achievements {
     // Perfect Day progression tracks TODAY's live attempt: the number of
     // games won today with zero losses so far. A single loss today nullifies
     // it — progress drops to 0 and the player must try again tomorrow. No
-    // games today → 0.
+    // games today → 0. A full 5/5 today reads as complete but is not yet
+    // earned: the achievement lands when the day ends still undefeated.
     const nowMs = Date.now();
     const todayStart = new Date(nowMs);
     todayStart.setHours(0, 0, 0, 0);


### PR DESCRIPTION
## Summary
Perfect Day achievement is now awarded only once the calendar day is over (after local midnight), rather than immediately upon the fifth consecutive win. This prevents the achievement from appearing and then disappearing if a loss occurs later the same day.

## Changes
- **Achievement logic** (`achievements.ts`): Added a check to skip awarding Perfect Day for any day that hasn't fully elapsed yet. Days are only eligible once they're in the past relative to the current time.
- **Test coverage** (`perfect-day.test.ts`): Added comprehensive test suite covering:
  - No award while the undefeated day is still in progress
  - Award once the next day has started
  - Earlier completed days still award while today is in progress
  - No award for games dated in the future
- **Perfect Week clarification** (`perfect-week.test.ts`): Added test confirming Perfect Week is still awarded immediately on the Friday win (losses never disqualify a week, so nothing later can take it away)
- **Documentation** (`achievements.ts`): Updated comments to clarify the timing difference between Perfect Day (awarded after day ends) and Perfect Week (awarded immediately)
- **Changelog** (`changelog-posts.ts`): Added user-facing post explaining the fix and why it matters

## Implementation Details
- Perfect Day progression still shows as a complete 5/5 attempt while the day is in progress, but the achievement itself is not granted until local midnight passes
- The check uses `dayStartOf(Date.now())` to determine today's boundary and skips any day at or after that point
- Perfect Week behavior is unchanged: it awards immediately since losses never count against a week

https://claude.ai/code/session_01GzpFLf1wizJWAZmaLFVunF