### PR TITLE
Add configurable settings to player pairings widget

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -123,7 +123,14 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
         "Where several equally short chains exist, the one with the most games on its last hop wins - picked hop by hop working back from the player you hover. That same count is what orders each column.",
       ),
       text(
-        "Only games between two active players count as links, so a retired player does not keep bridging the people who used to play through them.",
+        "A cog in the widget's top right opens two settings, both recalculating the chains as you change them, so the columns, their counts and the paths on hover all follow along.",
+      ),
+      list(
+        "Include retired players - off by default. Left off, only games between two active players count as links, so a retired player does not keep bridging the people who used to play through them. Turn it on and they reappear in the columns and start bridging again.",
+        "Games per link - anywhere from 1 to 10. At 1 a single game between two players connects them; higher up, only pairs who play each other that often count.",
+      ),
+      text(
+        "Games per link is the more interesting of the two: it strips out the one-off games that make almost everyone look two steps apart, leaving the chains that run through opponents people actually play. Pushed far enough it will route you around someone you have only met once, and drop players into the no-connection column entirely.",
       ),
     ],
   },

--- a/frontend/src/client/client-db/__tests__/player-pairings.test.ts
+++ b/frontend/src/client/client-db/__tests__/player-pairings.test.ts
@@ -1,5 +1,6 @@
 import { TennisTable } from "../tennis-table";
 import { EventType, EventTypeEnum } from "../event-store/event-types";
+import { PlayerPairingsOptions } from "../player-pairings";
 
 let time = 0;
 const nextTime = () => ++time;
@@ -24,8 +25,8 @@ function games(winner: string, loser: string, count = 1): EventType[] {
   });
 }
 
