### PR TITLE
Add "Achievements earned" metric to admin Top Gaming periods widget

### DIFF
--- a/frontend/src/pages/admin/top-days.tsx
+++ b/frontend/src/pages/admin/top-days.tsx
@@ -324,6 +324,12 @@ export const TopGamingDays: React.FC = () => {
     const { top, current } = data;
     const maxCount = top.length > 0 ? top[0].count : 0;
 
+    // A current period outside the top 10 gets its own row below, which already spells out
+    // "rank / total". When it made the top 10 that row is absent, so the table never says how
+    // many periods it was ranked against — this summary row supplies the denominator. Pointless
+    // when every period is already listed, so it needs more than the 10 shown.
+    const showRankSummary = current !== null && current.rank <= 10 && current.total > 10;
+
     const renderRow = (entry: PeriodData, rank: number, total: number | null) => {
       const ageMs = now - entry.timestamp;
       const recencyPercent = Math.max(0, Math.min(100, (1 - ageMs / windowMs) * 100));
@@ -379,6 +385,16 @@ export const TopGamingDays: React.FC = () => {
             <tbody>
               {top.map((entry, index) => renderRow(entry, index + 1, null))}
               {current && current.rank > 10 && renderRow(current.entry, current.rank, current.total)}
+              {showRankSummary && (
+                <tr className="text-primary-text/70">
+                  <td className="px-2 py-1 border border-primary-text/20 font-medium whitespace-nowrap">
+                    {current.rank} / {current.total}
+                  </td>
+                  <td colSpan={3} className="px-2 py-1 border border-primary-text/20">
+                    Current {periodLabel.singular.toLowerCase()} rank
+                  </td>
+                </tr>
+              )}
             </tbody>
           </table>
         )}

--- a/frontend/src/pages/admin/top-days.tsx
+++ b/frontend/src/pages/admin/top-days.tsx
@@ -4,7 +4,7 @@ import { relativeTimeString } from "../../common/date-utils";
 
 type Period = "day" | "week" | "month" | "year";
 
-type Metric = "games" | "activePlayers" | "pairings";
+type Metric = "games" | "activePlayers" | "pairings" | "achievements";
 
 interface PeriodData {
   key: string;
@@ -27,6 +27,7 @@ const METRIC_LABELS: Record<Metric, { option: string; column: string }> = {
   games: { option: "Games played", column: "Games" },
   activePlayers: { option: "Active players", column: "Players" },
   pairings: { option: "Player pairings", column: "Pairings" },
+  achievements: { option: "Achievements earned", column: "Achievements" },
 };
 
 const PERIOD_LABELS: Record<Period, { singular: string; plural: string }> = {
@@ -144,14 +145,16 @@ const formatPeriod = (timestamp: number, period: Period): string => {
 };
 
 /**
- * Everything needed to count any of the metrics for one period. Games are a running total,
- * while the two "unique" metrics need the members themselves so repeats are not counted twice.
+ * Everything needed to count any of the metrics for one period. Games and achievements are
+ * running totals, while the two "unique" metrics need the members themselves so repeats are
+ * not counted twice.
  */
 interface PeriodBucket {
   timestamp: number;
   games: number;
   players: Set<string>;
   pairings: Set<string>;
+  achievements: number;
 }
 
 const emptyBucket = (timestamp: number): PeriodBucket => ({
@@ -159,9 +162,19 @@ const emptyBucket = (timestamp: number): PeriodBucket => ({
   games: 0,
   players: new Set(),
   pairings: new Set(),
+  achievements: 0,
 });
 
 const pairingKey = (playerA: string, playerB: string): string => [playerA, playerB].sort().join("|");
+
+const getBucket = (map: Map<string, PeriodBucket>, key: string, timestamp: number): PeriodBucket => {
+  let bucket = map.get(key);
+  if (!bucket) {
+    bucket = emptyBucket(timestamp);
+    map.set(key, bucket);
+  }
+  return bucket;
+};
 
 const addGameToBucket = (
   map: Map<string, PeriodBucket>,
@@ -170,15 +183,15 @@ const addGameToBucket = (
   winner: string,
   loser: string,
 ) => {
-  let bucket = map.get(key);
-  if (!bucket) {
-    bucket = emptyBucket(timestamp);
-    map.set(key, bucket);
-  }
+  const bucket = getBucket(map, key, timestamp);
   bucket.games++;
   bucket.players.add(winner);
   bucket.players.add(loser);
   bucket.pairings.add(pairingKey(winner, loser));
+};
+
+const addAchievementToBucket = (map: Map<string, PeriodBucket>, key: string, timestamp: number) => {
+  getBucket(map, key, timestamp).achievements++;
 };
 
 const bucketCount = (bucket: PeriodBucket, metric: Metric): number => {
@@ -189,6 +202,8 @@ const bucketCount = (bucket: PeriodBucket, metric: Metric): number => {
       return bucket.players.size;
     case "pairings":
       return bucket.pairings.size;
+    case "achievements":
+      return bucket.achievements;
   }
 };
 
@@ -227,6 +242,26 @@ export const TopGamingDays: React.FC = () => {
         addGameToBucket(recentBuckets, key, timestamp, winner, loser);
       }
     });
+
+    // Achievements are not derived from the game loop above — they carry their own
+    // earnedAt — so they get a second pass, and only when they are the selected metric
+    // since calculating them the first time is expensive.
+    if (metric === "achievements") {
+      context.achievements.calculateAchievements();
+      context.achievements.achievementMap.forEach((playerAchievements) => {
+        playerAchievements.forEach(({ earnedAt }) => {
+          const date = new Date(earnedAt);
+          const key = getPeriodKey(date, period);
+          const timestamp = getPeriodTimestamp(date, period);
+
+          addAchievementToBucket(allTimeBuckets, key, timestamp);
+
+          if (earnedAt >= recentCutoff) {
+            addAchievementToBucket(recentBuckets, key, timestamp);
+          }
+        });
+      });
+    }
 
     // Seed every calendar period in the range with an empty bucket so that periods
     // with no games are still considered (including the current, possibly empty, period).
@@ -267,7 +302,7 @@ export const TopGamingDays: React.FC = () => {
       topAllTime: buildResult(allTimeBuckets),
       topRecent: buildResult(recentBuckets),
     };
-  }, [context.games, period, metric, recentCutoff, currentKey]);
+  }, [context.games, context.achievements, period, metric, recentCutoff, currentKey]);
 
   const periodLabel = PERIOD_LABELS[period];
   const metricLabel = METRIC_LABELS[metric];


### PR DESCRIPTION
The metric dropdown now offers achievements earned alongside games played,
active players and player pairings, ranking periods by how many achievements
the league picked up in each one.

Achievements are not derived from the game loop that feeds the other three
metrics — they carry their own earnedAt — so they are bucketed in a second
pass, guarded on the metric being selected since the first
calculateAchievements() call is expensive. Buckets are created on demand for
achievement timestamps that fall outside the games in the range. Zero-count
seeding, tie-breaks and the current-period highlight are unchanged, and the
count column header follows the selected metric as before.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QM7XMtduq19vYiBnfihEby