### PR TITLE
Link New connections entries back to their source games

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -31,6 +31,25 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "new-connections-view-match",
+    title: "Follow a New connections entry back to the match",
+    date: "2026-07-31",
+    tags: ["feature-update"],
+    summary:
+      "Every entry in the New connections widget links to the game behind it, and First tournament now counts everyone whose first tournament it was, debuts included.",
+    body: [
+      text(
+        "Every entry in New connections carries a View match button. It opens the tab the game is on - group play, either bracket, or the grand final - scrolls that game's card into view and wiggles it. A pair points at the game they first met over, a player at their first game of the tournament.",
+      ),
+      text(
+        "First tournament now lists everyone this was a first tournament for. That includes players making their club debut and players back from a long break, both of which it used to leave out to stop the lists repeating each other. The count read lower than the number of people it was true of, so if you read a debut as someone who had been to a tournament before, that is why. A player can now turn up in two lists, which is the honest answer to each.",
+      ),
+      text(
+        "The lists run in two columns from tablet width up. One column left most of the width empty, and these entries are short.",
+      ),
+    ],
+  },
+  {
     slug: "win-chance-predictions-for-unranked-and-retired-players",
     title: "Win chance predictions for unranked and retired players on Compare 1v1",
     date: "2026-07-31",

--- a/frontend/src/client/client-db/__tests__/tournaments/tournament-connections.test.ts
+++ b/frontend/src/client/client-db/__tests__/tournaments/tournament-connections.test.ts
@@ -221,8 +221,8 @@ describe("Tournament connections", () => {
     expect(debut.lastPlayedAt).toBeUndefined();
     expect(debut.awayFor).toBeUndefined();
     expect(debut.gamesInTournament).toBe(1);
-    // A debut already says it was their first tournament
-    expect(debut.firstTournament).toBe(false);
+    // A debut is a first tournament too, so they show up in both lists
+    expect(debut.firstTournament).toBe(true);
 
     expect(arrival(result, "P1").debut).toBe(false);
     // Debuts are listed first
@@ -296,5 +296,50 @@ describe("Tournament connections", () => {
     expect(arrival(result, "P6").firstTournament).toBe(true);
     // P1 and P2 played the earlier tournament, and nothing else about them is new
     expect(result.arrivals.map((candidate) => candidate.playerId).sort()).toEqual(["P5", "P6"]);
+  });
+
+  it("points every pair and every player at the game they turned up in", () => {
+    const result = connections([
+      ...baseEvents(["P1", "P2", "P3", "P4"], { doubleElimination: true }, ["H1"]),
+      ...recentHistory,
+      gameEvent("P1", "P4", day(1)), // Winners semifinal
+      gameEvent("P2", "P3", day(2)), // Winners semifinal
+      gameEvent("P4", "P3", day(3)), // Losers round 1
+      gameEvent("P1", "P2", day(4)), // Winners final
+      gameEvent("P2", "P4", day(5)), // Losers final
+      gameEvent("P1", "P2", day(6)), // Grand final
+    ])!;
+
+    // The players read in the order the bracket stores them, not the order they won in
+    const semifinal = pair(result, "P1", "P4").firstGame;
+    expect(semifinal.where).toBe("bracket");
+    expect(semifinal.section).toBe("winners");
+    expect([semifinal.player1, semifinal.player2].sort()).toEqual(["P1", "P4"]);
+
+    expect(pair(result, "P3", "P4").firstGame.section).toBe("losers");
+
+    // P1 and P2 met twice. The first of the two is the winners final, not the grand final
+    expect(pair(result, "P1", "P2").firstGame.section).toBe("winners");
+  });
+
+  it("points a debut at their very first game of the tournament", () => {
+    const result = connections([
+      ...baseEvents(["P1", "P2", "P3", "P4"], undefined, ["H1"]),
+      // P4 is left out of the history: the tournament is their first ever game
+      gameEvent("P1", "H1", before(5)),
+      gameEvent("P2", "H1", before(6)),
+      gameEvent("P3", "H1", before(7)),
+      ...bracketGames,
+    ])!;
+
+    const firstGame = arrival(result, "P4").firstGame;
+    expect(firstGame.where).toBe("bracket");
+    expect([firstGame.player1, firstGame.player2].sort()).toEqual(["P1", "P4"]);
+
+    // P1 played the semifinal before the final, so that is the game they are pointed at
+    expect([arrival(result, "P1").firstGame.player1, arrival(result, "P1").firstGame.player2].sort()).toEqual([
+      "P1",
+      "P4",
+    ]);
   });
 });

--- a/frontend/src/client/client-db/tournaments/tournament-connections.ts
+++ b/frontend/src/client/client-db/tournaments/tournament-connections.ts
@@ -1,6 +1,6 @@
 import { ONE_MONTH } from "../../../common/time-in-ms";
 import { TennisTable } from "../tennis-table";
-import { Tournament, TournamentGame } from "./tournament";
+import { Tournament, TournamentBracketSection, TournamentGame } from "./tournament";
 
 /**
  * What a tournament does to the club beyond crowning a winner: it puts people in front of each
@@ -22,6 +22,18 @@ export type PairKind =
   /** They play each other regularly enough that the tournament brought them nothing new */
   | "regular";
 
+/**
+ * Enough to point at a game's card on the tournament page. The players are kept in the order the
+ * game itself stores them, since that is what the page's deep link matches on
+ */
+export type GameLocation = {
+  player1: string;
+  player2: string;
+  where: "group" | "bracket";
+  /** Which bracket the game belongs to. Undefined for group play and single elimination */
+  section?: TournamentBracketSection;
+};
+
 export type PairMeeting = {
   /** Stable identity, used as the react key */
   key: string;
@@ -32,6 +44,8 @@ export type PairMeeting = {
   gamesInTournament: number;
   /** When they first met in the tournament */
   firstMetAt: number;
+  /** The game they first met over, so the pair can be followed back to the bracket or group */
+  firstGame: GameLocation;
   /** Games between the two before the tournament started */
   gamesBefore: number;
   /** Their most recent game before the tournament. Undefined when they had never met */
@@ -47,11 +61,13 @@ export type PlayerArrival = {
   /** They had played before, but not within LONG_ABSENCE of the tournament start */
   returning: boolean;
   /**
-   * They had played before but never in a tournament. Always false for a debut, where it would
-   * only repeat what `debut` already says
+   * This was their first tournament. True for a debut too - the sections answer different questions,
+   * and a player showing up in both is the honest answer to each
    */
   firstTournament: boolean;
   gamesInTournament: number;
+  /** Their first game of the tournament, so they can be followed back to the bracket or group */
+  firstGame: GameLocation;
   /** Their most recent game before the tournament. Undefined for a debut */
   lastPlayedAt?: number;
   /** How long they had been away when the tournament started. Undefined for a debut */
@@ -80,7 +96,7 @@ export type TournamentConnections = {
   gamesPlayed: number;
 };
 
-type PlayedGame = { player1: string; player2: string; completedAt: number };
+type PlayedGame = GameLocation & { completedAt: number };
 
 type History = { games: number; firstPlayedAt: number; lastPlayedAt: number };
 
@@ -94,14 +110,24 @@ function pairKey(player1: string, player2: string): string {
  */
 function playedGames(tournament: Tournament): PlayedGame[] {
   const games: PlayedGame[] = [];
-  const add = (game: Partial<TournamentGame>) => {
+  const add = (where: PlayedGame["where"]) => (game: Partial<TournamentGame>) => {
     if (game.skipped !== undefined) return;
     if (game.player1 === undefined || game.player2 === undefined || game.completedAt === undefined) return;
-    games.push({ player1: game.player1, player2: game.player2, completedAt: game.completedAt });
+    games.push({
+      player1: game.player1,
+      player2: game.player2,
+      completedAt: game.completedAt,
+      where,
+      section: game.section,
+    });
   };
-  tournament.groupPlay?.groups.forEach((group) => group.played.forEach(add));
-  tournament.bracket?.getCompletedGames().forEach(add);
+  tournament.groupPlay?.groups.forEach((group) => group.played.forEach(add("group")));
+  tournament.bracket?.getCompletedGames().forEach(add("bracket"));
   return games.sort((a, b) => a.completedAt - b.completedAt);
+}
+
+function gameLocation(game: PlayedGame): GameLocation {
+  return { player1: game.player1, player2: game.player2, where: game.where, section: game.section };
 }
 
 /** Everyone who played a game in a tournament that had already started before this one */
@@ -156,22 +182,30 @@ export function buildTournamentConnections(
 
   // ---- Pairs ----
 
-  type Met = { players: [string, string]; games: number; firstMetAt: number };
+  type Met = { players: [string, string]; games: number; firstMetAt: number; firstGame: GameLocation };
   const met = new Map<string, Met>();
-  const participants = new Map<string, number>();
+  type Participation = { games: number; firstGame: GameLocation };
+  const participants = new Map<string, Participation>();
 
+  // The games arrive oldest first, so the first one a pair or a player turns up in is their first
   for (const game of games) {
     const key = pairKey(game.player1, game.player2);
     const found = met.get(key);
     if (found === undefined) {
       // Sorted so the pair reads the same however the games went
       const players = [game.player1, game.player2].sort() as [string, string];
-      met.set(key, { players, games: 1, firstMetAt: game.completedAt });
+      met.set(key, { players, games: 1, firstMetAt: game.completedAt, firstGame: gameLocation(game) });
     } else {
       found.games++;
     }
-    participants.set(game.player1, (participants.get(game.player1) ?? 0) + 1);
-    participants.set(game.player2, (participants.get(game.player2) ?? 0) + 1);
+    for (const playerId of [game.player1, game.player2]) {
+      const participation = participants.get(playerId);
+      if (participation === undefined) {
+        participants.set(playerId, { games: 1, firstGame: gameLocation(game) });
+      } else {
+        participation.games++;
+      }
+    }
   }
 
   const pairs: PairMeeting[] = Array.from(met, ([key, pair]) => {
@@ -184,6 +218,7 @@ export function buildTournamentConnections(
       kind,
       gamesInTournament: pair.games,
       firstMetAt: pair.firstMetAt,
+      firstGame: pair.firstGame,
       gamesBefore: before?.games ?? 0,
       lastMetAt: before?.lastPlayedAt,
       gap,
@@ -206,18 +241,19 @@ export function buildTournamentConnections(
   const earlierTournamentPlayers = playersOfEarlierTournaments(tournament, context);
 
   const arrivals: PlayerArrival[] = [];
-  for (const [playerId, gamesInTournament] of participants) {
+  for (const [playerId, participation] of participants) {
     const before = history.players.get(playerId);
     const debut = before === undefined;
     const returning = before !== undefined && baseline - before.lastPlayedAt >= LONG_ABSENCE;
-    const firstTournament = !debut && !earlierTournamentPlayers.has(playerId);
+    const firstTournament = !earlierTournamentPlayers.has(playerId);
     if (!debut && !returning && !firstTournament) continue; // The tournament was business as usual for them
     arrivals.push({
       playerId,
       debut,
       returning,
       firstTournament,
-      gamesInTournament,
+      gamesInTournament: participation.games,
+      firstGame: participation.firstGame,
       lastPlayedAt: before?.lastPlayedAt,
       awayFor: before === undefined ? undefined : baseline - before.lastPlayedAt,
     });

--- a/frontend/src/pages/tournament/stats/connections-widget.tsx
+++ b/frontend/src/pages/tournament/stats/connections-widget.tsx
@@ -7,7 +7,6 @@ import {
   PlayerArrival,
 } from "../../../client/client-db/tournaments/tournament-connections";
 import { Tournament } from "../../../client/client-db/tournaments/tournament";
-import { classNames } from "../../../common/class-names";
 import { fmtNum } from "../../../common/number-utils";
 import { ONE_DAY, ONE_MONTH, ONE_YEAR } from "../../../common/time-in-ms";
 import { useEventDbContext } from "../../../wrappers/event-db-context";
@@ -44,15 +43,6 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
         {fmtNum(playersPlayed)} players · {fmtNum(gamesPlayed)} games · {fmtNum(pairs.length)} pairings
       </Header>
 
-      {/* Pairs first, then players, in the same order as the sections below */}
-      <div className="grid grid-cols-2 md:grid-cols-5 gap-2 mb-6">
-        <Tile value={firstMeetings.length} label="First-ever meetings" of={pairs.length} />
-        <Tile value={reunions.length} label="Reunions" of={pairs.length} />
-        <Tile value={debuts.length} label="First games ever" of={playersPlayed} />
-        <Tile value={returning.length} label="Back after a break" of={playersPlayed} />
-        <Tile value={firstTimers.length} label="First tournament" of={playersPlayed} />
-      </div>
-
       {nothingNew && (
         <p className="text-sm font-light mb-6">
           Everyone here already plays each other regularly.
@@ -68,7 +58,7 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
       )}
 
       {firstMeetings.length > 0 && (
-        <Section title="First-ever meetings">
+        <Section title="First-ever meetings" count={firstMeetings.length}>
           {firstMeetings.map((pair) => (
             <PairRow key={pair.key} pair={pair} tournamentId={tournament.id} />
           ))}
@@ -76,7 +66,7 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
       )}
 
       {reunions.length > 0 && (
-        <Section title="Reunions">
+        <Section title="Reunions" count={reunions.length}>
           {reunions.map((pair) => (
             <PairRow key={pair.key} pair={pair} tournamentId={tournament.id}>
               First meeting in <span className="font-medium">{formatGap(pair.gap ?? 0)}</span>
@@ -86,7 +76,7 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
       )}
 
       {debuts.length > 0 && (
-        <Section title="First game ever">
+        <Section title="First game ever" count={debuts.length}>
           {debuts.map((arrival) => (
             <PlayerRow key={arrival.playerId} arrival={arrival} tournamentId={tournament.id} />
           ))}
@@ -94,7 +84,7 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
       )}
 
       {returning.length > 0 && (
-        <Section title="Back after a break">
+        <Section title="Back after a break" count={returning.length}>
           {returning.map((arrival) => (
             <PlayerRow key={arrival.playerId} arrival={arrival} tournamentId={tournament.id}>
               Away for <span className="font-medium">{formatGap(arrival.awayFor ?? 0)}</span>
@@ -104,7 +94,7 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
       )}
 
       {firstTimers.length > 0 && (
-        <Section title="First tournament">
+        <Section title="First tournament" count={firstTimers.length}>
           {firstTimers.map((arrival) => (
             <PlayerRow key={arrival.playerId} arrival={arrival} tournamentId={tournament.id} />
           ))}
@@ -127,30 +117,23 @@ const Header: React.FC<{ children?: React.ReactNode }> = ({ children }) => (
   </div>
 );
 
-const Tile: React.FC<{ value: number; label: string; of: number }> = ({ value, label, of }) => (
-  <div
-    className={classNames(
-      "rounded-lg px-3 py-2 ring-1 ring-secondary-background",
-      value === 0 && "opacity-50",
-    )}
-  >
-    <p className="text-2xl font-bold leading-tight">{fmtNum(value)}</p>
-    <p className="text-xs font-light leading-tight">{label}</p>
-    <p className="text-[0.65rem] font-light mt-1">of {fmtNum(of)}</p>
-  </div>
-);
-
 /** Two columns from tablet up: the entries are short, and one column left most of the width empty */
-const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
+const Section: React.FC<{ title: string; count: number; children: React.ReactNode }> = ({
+  title,
+  count,
+  children,
+}) => (
   <div className="mb-6">
-    <h3 className="text-sm font-semibold mb-2">{title}</h3>
+    <h3 className="text-sm font-semibold mb-2">
+      {title} <span className="font-thin italic">({fmtNum(count)})</span>
+    </h3>
     <div className="grid gap-1 md:grid-cols-2">{children}</div>
   </div>
 );
 
 /** min-w-0 keeps the card inside its grid column, so long names truncate instead of pushing it wider */
 const EntryCard: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-  <div className="flex min-w-0 items-center gap-3 rounded-lg px-3 py-2 ring-1 ring-secondary-background">
+  <div className="flex min-w-0 items-center gap-3 rounded-lg px-3 py-2 bg-secondary-background text-secondary-text">
     {children}
   </div>
 );
@@ -213,7 +196,7 @@ const PlayerRow: React.FC<{ arrival: PlayerArrival; tournamentId: string; childr
 const ViewMatch: React.FC<{ tournamentId: string; game: GameLocation }> = ({ tournamentId, game }) => (
   <Link
     to={gameLink(tournamentId, game)}
-    className="shrink-0 rounded-md px-2 py-1 text-xs font-light whitespace-nowrap ring-1 ring-secondary-background hover:bg-secondary-background hover:text-secondary-text transition-colors"
+    className="shrink-0 rounded-md px-2 py-1 text-xs font-light whitespace-nowrap bg-tertiary-background text-tertiary-text hover:opacity-80 transition-opacity"
   >
     View match
   </Link>

--- a/frontend/src/pages/tournament/stats/connections-widget.tsx
+++ b/frontend/src/pages/tournament/stats/connections-widget.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import { Link } from "react-router-dom";
 import {
   buildTournamentConnections,
+  GameLocation,
   PairMeeting,
   PlayerArrival,
 } from "../../../client/client-db/tournaments/tournament-connections";
@@ -30,9 +31,11 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
   }
 
   const { firstMeetings, reunions, longestGap, arrivals, pairs, playersPlayed, gamesPlayed } = connections;
+  // The three player lists answer different questions, so the same player can turn up in more than
+  // one of them: a debut is also a first tournament, and so is a return from a long break
   const debuts = arrivals.filter((arrival) => arrival.debut);
   const returning = arrivals.filter((arrival) => arrival.returning);
-  const firstTimers = arrivals.filter((arrival) => arrival.firstTournament && !arrival.returning);
+  const firstTimers = arrivals.filter((arrival) => arrival.firstTournament);
   const nothingNew = firstMeetings.length === 0 && reunions.length === 0 && arrivals.length === 0;
 
   return (
@@ -67,7 +70,7 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
       {firstMeetings.length > 0 && (
         <Section title="First-ever meetings">
           {firstMeetings.map((pair) => (
-            <PairRow key={pair.key} pair={pair} />
+            <PairRow key={pair.key} pair={pair} tournamentId={tournament.id} />
           ))}
         </Section>
       )}
@@ -75,7 +78,7 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
       {reunions.length > 0 && (
         <Section title="Reunions">
           {reunions.map((pair) => (
-            <PairRow key={pair.key} pair={pair}>
+            <PairRow key={pair.key} pair={pair} tournamentId={tournament.id}>
               First meeting in <span className="font-medium">{formatGap(pair.gap ?? 0)}</span>
             </PairRow>
           ))}
@@ -85,7 +88,7 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
       {debuts.length > 0 && (
         <Section title="First game ever">
           {debuts.map((arrival) => (
-            <PlayerRow key={arrival.playerId} arrival={arrival} />
+            <PlayerRow key={arrival.playerId} arrival={arrival} tournamentId={tournament.id} />
           ))}
         </Section>
       )}
@@ -93,7 +96,7 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
       {returning.length > 0 && (
         <Section title="Back after a break">
           {returning.map((arrival) => (
-            <PlayerRow key={arrival.playerId} arrival={arrival}>
+            <PlayerRow key={arrival.playerId} arrival={arrival} tournamentId={tournament.id}>
               Away for <span className="font-medium">{formatGap(arrival.awayFor ?? 0)}</span>
             </PlayerRow>
           ))}
@@ -103,7 +106,7 @@ export const TournamentConnectionsWidget: React.FC<{ tournament: Tournament }> =
       {firstTimers.length > 0 && (
         <Section title="First tournament">
           {firstTimers.map((arrival) => (
-            <PlayerRow key={arrival.playerId} arrival={arrival} />
+            <PlayerRow key={arrival.playerId} arrival={arrival} tournamentId={tournament.id} />
           ))}
         </Section>
       )}
@@ -137,16 +140,29 @@ const Tile: React.FC<{ value: number; label: string; of: number }> = ({ value, l
   </div>
 );
 
+/** Two columns from tablet up: the entries are short, and one column left most of the width empty */
 const Section: React.FC<{ title: string; children: React.ReactNode }> = ({ title, children }) => (
   <div className="mb-6">
     <h3 className="text-sm font-semibold mb-2">{title}</h3>
-    <div className="space-y-1">{children}</div>
+    <div className="grid gap-1 md:grid-cols-2">{children}</div>
   </div>
 );
 
-const PairRow: React.FC<{ pair: PairMeeting; children?: React.ReactNode }> = ({ pair, children }) => {
+/** min-w-0 keeps the card inside its grid column, so long names truncate instead of pushing it wider */
+const EntryCard: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="flex min-w-0 items-center gap-3 rounded-lg px-3 py-2 ring-1 ring-secondary-background">
+    {children}
+  </div>
+);
+
+const PairRow: React.FC<{ pair: PairMeeting; tournamentId: string; children?: React.ReactNode }> = ({
+  pair,
+  tournamentId,
+  children,
+}) => {
+  const metAgain = pair.gamesInTournament > 1;
   return (
-    <div className="flex items-center gap-3 rounded-lg px-3 py-2 ring-1 ring-secondary-background">
+    <EntryCard>
       <div className="flex -space-x-2 shrink-0">
         <ProfilePicture playerId={pair.players[0]} size={28} border={2} linkToPlayer />
         <ProfilePicture playerId={pair.players[1]} size={28} border={2} linkToPlayer />
@@ -156,20 +172,26 @@ const PairRow: React.FC<{ pair: PairMeeting; children?: React.ReactNode }> = ({ 
           <PlayerLink playerId={pair.players[0]} /> <span className="font-light">vs</span>{" "}
           <PlayerLink playerId={pair.players[1]} />
         </p>
-        {children && <p className="text-xs font-light">{children}</p>}
+        {(children || metAgain) && (
+          <p className="text-xs font-light truncate">
+            {children}
+            {children && metAgain && " · "}
+            {metAgain && `met ${fmtNum(pair.gamesInTournament)}×`}
+          </p>
+        )}
       </div>
-      {pair.gamesInTournament > 1 && (
-        <p className="shrink-0 text-xs font-light" title={`They met ${pair.gamesInTournament} times in this tournament`}>
-          met {fmtNum(pair.gamesInTournament)}×
-        </p>
-      )}
-    </div>
+      <ViewMatch tournamentId={tournamentId} game={pair.firstGame} />
+    </EntryCard>
   );
 };
 
-const PlayerRow: React.FC<{ arrival: PlayerArrival; children?: React.ReactNode }> = ({ arrival, children }) => {
+const PlayerRow: React.FC<{ arrival: PlayerArrival; tournamentId: string; children?: React.ReactNode }> = ({
+  arrival,
+  tournamentId,
+  children,
+}) => {
   return (
-    <div className="flex items-center gap-3 rounded-lg px-3 py-2 ring-1 ring-secondary-background">
+    <EntryCard>
       <div className="shrink-0">
         <ProfilePicture playerId={arrival.playerId} size={28} border={2} linkToPlayer />
       </div>
@@ -177,11 +199,42 @@ const PlayerRow: React.FC<{ arrival: PlayerArrival; children?: React.ReactNode }
         <p className="text-sm truncate">
           <PlayerLink playerId={arrival.playerId} />
         </p>
-        {children && <p className="text-xs font-light">{children}</p>}
+        {children && <p className="text-xs font-light truncate">{children}</p>}
       </div>
-    </div>
+      <ViewMatch tournamentId={tournamentId} game={arrival.firstGame} />
+    </EntryCard>
   );
 };
+
+/**
+ * Every entry in every section came out of a game, so every entry can be followed back to it. The
+ * tournament page scrolls the game's card into view and wiggles it once it is there
+ */
+const ViewMatch: React.FC<{ tournamentId: string; game: GameLocation }> = ({ tournamentId, game }) => (
+  <Link
+    to={gameLink(tournamentId, game)}
+    className="shrink-0 rounded-md px-2 py-1 text-xs font-light whitespace-nowrap ring-1 ring-secondary-background hover:bg-secondary-background hover:text-secondary-text transition-colors"
+  >
+    View match
+  </Link>
+);
+
+/** The tab has to come along, or the link would land on whichever tab the reader is already on */
+function gameLink(tournamentId: string, game: GameLocation): string {
+  const tab = (() => {
+    if (game.where === "group") return "group-play";
+    if (game.section === "losers") return "losers";
+    if (game.section === "grandFinal" || game.section === "bracketReset") return "grand-final";
+    return "finals";
+  })();
+  const params = new URLSearchParams({
+    tournament: tournamentId,
+    player1: game.player1,
+    player2: game.player2,
+    tab,
+  });
+  return `/tournament?${params.toString()}`;
+}
 
 const PlayerLink: React.FC<{ playerId: string }> = ({ playerId }) => {
   const context = useEventDbContext();


### PR DESCRIPTION
## Summary
Every entry in the New connections widget now links to the game it came from, with a "View match" button that opens the appropriate tournament tab and highlights the game. Additionally, the "First tournament" section now correctly includes all players for whom it was their first tournament, including debuts and returning players.

## Changes

- **Added game location tracking:** Introduced `GameLocation` type to capture which game (group play or bracket section) each pair first met in and each player first played in
- **Updated data structures:** `PairMeeting` and `PlayerArrival` now include `firstGame` field pointing to their source game
- **Added View match links:** New `ViewMatch` component and `gameLink()` function generate deep links to games with the correct tournament tab (group-play, losers, grand-final, or finals)
- **Fixed First tournament logic:** Removed the `!arrival.returning` filter so debuts and returning players are now correctly included in the "First tournament" list, since a debut is also a first tournament
- **Improved layout:** Wrapped entry cards in a new `EntryCard` component and updated `Section` to use a two-column grid on tablet and up, with proper text truncation
- **Added changelog post:** Documented the new feature and behavior change

## Implementation Details

- Games are processed in chronological order, so the first game a pair or player appears in is automatically their first
- The `gameLink()` function maps bracket sections to the correct tab parameter for the tournament page's deep linking
- Player order in `GameLocation` matches the order stored in the game itself, ensuring deep links work correctly
- The "First tournament" section now honestly reflects all players for whom it was true, even if they also appear in "First game ever" or "Back after a break"

https://claude.ai/code/session_01Txr6jbRdqjXcQpmXnBJvvT