### PR TITLE
Add Longest Win Streak and Longest Lose Streak achievements

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -31,6 +31,31 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "longest-win-and-lose-streak-achievements",
+    title: "2 new achievements: Longest Win Streak and Longest Lose Streak",
+    date: "2026-07-30",
+    tags: ["new-feature"],
+    summary:
+      "Two league records, one for consecutive wins and one for consecutive losses. Whoever holds a record keeps the award, and it grows as the streak does.",
+    body: [
+      text(
+        "Longest Win Streak goes to whoever has strung together the most wins in a row, and Longest Lose Streak to whoever has managed the opposite. Both are league records: you take one by beating the streak that stands, and the award records how long your streak was.",
+      ),
+      text(
+        "Extending a streak you already hold the record with does not hand you a second award - the one you have grows instead. Win your 11th in a row while your 10 is still the record and you have one award worth 11, not two.",
+      ),
+      text(
+        "It can be earned more than once, in two ways. A new streak that beats the record earns its own award, so a run of 10, a loss, and then 11 is two awards. So is being overtaken mid-streak: if somebody else reaches 11 while your 10-streak is alive, passing them again earns a second award, and the first keeps the 10 it was worth while it was the record.",
+      ),
+      text(
+        "The first record in either direction needs 3 in a row. After that only the record matters - and ties do not count, you have to beat it.",
+      ),
+      text(
+        "Your Progress tab shows the streak you are on, your longest ever, and who holds the record. Note that the progress bar tracks the streak you are on now: a long run in the past does not bring you closer to the record, only a live streak can grow into it.",
+      ),
+    ],
+  },
+  {
     slug: "tournament-predictions-stream-running-tallies",
     title: "Tournament predictions update while they run",
     date: "2026-07-30",

--- a/frontend/src/client/client-db/__tests__/achievements/longest-streak.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/longest-streak.test.ts
@@ -1,0 +1,275 @@
+import { Achievement } from "../../achievements";
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { TennisTable } from "../../tennis-table";
+
+// Games are played one minute apart, in the order they are listed.
+const GAME_INTERVAL = 60 * 1000;
+const FIRST_GAME_AT = 1_000_000;
+
+function playedAt(index: number): number {
+  return FIRST_GAME_AT + index * GAME_INTERVAL;
+}
+
+/** Builds the event log for a list of games given as [winner, loser] pairs. */
+function eventsForGames(games: [winner: string, loser: string][]): EventType[] {
+  const players = Array.from(new Set(games.flat()));
+  return [
+    ...players.map<EventType>((player, index) => ({
+      type: EventTypeEnum.PLAYER_CREATED,
+      stream: player,
+      time: index + 1,
+      data: { name: player },
+    })),
+    ...games.map<EventType>(([winner, loser], index) => ({
+      type: EventTypeEnum.GAME_CREATED,
+      stream: `g${index}`,
+      time: playedAt(index),
+      data: { winner, loser, playedAt: playedAt(index) },
+    })),
+  ];
+}
+
+function achievementsOfType<T extends "longest-win-streak" | "longest-lose-streak">(
+  tt: TennisTable,
+  player: string,
+  type: T,
+): Extract<Achievement, { type: T }>[] {
+  return tt.achievements
+    .getAchievements(player)
+    .filter((achievement): achievement is Extract<Achievement, { type: T }> => achievement.type === type);
+}
+
+function calculate(games: [winner: string, loser: string][]): TennisTable {
+  const tt = new TennisTable({ events: eventsForGames(games) });
+  tt.achievements.calculateAchievements();
+  return tt;
+}
+
+/** `count` wins for `winner`, cycling through the given opponents. */
+function wins(winner: string, opponents: string[], count: number): [string, string][] {
+  return Array.from({ length: count }, (_, index) => [winner, opponents[index % opponents.length]]);
+}
+
+/** `count` losses for `loser`, cycling through the given opponents. */
+function losses(loser: string, opponents: string[], count: number): [string, string][] {
+  return Array.from({ length: count }, (_, index) => [opponents[index % opponents.length], loser]);
+}
+
+describe("Longest Win Streak / Longest Lose Streak achievements", () => {
+  it("does not award a streak shorter than the 3 game floor", () => {
+    const tt = calculate([
+      ["alice", "bob"],
+      ["alice", "carol"],
+    ]);
+
+    expect(achievementsOfType(tt, "alice", "longest-win-streak")).toHaveLength(0);
+    expect(tt.achievements.winStreakRecord).toStrictEqual({ length: undefined, holder: undefined });
+  });
+
+  it("awards the first streak to reach the floor, with no previous record", () => {
+    const tt = calculate(wins("alice", ["bob", "carol"], 3));
+
+    const awards = achievementsOfType(tt, "alice", "longest-win-streak");
+    expect(awards).toHaveLength(1);
+    expect(awards[0]).toStrictEqual({
+      type: "longest-win-streak",
+      earnedBy: "alice",
+      earnedAt: playedAt(2),
+      data: { streakLength: 3, startedAt: playedAt(0), previousRecord: undefined },
+    });
+    expect(tt.achievements.winStreakRecord).toStrictEqual({ length: 3, holder: "alice" });
+  });
+
+  it("grows the award instead of handing out another one while the same streak keeps the record", () => {
+    const tt = calculate(wins("alice", ["bob", "carol"], 6));
+
+    const awards = achievementsOfType(tt, "alice", "longest-win-streak");
+    expect(awards).toHaveLength(1);
+    expect(awards[0].data).toStrictEqual({
+      streakLength: 6,
+      startedAt: playedAt(0),
+      previousRecord: undefined,
+    });
+    // earnedAt follows the streak, so the award spans the whole record run.
+    expect(awards[0].earnedAt).toBe(playedAt(5));
+    expect(tt.achievements.winStreakRecord).toStrictEqual({ length: 6, holder: "alice" });
+  });
+
+  it("awards a second time when a new streak beats the player's own record", () => {
+    const tt = calculate([
+      // Alice takes the record with 4 in a row.
+      ...wins("alice", ["bob", "carol"], 4),
+      // The streak is broken, so the next run is a different streak.
+      ["bob", "alice"],
+      ...wins("alice", ["bob", "carol"], 5),
+    ]);
+
+    const awards = achievementsOfType(tt, "alice", "longest-win-streak");
+    expect(awards).toHaveLength(2);
+    expect(awards[0].data).toStrictEqual({
+      streakLength: 4,
+      startedAt: playedAt(0),
+      previousRecord: undefined,
+    });
+    expect(awards[1].data).toStrictEqual({
+      streakLength: 5,
+      startedAt: playedAt(5),
+      previousRecord: 4,
+    });
+    expect(tt.achievements.winStreakRecord).toStrictEqual({ length: 5, holder: "alice" });
+  });
+
+  it("awards the same streak a second time when another player took the record in the meantime", () => {
+    const tt = calculate([
+      // Alice takes the record with 10 in a row, and stops there for now.
+      ...wins("alice", ["bob", "carol"], 10),
+      // Dave beats it with 11 while Alice's streak is still alive.
+      ...wins("dave", ["bob", "carol"], 11),
+      // Alice wins 2 more — 11 ties Dave and does not award, 12 takes the
+      // record back and, because Dave broke it in between, earns again.
+      ...wins("alice", ["bob", "carol"], 2),
+    ]);
+
+    const aliceAwards = achievementsOfType(tt, "alice", "longest-win-streak");
+    expect(aliceAwards).toHaveLength(2);
+    // The first award keeps the length it had while it was the record.
+    expect(aliceAwards[0].data).toStrictEqual({
+      streakLength: 10,
+      startedAt: playedAt(0),
+      previousRecord: undefined,
+    });
+    expect(aliceAwards[0].earnedAt).toBe(playedAt(9));
+    // The second covers the same streak, now 12 long.
+    expect(aliceAwards[1].data).toStrictEqual({
+      streakLength: 12,
+      startedAt: playedAt(0),
+      previousRecord: 11,
+    });
+    expect(aliceAwards[1].earnedAt).toBe(playedAt(22));
+
+    expect(achievementsOfType(tt, "dave", "longest-win-streak")).toHaveLength(1);
+    expect(tt.achievements.winStreakRecord).toStrictEqual({ length: 12, holder: "alice" });
+  });
+
+  it("does not award for tying the record", () => {
+    const tt = calculate([...wins("alice", ["bob", "carol"], 5), ...wins("dave", ["bob", "carol"], 5)]);
+
+    expect(achievementsOfType(tt, "alice", "longest-win-streak")).toHaveLength(1);
+    expect(achievementsOfType(tt, "dave", "longest-win-streak")).toHaveLength(0);
+    expect(tt.achievements.winStreakRecord).toStrictEqual({ length: 5, holder: "alice" });
+  });
+
+  it("keeps growing the award after a rival tried and failed to beat it", () => {
+    const tt = calculate([
+      ...wins("alice", ["bob", "carol"], 5),
+      // Dave gets to 4 — short of the record, so Alice still holds it.
+      ...wins("dave", ["bob", "carol"], 4),
+      ["bob", "dave"],
+      // Alice extends the same streak: still one award, now 7 long.
+      ...wins("alice", ["bob", "carol"], 2),
+    ]);
+
+    const awards = achievementsOfType(tt, "alice", "longest-win-streak");
+    expect(awards).toHaveLength(1);
+    expect(awards[0].data.streakLength).toBe(7);
+    expect(achievementsOfType(tt, "dave", "longest-win-streak")).toHaveLength(0);
+    expect(tt.achievements.winStreakRecord).toStrictEqual({ length: 7, holder: "alice" });
+  });
+
+  it("tracks the lose streak record the same way", () => {
+    const tt = calculate([
+      // Alice loses 4 in a row and takes the lose streak record.
+      ...losses("alice", ["bob", "carol"], 4),
+      // Dave loses 5 and takes it over.
+      ...losses("dave", ["bob", "carol"], 5),
+      // Alice loses 2 more, reaching 6, and earns again.
+      ...losses("alice", ["bob", "carol"], 2),
+    ]);
+
+    const aliceAwards = achievementsOfType(tt, "alice", "longest-lose-streak");
+    expect(aliceAwards).toHaveLength(2);
+    expect(aliceAwards[0].data).toStrictEqual({
+      streakLength: 4,
+      startedAt: playedAt(0),
+      previousRecord: undefined,
+    });
+    expect(aliceAwards[1].data).toStrictEqual({
+      streakLength: 6,
+      startedAt: playedAt(0),
+      previousRecord: 5,
+    });
+
+    const daveAwards = achievementsOfType(tt, "dave", "longest-lose-streak");
+    expect(daveAwards).toHaveLength(1);
+    expect(daveAwards[0].data).toStrictEqual({
+      streakLength: 5,
+      startedAt: playedAt(4),
+      previousRecord: 4,
+    });
+
+    expect(tt.achievements.loseStreakRecord).toStrictEqual({ length: 6, holder: "alice" });
+    // The two records are tracked apart: Alice never won a game here, so she
+    // holds the lose streak record and no win streak award at all.
+    expect(achievementsOfType(tt, "alice", "longest-win-streak")).toHaveLength(0);
+  });
+
+  it("starts a new lose streak once a win breaks the old one", () => {
+    const tt = calculate([
+      ...losses("alice", ["bob", "carol"], 4),
+      ["alice", "bob"],
+      ...losses("alice", ["bob", "carol"], 5),
+    ]);
+
+    const awards = achievementsOfType(tt, "alice", "longest-lose-streak");
+    expect(awards).toHaveLength(2);
+    expect(awards[0].data).toStrictEqual({
+      streakLength: 4,
+      startedAt: playedAt(0),
+      previousRecord: undefined,
+    });
+    expect(awards[1].data).toStrictEqual({
+      streakLength: 5,
+      startedAt: playedAt(5),
+      previousRecord: 4,
+    });
+  });
+
+  it("reports the live streak, personal best and league record in the progression", () => {
+    const tt = calculate([
+      // Alice takes the record with 5, then loses, then wins 2.
+      ...wins("alice", ["bob", "carol"], 5),
+      ["bob", "alice"],
+      ...wins("alice", ["bob", "carol"], 2),
+    ]);
+
+    const aliceProgression = tt.achievements.getPlayerProgression("alice")["longest-win-streak"];
+    expect(aliceProgression.current).toBe(2);
+    expect(aliceProgression.personalBest).toBe(5);
+    expect(aliceProgression.target).toBe(5);
+    expect(aliceProgression.recordHolder).toBe("alice");
+    expect(aliceProgression.earned).toBe(1);
+
+    const bobProgression = tt.achievements.getPlayerProgression("bob")["longest-win-streak"];
+    expect(bobProgression.current).toBe(0);
+    expect(bobProgression.personalBest).toBe(1);
+    expect(bobProgression.target).toBe(5);
+    expect(bobProgression.recordHolder).toBe("alice");
+    expect(bobProgression.earned).toBe(0);
+  });
+
+  it("leaves the progression target unset until someone holds the record", () => {
+    const tt = calculate([
+      ["alice", "bob"],
+      ["alice", "carol"],
+    ]);
+
+    const progression = tt.achievements.getPlayerProgression("alice");
+    expect(progression["longest-win-streak"].target).toBeUndefined();
+    expect(progression["longest-win-streak"].recordHolder).toBeUndefined();
+    expect(progression["longest-win-streak"].current).toBe(2);
+    expect(progression["longest-win-streak"].personalBest).toBe(2);
+    expect(progression["longest-lose-streak"].target).toBeUndefined();
+    expect(progression["longest-lose-streak"].current).toBe(0);
+    expect(progression["longest-lose-streak"].personalBest).toBe(0);
+  });
+});

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -3,6 +3,11 @@ import { EventTypeEnum } from "./event-store/event-types";
 import { Game } from "./event-store/projectors/games-projector";
 import { TennisTable } from "./tennis-table";
 
+// Shortest streak that can establish the very first Longest Win / Lose Streak
+// record. Below this a run is too ordinary to be a record worth holding. Once
+// a record exists the floor is irrelevant — only beating the record counts.
+export const STREAK_RECORD_FLOOR = 3;
+
 export class Achievements {
   private parent: TennisTable;
   private hasCalculated = false;
@@ -47,6 +52,19 @@ export class Achievements {
   // prior record to break.
   earliestGameRecord: { minutesIntoDay: number | undefined } = { minutesIntoDay: undefined };
   latestGameRecord: { minutesIntoDay: number | undefined } = { minutesIntoDay: undefined };
+  // League-wide running records for the Longest Win Streak / Longest Lose
+  // Streak achievements: the longest run of consecutive wins / losses any
+  // player has put together to date. Undefined until a streak reaches
+  // STREAK_RECORD_FLOOR and establishes the first record. Used by the
+  // progression view so players can see the mark they need to beat.
+  winStreakRecord: { length: number | undefined; holder: string | undefined } = {
+    length: undefined,
+    holder: undefined,
+  };
+  loseStreakRecord: { length: number | undefined; holder: string | undefined } = {
+    length: undefined,
+    holder: undefined,
+  };
 
   constructor(parent: TennisTable) {
     this.parent = parent;
@@ -66,6 +84,8 @@ export class Achievements {
     this.bestRankJump.clear();
     this.earliestGameRecord = { minutesIntoDay: undefined };
     this.latestGameRecord = { minutesIntoDay: undefined };
+    this.winStreakRecord = { length: undefined, holder: undefined };
+    this.loseStreakRecord = { length: undefined, holder: undefined };
 
     const playerTracker = new Map<
       string,
@@ -77,6 +97,13 @@ export class Achievements {
         loseStreakAll: number;
         loseStreakAllStartedAt: number;
         winStreakPlayer: Map<string, { count: number; startedAt: number }>;
+        // The Longest Win / Lose Streak achievement earned by the streak
+        // that is running right now, while this player still holds the
+        // record with it — the one that grows as the streak grows. Cleared
+        // when the streak breaks, and left in place (but no longer grown)
+        // once another player takes the record over.
+        openWinStreakRecord: StreakRecordAchievement | undefined;
+        openLoseStreakRecord: StreakRecordAchievement | undefined;
         donutCount: number;
         closeCallsCount: number;
         edgeLordCount: number;
@@ -102,6 +129,8 @@ export class Achievements {
           loseStreakAll: 0,
           loseStreakAllStartedAt: game.playedAt,
           winStreakPlayer: new Map(),
+          openWinStreakRecord: undefined,
+          openLoseStreakRecord: undefined,
           donutCount: 0,
           closeCallsCount: 0,
           edgeLordCount: 0,
@@ -122,6 +151,8 @@ export class Achievements {
           loseStreakAll: 0,
           loseStreakAllStartedAt: game.playedAt,
           winStreakPlayer: new Map(),
+          openWinStreakRecord: undefined,
+          openLoseStreakRecord: undefined,
           donutCount: 0,
           closeCallsCount: 0,
           edgeLordCount: 0,
@@ -317,6 +348,17 @@ export class Achievements {
       }
       winner.winStreakAll++;
 
+      // Longest Win Streak: the league-wide record for consecutive wins.
+      winner.openWinStreakRecord = this.#checkStreakRecordAchievement(
+        "longest-win-streak",
+        this.winStreakRecord,
+        game.winner,
+        winner.winStreakAll,
+        winner.winStreakAllStartedAt,
+        game.playedAt,
+        winner.openWinStreakRecord,
+      );
+
       // Check if winner just broke a lose streak
       if (winner.loseStreakAll >= 20) {
         this.#addAchievement(
@@ -334,9 +376,11 @@ export class Achievements {
         );
       }
 
-      // Winner resets their lose streak
+      // Winner resets their lose streak. Any Longest Lose Streak award it
+      // earned stops growing here — a later losing run is a new streak.
       winner.loseStreakAll = 0;
       winner.loseStreakAllStartedAt = game.playedAt;
+      winner.openLoseStreakRecord = undefined;
 
       // Update player-specific win streak
       if (!winner.winStreakPlayer.has(game.loser)) {
@@ -361,17 +405,30 @@ export class Achievements {
         );
       }
 
-      // Update loser stats
+      // Update loser stats. Any Longest Win Streak award their broken streak
+      // earned stops growing here — a later winning run is a new streak.
       loser.lastActiveAt = game.playedAt;
       loser.winStreakAll = 0;
       loser.winStreakAllStartedAt = game.playedAt;
       loser.winStreakPlayer.set(game.winner, { count: 0, startedAt: game.playedAt });
+      loser.openWinStreakRecord = undefined;
 
       // Start or continue lose streak for loser
       if (loser.loseStreakAll === 0) {
         loser.loseStreakAllStartedAt = game.playedAt;
       }
       loser.loseStreakAll++;
+
+      // Longest Lose Streak: the league-wide record for consecutive losses.
+      loser.openLoseStreakRecord = this.#checkStreakRecordAchievement(
+        "longest-lose-streak",
+        this.loseStreakRecord,
+        game.loser,
+        loser.loseStreakAll,
+        loser.loseStreakAllStartedAt,
+        game.playedAt,
+        loser.openLoseStreakRecord,
+      );
 
       // Check for lose streak achievements for loser
       if (loser.loseStreakAll === 10) {
@@ -1553,6 +1610,60 @@ export class Achievements {
     }
   }
 
+  // Awards "Longest Win Streak" / "Longest Lose Streak" — the league-wide
+  // records for consecutive wins and consecutive losses. Called with the
+  // player's streak as it stands after the game just played.
+  //
+  // A streak takes the record the moment it passes the standing one (or
+  // reaches STREAK_RECORD_FLOOR, when nobody holds it yet). Extending that
+  // same streak while still holding the record does not award again — the
+  // achievement already earned grows with the streak instead, so an
+  // 11th straight win reads as one award worth 11 rather than two worth
+  // 10 and 11. Its `earnedAt` moves to the game that extended it, so the
+  // award always spans the whole of the record streak.
+  //
+  // Being overtaken mid-streak resets that: once another player holds the
+  // record, passing them again earns a second award, and the first keeps
+  // the length it had while it was the record. A streak that has been
+  // broken always earns its own award when it takes the record back.
+  //
+  // Returns the award this streak now owns, to be stored on the player's
+  // tracker and passed back in on their next game.
+  #checkStreakRecordAchievement(
+    type: "longest-win-streak" | "longest-lose-streak",
+    record: { length: number | undefined; holder: string | undefined },
+    playerId: string,
+    streakLength: number,
+    startedAt: number,
+    playedAt: number,
+    openRecord: StreakRecordAchievement | undefined,
+  ): StreakRecordAchievement | undefined {
+    const beatsRecord =
+      record.length === undefined ? streakLength >= STREAK_RECORD_FLOOR : streakLength > record.length;
+    if (!beatsRecord) {
+      return openRecord;
+    }
+
+    // Same streak, still the record holder: grow the award instead of
+    // handing out another one.
+    if (openRecord !== undefined && record.holder === playerId) {
+      openRecord.data.streakLength = streakLength;
+      openRecord.earnedAt = playedAt;
+      record.length = streakLength;
+      return openRecord;
+    }
+
+    const data = { streakLength, startedAt, previousRecord: record.length };
+    const achievement: StreakRecordAchievement =
+      type === "longest-win-streak"
+        ? this.#createAchievement("longest-win-streak", playerId, playedAt, data)
+        : this.#createAchievement("longest-lose-streak", playerId, playedAt, data);
+    this.#addAchievement(playerId, achievement);
+    record.length = streakLength;
+    record.holder = playerId;
+    return achievement;
+  }
+
   #checkBackAfterAchievement(playerId: string, lastActiveAt: number, currentGameAt: number) {
     const timeDiff = currentGameAt - lastActiveAt;
     const SIX_MONTHS = 6 * 30 * 24 * 60 * 60 * 1000;
@@ -1903,12 +2014,26 @@ export class Achievements {
       "perfect-day": { current: 0, target: 5, earned: 0 },
       "perfect-week": { current: 0, target: 5, earned: 0 },
       "streak-ender": { earned: 0 },
+      "longest-win-streak": {
+        earned: 0,
+        current: 0,
+        personalBest: 0,
+        target: this.winStreakRecord.length,
+        recordHolder: this.winStreakRecord.holder,
+      },
 
       // Resilience
       "punching-bag": { current: 0, target: 10, earned: 0 },
       "never-give-up": { current: 0, target: 20, earned: 0 },
       "comeback-kid": { earned: 0 },
       "unbreakable-spirit": { earned: 0 },
+      "longest-lose-streak": {
+        earned: 0,
+        current: 0,
+        personalBest: 0,
+        target: this.loseStreakRecord.length,
+        recordHolder: this.loseStreakRecord.holder,
+      },
 
       // Rank & Score
       "on-the-podium": { earned: 0 },
@@ -1979,6 +2104,10 @@ export class Achievements {
     let gamesPlayedCount = 0;
     let currentWinStreakAll = 0;
     let currentLoseStreakAll = 0;
+    // Longest runs the player has ever put together, which may be longer than
+    // the streak they are on now. Shown alongside the league streak records.
+    let longestWinStreakAll = 0;
+    let longestLoseStreakAll = 0;
     let donutCount = 0;
     let closeCallsCount = 0;
     let edgeLordCount = 0;
@@ -2106,6 +2235,7 @@ export class Achievements {
         // Track win streak against all
         currentWinStreakAll++;
         currentLoseStreakAll = 0;
+        longestWinStreakAll = Math.max(longestWinStreakAll, currentWinStreakAll);
 
         // Track win streak against specific opponent
         streaksPerOpponent.set(opponent, (streaksPerOpponent.get(opponent) || 0) + 1);
@@ -2122,6 +2252,7 @@ export class Achievements {
         // Lost a game - reset win streak and increment lose streak
         currentWinStreakAll = 0;
         currentLoseStreakAll++;
+        longestLoseStreakAll = Math.max(longestLoseStreakAll, currentLoseStreakAll);
 
         // Reset streak against this specific opponent
         if (isLoser) {
@@ -2178,6 +2309,14 @@ export class Achievements {
     progression["global-player"].opponents = opponentsPlayed;
     progression["punching-bag"].current = currentLoseStreakAll;
     progression["never-give-up"].current = currentLoseStreakAll;
+
+    // Longest Win / Lose Streak: the live streak is what can still grow into
+    // the league record, so that is the progress. The player's longest ever
+    // run is reported alongside it.
+    progression["longest-win-streak"].current = currentWinStreakAll;
+    progression["longest-win-streak"].personalBest = longestWinStreakAll;
+    progression["longest-lose-streak"].current = currentLoseStreakAll;
+    progression["longest-lose-streak"].personalBest = longestLoseStreakAll;
 
     // Perfect Day progression tracks TODAY's live attempt: the number of
     // games won today with zero losses so far. A single loss today nullifies
@@ -2467,6 +2606,13 @@ export class Achievements {
 }
 
 // Type Definitions
+type StreakRecordAchievementData = {
+  streakLength: number;
+  startedAt: number;
+  // Undefined when this streak is the first to establish the league record.
+  previousRecord?: number;
+};
+
 type AchievementDefinitions = {
   "first-game": { gameId: string; opponent: string };
   "ranked": { gameId: string; opponent: string };
@@ -2537,6 +2683,12 @@ type AchievementDefinitions = {
     previousRecord?: number;
   };
   "streak-ender": { opponent: string; gameId: string; streakLength: number };
+  // Record-breaking streak achievements. `streakLength` is how long the
+  // streak was when it last held the league record — it grows while the
+  // streak keeps extending the record — and `startedAt` is the first game
+  // of the streak, so startedAt → earnedAt spans the record run.
+  "longest-win-streak": StreakRecordAchievementData;
+  "longest-lose-streak": StreakRecordAchievementData;
   "group-stage-star": { tournamentId: string; wins: number };
   "full-house": { count: number; firstGameAt: number };
   "humbled": { count: number; firstGameAt: number };
@@ -2560,6 +2712,13 @@ type GenericAchievement<T extends AchievementType = AchievementType> = {
 export type Achievement = {
   [K in AchievementType]: GenericAchievement<K>;
 }[AchievementType];
+
+// The award for holding a streak record — either direction. The two share a
+// data shape, so the code that grows one as the streak grows can treat them
+// interchangeably.
+type StreakRecordAchievement =
+  | GenericAchievement<"longest-win-streak">
+  | GenericAchievement<"longest-lose-streak">;
 
 // Progression Types
 type BaseProgression = {
@@ -2627,6 +2786,22 @@ type MarathonSetProgression = BaseProgression & {
   recordHolder?: string;
 };
 
+type StreakRecordProgression = BaseProgression & {
+  // The player's streak as it stands right now (0 if their last game went
+  // the other way). Only a live streak can grow into the record, so this is
+  // what the progress bar measures.
+  current: number;
+  // The league record — the streak this player must strictly exceed to take
+  // it. Undefined while nobody holds it (a streak of STREAK_RECORD_FLOOR
+  // takes it outright).
+  target?: number;
+  // Player who currently holds the league record, if any.
+  recordHolder?: string;
+  // The player's own longest streak ever, which may be longer than the one
+  // they are on now. Shown so they can see how their best compares.
+  personalBest: number;
+};
+
 // Earliest / Latest Game are record-breaking achievements with no numeric
 // progress bar — you either hold the record or you don't. Instead of a
 // percentage, the progress view shows the current league record and the
@@ -2685,6 +2860,8 @@ export type AchievementProgression = {
   "climber": ProgressionWithTarget;
   "marathon-set": MarathonSetProgression;
   "streak-ender": BaseProgression;
+  "longest-win-streak": StreakRecordProgression;
+  "longest-lose-streak": StreakRecordProgression;
   "group-stage-star": BaseProgression;
   "full-house": MissingPlayersProgression;
   "humbled": MissingPlayersProgression;

--- a/frontend/src/pages/achievements/achievements-list.tsx
+++ b/frontend/src/pages/achievements/achievements-list.tsx
@@ -210,6 +210,17 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                       Ended {achievement.data.streakLength}-game streak
                     </span>
                   )}
+                  {(achievement.type === "longest-win-streak" ||
+                    achievement.type === "longest-lose-streak") &&
+                    achievement.data && (
+                      <span className="text-[11px] opacity-80">
+                        {achievement.data.streakLength}{" "}
+                        {achievement.type === "longest-win-streak" ? "wins" : "losses"} in a row
+                        {achievement.data.previousRecord !== undefined
+                          ? ` (prev record ${achievement.data.previousRecord})`
+                          : " (first league record!)"}
+                      </span>
+                    )}
                   {achievement.type === "perfect-day" && achievement.data && (
                     <span className="text-[11px] opacity-80">
                       {achievement.data.wins} wins, 0 losses

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -2,7 +2,7 @@ import { useEventDbContext } from "../../wrappers/event-db-context";
 import { relativeTimeString } from "../../common/date-utils";
 import { classNames } from "../../common/class-names";
 import { useState } from "react";
-import { Achievement, AchievementProgression } from "../../client/client-db/achievements";
+import { Achievement, AchievementProgression, STREAK_RECORD_FLOOR } from "../../client/client-db/achievements";
 import { Link } from "react-router-dom";
 import { fmtNum } from "../../common/number-utils";
 import { usePlayerLinkSearch } from "../../hooks/use-player-link-search";
@@ -50,6 +50,11 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
     description: "Won 20 games in a row against the same opponent",
     icon: "👹",
   },
+  "longest-win-streak": {
+    title: "Longest Win Streak",
+    description: "Put together the longest run of consecutive wins in league history",
+    icon: "🌋",
+  },
   "punching-bag": {
     title: "Punching Bag",
     description: "Lose 10 games in a row",
@@ -59,6 +64,11 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
     title: "Never Give Up",
     description: "Lose 20 games in a row",
     icon: "🫠",
+  },
+  "longest-lose-streak": {
+    title: "Longest Lose Streak",
+    description: "Suffer the longest run of consecutive losses in league history",
+    icon: "🕳️",
   },
   "comeback-kid": {
     title: "Comeback Kid",
@@ -512,6 +522,17 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
                   </p>
                 )}
 
+                {(achievement.type === "longest-win-streak" || achievement.type === "longest-lose-streak") &&
+                  achievement.data && (
+                    <p className="text-xs text-secondary-text/70 mt-2">
+                      {achievement.data.streakLength}{" "}
+                      {achievement.type === "longest-win-streak" ? "wins" : "losses"} in a row
+                      {achievement.data.previousRecord !== undefined
+                        ? ` (previous record: ${achievement.data.previousRecord})`
+                        : " (first league record!)"}
+                    </p>
+                  )}
+
                 {achievement.type === "perfect-day" && achievement.data && (
                   <p className="text-xs text-secondary-text/70 mt-2">
                     {achievement.data.wins} wins, 0 losses on {dateString(achievement.data.day)}
@@ -859,6 +880,41 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                           )}
                         </div>
                       )}
+
+                      {/* Record holder and personal best for the streak records.
+                          The bar tracks the live streak, so the player's longest
+                          ever run is spelt out separately. */}
+                      {(type === "longest-win-streak" || type === "longest-lose-streak") &&
+                        "recordHolder" in data && (
+                          <div className="mt-2 text-xs text-secondary-text/70 space-y-1">
+                            {"personalBest" in data && (
+                              <p>
+                                Your longest ever: {data.personalBest}{" "}
+                                {type === "longest-win-streak" ? "wins" : "losses"} in a row
+                              </p>
+                            )}
+                            <p>
+                              {data.recordHolder ? (
+                                <>
+                                  League record held by{" "}
+                                  <Link to={{ pathname: "/player/" + data.recordHolder, search }}>
+                                    <span className="text-secondary-text underline">
+                                      {context.playerName(data.recordHolder)}
+                                    </span>
+                                  </Link>
+                                  . {type === "longest-win-streak" ? "Win" : "Lose"} {(data.target ?? 0) + 1} in a
+                                  row to take it.
+                                </>
+                              ) : (
+                                <>
+                                  No record set yet —{" "}
+                                  {type === "longest-win-streak" ? "win" : "lose"} {STREAK_RECORD_FLOOR} in a row to
+                                  start the record.
+                                </>
+                              )}
+                            </p>
+                          </div>
+                        )}
                     </>
                   ) : type === "marathon-set" ? (
                     <div className="mt-2 text-xs text-secondary-text/70">
@@ -867,6 +923,11 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                   ) : type === "leap-frog" ? (
                     <div className="mt-2 text-xs text-secondary-text/70">
                       No league record yet — jump 2 or more ranks in a single game to set the first record.
+                    </div>
+                  ) : type === "longest-win-streak" || type === "longest-lose-streak" ? (
+                    <div className="mt-2 text-xs text-secondary-text/70">
+                      No league record yet — {type === "longest-win-streak" ? "win" : "lose"}{" "}
+                      {STREAK_RECORD_FLOOR} in a row to set the first record.
                     </div>
                   ) : type === "earliest-game" || type === "latest-game" ? (
                     <div className="mt-2 text-xs text-secondary-text/70 space-y-1">


### PR DESCRIPTION
Two league-wide record achievements: the longest run of consecutive wins
and the longest run of consecutive losses.

A streak takes the record when it passes the standing one, or reaches 3
when nobody holds it. Extending the same streak while still holding the
record grows the award already earned rather than handing out another, so
an 11th straight win is one award worth 11 and not two worth 10 and 11.
Being overtaken mid-streak resets that: passing the new holder earns a
second award, and the first keeps the length it had while it was the
record. A broken streak always earns its own award.

The progress view measures the live streak, since only a live streak can
grow into the record, and reports the player's longest run alongside it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018yL6x6ZraXx3xGbFTh7axt