-function pairings(events: EventType[], playerId: string) {
-  const result = new TennisTable({ events }).playerPairings.get(playerId);
+function pairings(events: EventType[], playerId: string, options?: PlayerPairingsOptions) {
+  const result = new TennisTable({ events }).playerPairings.get(playerId, options);
   return {
     columns: result.columns.map((column) => ({
       degree: column.degree,
@@ -159,6 +160,70 @@ describe("PlayerPairings", () => {
       columns: [
         { degree: 1, players: ["a"] },
         { degree: 2, players: ["b"] },
+      ],
+      unreachable: [],
+    });
+  });
+
+  it("includes retired players and routes paths through them when asked to", () => {
+    const events = [
+      player("me"),
+      player("retired"),
+      player("behind-retired"),
+      ...games("me", "retired"),
+      ...games("retired", "behind-retired"),
+      deactivate("retired"),
+    ];
+
+    expect(pairings(events, "me", { includeRetired: true })).toEqual({
+      columns: [
+        { degree: 1, players: ["retired"] },
+        { degree: 2, players: ["behind-retired"] },
+      ],
+      unreachable: [],
+    });
+  });
+
+  it("lists a retired player with no connecting games as unreachable when included", () => {
+    const events = [player("me"), player("a"), player("gone"), ...games("me", "a"), deactivate("gone")];
+
+    expect(pairings(events, "me", { includeRetired: true })).toEqual({
+      columns: [{ degree: 1, players: ["a"] }],
+      unreachable: ["gone"],
+    });
+  });
+
+  it("only links players who have played each other the required number of times", () => {
+    const events = [
+      player("me"),
+      player("often"),
+      player("once"),
+      player("behind-once"),
+      ...games("me", "often", 3),
+      ...games("me", "once", 1),
+      ...games("once", "behind-once", 4),
+    ];
+
+    expect(pairings(events, "me", { minGamesPerLink: 3 })).toEqual({
+      columns: [{ degree: 1, players: ["often"] }],
+      unreachable: ["behind-once", "once"],
+    });
+  });
+
+  it("reaches players through a longer route when the short one is below the threshold", () => {
+    const events = [
+      player("me"),
+      player("hub"),
+      player("target"),
+      ...games("me", "hub", 5),
+      ...games("hub", "target", 5),
+      ...games("me", "target", 1),
+    ];
+
+    expect(pairings(events, "me", { minGamesPerLink: 2 })).toEqual({
+      columns: [
+        { degree: 1, players: ["hub"] },
+        { degree: 2, players: ["target"] },
       ],
       unreachable: [],
     });

--- a/frontend/src/client/client-db/player-pairings.ts
+++ b/frontend/src/client/client-db/player-pairings.ts
@@ -16,14 +16,21 @@ export type PlayerPairingsColumn = {
 
 export type PlayerPairingsDTO = {
   columns: PlayerPairingsColumn[];
-  /** Active players with no path of games connecting them to the player. */
+  /** Included players with no path of games connecting them to the player. */
   unreachable: string[];
 };
 
+export type PlayerPairingsOptions = {
+  /** Let retired players be reached, and be routed through. Defaults to false. */
+  includeRetired?: boolean;
+  /** Games two players need against each other before that counts as a link. Defaults to 1. */
+  minGamesPerLink?: number;
+};
+
 /**
- * Groups every other active player by how many intermediaries it takes to connect them to a
- * player through games played. Only games between two active players count as connections, so
- * retiring a player breaks the paths that ran through them.
+ * Groups every other player by how many intermediaries it takes to connect them to a player
+ * through games played. Retired players are left out of the graph by default, so retiring a
+ * player breaks the paths that ran through them.
  */
 export class PlayerPairings {
   private parent: TennisTable;
@@ -32,9 +39,13 @@ export class PlayerPairings {
     this.parent = parent;
   }
 
-  get(playerId: string): PlayerPairingsDTO {
+  get(playerId: string, options: PlayerPairingsOptions = {}): PlayerPairingsDTO {
+    const includeRetired = options.includeRetired ?? false;
+    const minGamesPerLink = Math.max(1, options.minGamesPerLink ?? 1);
+
+    const included = includeRetired ? this.parent.allPlayers : this.parent.players;
     // The player themselves may be retired, but their own games still connect them to the graph.
-    const nodes = new Set<string>(this.parent.players.map((player) => player.id));
+    const nodes = new Set<string>(included.map((player) => player.id));
     nodes.add(playerId);
 
     const games = new Map<string, Map<string, number>>();
@@ -59,6 +70,7 @@ export class PlayerPairings {
 
       for (const from of previous) {
         for (const [to, gamesPlayed] of games.get(from.playerId) ?? []) {
+          if (gamesPlayed < minGamesPerLink) continue; // Too few games together to count as a link
           if (degrees.has(to)) continue; // Already reached on a shorter path
           const existing = found.get(to);
           // Multiple paths of the same length: keep the one with the most games on the last hop.
@@ -81,7 +93,7 @@ export class PlayerPairings {
       }
     }
 
-    const unreachable = this.parent.players
+    const unreachable = included
       .filter((player) => !degrees.has(player.id))
       .map((player) => player.id)
       .sort((a, b) => this.parent.playerName(a).localeCompare(this.parent.playerName(b)));

--- a/frontend/src/pages/player/content-card.tsx
+++ b/frontend/src/pages/player/content-card.tsx
@@ -8,7 +8,9 @@ type Props = {
 
 export const ContentCard: React.FC<Props> = ({ title, description, action, children }) => {
   return (
-    <div className="bg-primary-background text-primary-text rounded-xl p-3 md:p-6 pt-2 md:pt-3">
+    // min-w-0 so a grid or flex parent clamps the card to its track instead of letting wide
+    // content stretch it past the viewport, which would put the action out of reach.
+    <div className="min-w-0 bg-primary-background text-primary-text rounded-xl p-3 md:p-6 pt-2 md:pt-3">
       <div className="flex items-start justify-between gap-3 mb-2 md:mb-4">
         <section className="flex flex-col gap-x-6 md:flex-row items-baseline">
           <h3 className="text-base md:text-lg font-semibold">{title}</h3>

--- a/frontend/src/pages/player/content-card.tsx
+++ b/frontend/src/pages/player/content-card.tsx
@@ -1,0 +1,22 @@
+type Props = {
+  title: string;
+  description?: string;
+  /** Rendered in the card's top right corner, level with the title. */
+  action?: React.ReactNode;
+  children: React.ReactNode;
+};
+
+export const ContentCard: React.FC<Props> = ({ title, description, action, children }) => {
+  return (
+    <div className="bg-primary-background text-primary-text rounded-xl p-3 md:p-6 pt-2 md:pt-3">
+      <div className="flex items-start justify-between gap-3 mb-2 md:mb-4">
+        <section className="flex flex-col gap-x-6 md:flex-row items-baseline">
+          <h3 className="text-base md:text-lg font-semibold">{title}</h3>
+          <p className="text-sm md:text-base">{description}</p>
+        </section>
+        {action && <div className="shrink-0">{action}</div>}
+      </div>
+      {children}
+    </div>
+  );
+};

--- a/frontend/src/pages/player/player-page.tsx
+++ b/frontend/src/pages/player/player-page.tsx
@@ -15,6 +15,7 @@ import { PlayerAchievements } from "./player-achievements";
 import { PlayerPredictionsPage } from "./player-predictions-page";
 import { PlayerSeasonStats } from "./player-season-stats";
 import { PlayerPairings } from "./player-pairings";
+import { ContentCard } from "./content-card";
 import { usePlayerLinkSearch } from "../../hooks/use-player-link-search";
 
 type TabType = "overview" | "games" | "statistics" | "achievements" | "predictions" | "season";
@@ -368,11 +369,7 @@ export const PlayerPage: React.FC = () => {
                 </ContentCard>
               )}
 
-              {playerId && (
-                <ContentCard title="Player pairings" description="How many players it takes to connect you">
-                  <PlayerPairings playerId={playerId} />
-                </ContentCard>
-              )}
+              {playerId && <PlayerPairings playerId={playerId} />}
             </div>
           </div>
         )}
@@ -386,18 +383,3 @@ export const PlayerPage: React.FC = () => {
   );
 };
 
-export const ContentCard: React.FC<{ title: string; description?: string; children: React.ReactNode }> = ({
-  title,
-  description,
-  children,
-}) => {
-  return (
-    <div className="bg-primary-background text-primary-text rounded-xl p-3 md:p-6 pt-2 md:pt-3">
-      <section className="flex flex-col gap-x-6 md:flex-row items-baseline mb-2 md:mb-4">
-        <h3 className="text-base md:text-lg font-semibold">{title}</h3>
-        <p className="text-sm md:text-base">{description}</p>
-      </section>
-      {children}
-    </div>
-  );
-};

--- a/frontend/src/pages/player/player-pairings.tsx
+++ b/frontend/src/pages/player/player-pairings.tsx
@@ -70,13 +70,77 @@ const PairingsColumn: React.FC<{ title: string; count: number; children: React.R
   </div>
 );
 
+const MIN_GAMES_PER_LINK = 1;
+const MAX_GAMES_PER_LINK = 10;
+
+const CogIcon: React.FC = () => (
+  <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth={1.5} viewBox="0 0 24 24">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 0 1 0 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 0 1 0-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281Z"
+    />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+  </svg>
+);
+
+type SettingsProps = {
+  includeRetired: boolean;
+  onIncludeRetiredChange: (value: boolean) => void;
+  minGamesPerLink: number;
+  onMinGamesPerLinkChange: (value: number) => void;
+};
+
+const PairingsSettings: React.FC<SettingsProps> = ({
+  includeRetired,
+  onIncludeRetiredChange,
+  minGamesPerLink,
+  onMinGamesPerLinkChange,
+}) => (
+  <div className="w-full sm:w-72 bg-secondary-background text-secondary-text rounded-lg p-3 space-y-3">
+    <label className="flex items-center gap-2 py-1 text-sm cursor-pointer">
+      <input
+        type="checkbox"
+        className="w-4 h-4 cursor-pointer accent-secondary-text"
+        checked={includeRetired}
+        onChange={(event) => onIncludeRetiredChange(event.target.checked)}
+      />
+      Include retired players
+    </label>
+    <div>
+      <label className="flex items-baseline justify-between gap-2 text-sm" htmlFor="pairings-min-games">
+        Games per link
+        <span className="font-semibold">
+          {minGamesPerLink} game{minGamesPerLink === 1 ? "" : "s"}
+        </span>
+      </label>
+      <input
+        id="pairings-min-games"
+        type="range"
+        min={MIN_GAMES_PER_LINK}
+        max={MAX_GAMES_PER_LINK}
+        value={minGamesPerLink}
+        onChange={(event) => onMinGamesPerLinkChange(Number(event.target.value))}
+        className="w-full mt-1 cursor-pointer accent-secondary-text"
+      />
+      <p className="text-xs opacity-70">
+        Two players are only linked once they have played each other this many times.
+      </p>
+    </div>
+  </div>
+);
+
 export const PlayerPairings: React.FC<Props> = ({ playerId }) => {
   const context = useEventDbContext();
   const search = usePlayerLinkSearch();
 
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [includeRetired, setIncludeRetired] = useState(false);
+  const [minGamesPerLink, setMinGamesPerLink] = useState(MIN_GAMES_PER_LINK);
+
   const { columns, unreachable } = useMemo(
-    () => context.playerPairings.get(playerId),
-    [context.playerPairings, playerId],
+    () => context.playerPairings.get(playerId, { includeRetired, minGamesPerLink }),
+    [context.playerPairings, playerId, includeRetired, minGamesPerLink],
   );
 
   const paths = useMemo(() => {
@@ -141,83 +205,108 @@ export const PlayerPairings: React.FC<Props> = ({ playerId }) => {
     return () => window.removeEventListener("resize", measure);
   }, [path]);
 
-  if (columns.length === 0 && unreachable.length === 0) {
-    return <p className="text-sm opacity-70">No other players to connect to.</p>;
-  }
-
   const onPath = new Set(path);
   const dimmed = (id: string) => path.length > 0 && !onPath.has(id);
+  const isEmpty = columns.length === 0 && unreachable.length === 0;
 
   return (
-    <div className="overflow-x-auto -mx-1 px-1">
-      <div ref={contentRef} className="relative flex gap-6 items-start w-max">
-        {columns.map((column) => (
-          <PairingsColumn key={column.degree} title={columnTitle(column.degree)} count={column.players.length}>
-            {column.players.map((player) => (
-              <PlayerTag
-                key={player.playerId}
-                playerId={player.playerId}
-                dimmed={dimmed(player.playerId)}
-                search={search}
-                onRef={registerTag}
-                onHighlight={setHighlighted}
-                title={
-                  column.degree === 1
-                    ? `${player.games} game${player.games === 1 ? "" : "s"} together`
-                    : `Via ${player.path
-                        .slice(0, -1)
-                        .map((id) => context.playerName(id))
-                        .join(" → ")}`
-                }
-              />
-            ))}
-          </PairingsColumn>
-        ))}
-        {unreachable.length > 0 && (
-          <PairingsColumn title="No connection" count={unreachable.length}>
-            {unreachable.map((id) => (
-              <PlayerTag
-                key={id}
-                playerId={id}
-                dimmed={dimmed(id)}
-                search={search}
-                onRef={registerTag}
-                onHighlight={setHighlighted}
-              />
-            ))}
-          </PairingsColumn>
-        )}
-        {lines.length > 0 && (
-          <svg className="absolute inset-0 w-full h-full overflow-visible pointer-events-none">
-            <defs>
-              <marker
-                id={ARROW_MARKER_ID}
-                markerWidth={5}
-                markerHeight={5}
-                refX={4}
-                refY={2}
-                orient="auto"
-                fill="rgb(var(--color-primary-text))"
-              >
-                <path d="M 0 0 L 4 2 L 0 4 z" />
-              </marker>
-            </defs>
-            {lines.map((line) => (
-              <line
-                key={line.key}
-                x1={line.x1}
-                y1={line.y1}
-                x2={line.x2}
-                y2={line.y2}
-                stroke="rgb(var(--color-primary-text))"
-                strokeWidth={2}
-                strokeLinecap="round"
-                markerEnd={`url(#${ARROW_MARKER_ID})`}
-              />
-            ))}
-          </svg>
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-col items-end gap-2">
+        <button
+          type="button"
+          aria-label="Pairing settings"
+          aria-expanded={settingsOpen}
+          onClick={() => setSettingsOpen((open) => !open)}
+          className={classNames(
+            "rounded-full p-2 hover:bg-secondary-background hover:text-secondary-text transition-colors",
+            settingsOpen && "bg-secondary-background text-secondary-text",
+          )}
+        >
+          <CogIcon />
+        </button>
+        {settingsOpen && (
+          <PairingsSettings
+            includeRetired={includeRetired}
+            onIncludeRetiredChange={setIncludeRetired}
+            minGamesPerLink={minGamesPerLink}
+            onMinGamesPerLinkChange={setMinGamesPerLink}
+          />
         )}
       </div>
+      {isEmpty ? (
+        <p className="text-sm opacity-70">No other players to connect to.</p>
+      ) : (
+        <div className="overflow-x-auto -mx-1 px-1">
+          <div ref={contentRef} className="relative flex gap-6 items-start w-max">
+            {columns.map((column) => (
+              <PairingsColumn key={column.degree} title={columnTitle(column.degree)} count={column.players.length}>
+                {column.players.map((player) => (
+                  <PlayerTag
+                    key={player.playerId}
+                    playerId={player.playerId}
+                    dimmed={dimmed(player.playerId)}
+                    search={search}
+                    onRef={registerTag}
+                    onHighlight={setHighlighted}
+                    title={
+                      column.degree === 1
+                        ? `${player.games} game${player.games === 1 ? "" : "s"} together`
+                        : `Via ${player.path
+                            .slice(0, -1)
+                            .map((id) => context.playerName(id))
+                            .join(" → ")}`
+                    }
+                  />
+                ))}
+              </PairingsColumn>
+            ))}
+            {unreachable.length > 0 && (
+              <PairingsColumn title="No connection" count={unreachable.length}>
+                {unreachable.map((id) => (
+                  <PlayerTag
+                    key={id}
+                    playerId={id}
+                    dimmed={dimmed(id)}
+                    search={search}
+                    onRef={registerTag}
+                    onHighlight={setHighlighted}
+                  />
+                ))}
+              </PairingsColumn>
+            )}
+            {lines.length > 0 && (
+              <svg className="absolute inset-0 w-full h-full overflow-visible pointer-events-none">
+                <defs>
+                  <marker
+                    id={ARROW_MARKER_ID}
+                    markerWidth={5}
+                    markerHeight={5}
+                    refX={4}
+                    refY={2}
+                    orient="auto"
+                    fill="rgb(var(--color-primary-text))"
+                  >
+                    <path d="M 0 0 L 4 2 L 0 4 z" />
+                  </marker>
+                </defs>
+                {lines.map((line) => (
+                  <line
+                    key={line.key}
+                    x1={line.x1}
+                    y1={line.y1}
+                    x2={line.x2}
+                    y2={line.y2}
+                    stroke="rgb(var(--color-primary-text))"
+                    strokeWidth={2}
+                    strokeLinecap="round"
+                    markerEnd={`url(#${ARROW_MARKER_ID})`}
+                  />
+                ))}
+              </svg>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/player/player-pairings.tsx
+++ b/frontend/src/pages/player/player-pairings.tsx
@@ -5,6 +5,7 @@ import { stringToColor } from "../../common/string-to-color";
 import { classNames } from "../../common/class-names";
 import { readableTextColor } from "../../common/color-utils";
 import { usePlayerLinkSearch } from "../../hooks/use-player-link-search";
+import { ContentCard } from "./content-card";
 
 type Props = {
   playerId: string;
@@ -97,7 +98,7 @@ const PairingsSettings: React.FC<SettingsProps> = ({
   minGamesPerLink,
   onMinGamesPerLinkChange,
 }) => (
-  <div className="w-full sm:w-72 bg-secondary-background text-secondary-text rounded-lg p-3 space-y-3">
+  <div className="w-full bg-secondary-background text-secondary-text rounded-lg p-3 mb-3 space-y-3">
     <label className="flex items-center gap-2 py-1 text-sm cursor-pointer">
       <input
         type="checkbox"
@@ -210,8 +211,10 @@ export const PlayerPairings: React.FC<Props> = ({ playerId }) => {
   const isEmpty = columns.length === 0 && unreachable.length === 0;
 
   return (
-    <div className="flex flex-col gap-2">
-      <div className="flex flex-col items-end gap-2">
+    <ContentCard
+      title="Player pairings"
+      description="How many players it takes to connect you"
+      action={
         <button
           type="button"
           aria-label="Pairing settings"
@@ -224,15 +227,16 @@ export const PlayerPairings: React.FC<Props> = ({ playerId }) => {
         >
           <CogIcon />
         </button>
-        {settingsOpen && (
-          <PairingsSettings
-            includeRetired={includeRetired}
-            onIncludeRetiredChange={setIncludeRetired}
-            minGamesPerLink={minGamesPerLink}
-            onMinGamesPerLinkChange={setMinGamesPerLink}
-          />
-        )}
-      </div>
+      }
+    >
+      {settingsOpen && (
+        <PairingsSettings
+          includeRetired={includeRetired}
+          onIncludeRetiredChange={setIncludeRetired}
+          minGamesPerLink={minGamesPerLink}
+          onMinGamesPerLinkChange={setMinGamesPerLink}
+        />
+      )}
       {isEmpty ? (
         <p className="text-sm opacity-70">No other players to connect to.</p>
       ) : (
@@ -307,6 +311,6 @@ export const PlayerPairings: React.FC<Props> = ({ playerId }) => {
           </div>
         </div>
       )}
-    </div>
+    </ContentCard>
   );
 };

--- a/frontend/src/pages/player/player-pairings.tsx
+++ b/frontend/src/pages/player/player-pairings.tsx
@@ -98,8 +98,8 @@ const PairingsSettings: React.FC<SettingsProps> = ({
   minGamesPerLink,
   onMinGamesPerLinkChange,
 }) => (
-  <div className="w-full bg-secondary-background text-secondary-text rounded-lg p-3 mb-3 space-y-3">
-    <label className="flex items-center gap-2 py-1 text-sm cursor-pointer">
+  <div className="w-full bg-secondary-background text-secondary-text rounded-lg p-3 mb-3 flex flex-col gap-3 sm:flex-row sm:gap-6">
+    <label className="flex items-center gap-2 py-1 text-sm cursor-pointer sm:w-52 sm:shrink-0 sm:self-start">
       <input
         type="checkbox"
         className="w-4 h-4 cursor-pointer accent-secondary-text"
@@ -108,7 +108,7 @@ const PairingsSettings: React.FC<SettingsProps> = ({
       />
       Include retired players
     </label>
-    <div>
+    <div className="sm:flex-1 sm:min-w-0">
       <label className="flex items-baseline justify-between gap-2 text-sm" htmlFor="pairings-min-games">
         Games per link
         <span className="font-semibold">
@@ -124,9 +124,7 @@ const PairingsSettings: React.FC<SettingsProps> = ({
         onChange={(event) => onMinGamesPerLinkChange(Number(event.target.value))}
         className="w-full mt-1 cursor-pointer accent-secondary-text"
       />
-      <p className="text-xs opacity-70">
-        Two players are only linked once they have played each other this many times.
-      </p>
+      <p className="text-xs opacity-70">Games two players need against each other to count as a link.</p>
     </div>
   </div>
 );

--- a/frontend/src/pages/player/player-season-stats.tsx
+++ b/frontend/src/pages/player/player-season-stats.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { useEventDbContext } from "../../wrappers/event-db-context";
 import { fmtNum } from "../../common/number-utils";
-import { ContentCard } from "./player-page";
+import { ContentCard } from "./content-card";
 import { Season } from "../../client/client-db/seasons/season";
 import { dateString } from "./player-achievements";
 import { SeasonPlayerScoreGraph } from "./season-player-score-graph";


### PR DESCRIPTION
Adds a settings panel to the player pairings widget, allowing users to control how the connection graph is built and displayed.

## Changes

- **Settings UI**: Added a cog icon button that toggles a settings panel with two configurable options:
  - "Include retired players" checkbox: Controls whether retired players appear in the graph and can bridge connections
  - "Games per link" slider (1-10): Sets the minimum number of games two players must have against each other to count as a direct link

- **Graph calculation**: Updated `PlayerPairings.get()` to accept `PlayerPairingsOptions` with `includeRetired` and `minGamesPerLink` settings, filtering the player graph and link thresholds accordingly

- **UI layout**: Restructured the component to place settings above the pairings display, with the graph conditionally rendered only when there are players to display

- **Tests**: Added comprehensive test coverage for both new settings, including edge cases like reaching players through longer routes when shorter ones fall below the threshold

- **Changelog**: Added a post documenting the new settings feature and its effects on the pairings display

## Implementation Details

The settings are applied reactively—changing either option immediately recalculates the graph, updating columns, counts, and hover paths. The "Games per link" setting is particularly useful for filtering out one-off games and focusing on established rivalries.

https://claude.ai/code/session_01EfW8V32Vzxpo3jjhvVA3hs