### PR TITLE
Fix record achievement targets and add retirement achievements

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -36,10 +36,10 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
     date: "2026-08-03",
     tags: ["new-feature"],
     summary:
-      "Hero of the Day 🦸 goes to the league record for most games played in a single day. The first day with 10 games sets the record; after that only a busier day takes it.",
+      "Hero of the Day 🦸 goes to the league record for most games played in a single day. The first day with 5 games sets the record; after that only a busier day takes it.",
     body: [
       text(
-        "Hero of the Day 🦸 is a league record, like Marathon Set and the streak records: it is held, not just earned. The first player to play 10 games in one calendar day establishes the record, and from then on it takes a strictly busier day to claim it. Wins and losses both count - the record is about showing up and playing.",
+        "Hero of the Day 🦸 is a league record, like Marathon Set and the streak records: it is held, not just earned. The first player to play 5 games in one calendar day establishes the record, and from then on it takes a strictly busier day to claim it. Wins and losses both count - the record is about showing up and playing.",
       ),
       text(
         "One award covers the whole record day: keep playing while you hold the record and the award grows with the day instead of stacking a new one per game. The progress view shows today's games against the record, your busiest day ever, and who currently holds it.",

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -36,10 +36,10 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
     date: "2026-08-03",
     tags: ["new-feature"],
     summary:
-      "Hero of the Day 🦸 goes to the league record for most games played in a single day. The first day with 5 games sets the record; after that only a busier day takes it.",
+      "Hero of the Day 🦸 goes to the league record for most games played in a single day. The first day with 3 games sets the record; after that only a busier day takes it.",
     body: [
       text(
-        "Hero of the Day 🦸 is a league record, like Marathon Set and the streak records: it is held, not just earned. The first player to play 5 games in one calendar day establishes the record, and from then on it takes a strictly busier day to claim it. Wins and losses both count - the record is about showing up and playing.",
+        "Hero of the Day 🦸 is a league record, like Marathon Set and the streak records: it is held, not just earned. The first player to play 3 games in one calendar day establishes the record, and from then on it takes a strictly busier day to claim it. Wins and losses both count - the record is about showing up and playing.",
       ),
       text(
         "One award covers the whole record day: keep playing while you hold the record and the award grows with the day instead of stacking a new one per game. The progress view shows today's games against the record, your busiest day ever, and who currently holds it.",

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -31,6 +31,22 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "hero-of-the-day-achievement",
+    title: "New achievement: Hero of the Day",
+    date: "2026-08-03",
+    tags: ["new-feature"],
+    summary:
+      "Hero of the Day 🦸 goes to the league record for most games played in a single day. The first day with 10 games sets the record; after that only a busier day takes it.",
+    body: [
+      text(
+        "Hero of the Day 🦸 is a league record, like Marathon Set and the streak records: it is held, not just earned. The first player to play 10 games in one calendar day establishes the record, and from then on it takes a strictly busier day to claim it. Wins and losses both count - the record is about showing up and playing.",
+      ),
+      text(
+        "One award covers the whole record day: keep playing while you hold the record and the award grows with the day instead of stacking a new one per game. The progress view shows today's games against the record, your busiest day ever, and who currently holds it.",
+      ),
+    ],
+  },
+  {
     slug: "retirement-achievements",
     title: "2 new achievements for retiring and coming back",
     date: "2026-08-03",

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -31,6 +31,39 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "retirement-achievements",
+    title: "2 new achievements for retiring and coming back",
+    date: "2026-08-03",
+    tags: ["new-feature"],
+    summary:
+      "Retired 🪦 marks leaving the league, Back From The Dead 🧟 marks returning from retirement, and retired players now appear in the achievements progress list.",
+    body: [
+      list(
+        "Retired 🪦 - earned when you retire from the league. Awarded for every retirement, should you make a habit of it.",
+        "Back From The Dead 🧟 - earned when you come back after retiring. The achievement shows how long you were gone.",
+      ),
+      text(
+        "The 2-year comeback achievement previously held the Back From The Dead name; it is now called A Cinderella Story 👸. Returning from an actual retirement is the stronger claim to the title.",
+      ),
+      text(
+        "The Everyone's Progress view on the achievements page now includes retired players, tagged with a Retired badge. Their history is as real as anyone's, and their names were already on the records they hold.",
+      ),
+    ],
+  },
+  {
+    slug: "record-achievement-targets-beyond-record",
+    title: "Record achievement progress bars now aim one beyond the record",
+    date: "2026-08-03",
+    tags: ["bug-fix"],
+    summary:
+      "Progress toward Longest Win/Lose Streak, Marathon Set and Leap Frog is now measured against the value that actually takes the record, not the record itself.",
+    body: [
+      text(
+        "The four record-chasing achievements are earned by beating the league record, not by matching it. Their progress bars and targets now reflect that: with the win-streak record at 8, the bar aims at 9. Previously the target was the record itself, so tying it read as 100% without earning anything. If your progress on one of these dropped slightly, this is why - the goal moved to where it always really was.",
+      ),
+    ],
+  },
+  {
     slug: "tournament-timeline-whole-days",
     title: "The tournament timeline counts whole days",
     date: "2026-07-31",

--- a/frontend/src/client/client-db/__tests__/achievements/hero-of-the-day.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/hero-of-the-day.test.ts
@@ -171,12 +171,12 @@ describe("Hero of the Day achievement", () => {
   });
 
   it("leaves the progression target unset until someone holds the record", () => {
-    const tt = calculate(gamesOnDay(1, "alice", "bob", 3));
+    const tt = calculate(gamesOnDay(1, "alice", "bob", GAMES_IN_DAY_RECORD_FLOOR - 1));
 
     const progression = tt.achievements.getPlayerProgression("alice")["hero-of-the-day"];
     expect(progression.target).toBeUndefined();
     expect(progression.recordHolder).toBeUndefined();
-    expect(progression.personalBest).toBe(3);
+    expect(progression.personalBest).toBe(GAMES_IN_DAY_RECORD_FLOOR - 1);
     expect(progression.earned).toBe(0);
   });
 });

--- a/frontend/src/client/client-db/__tests__/achievements/hero-of-the-day.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/hero-of-the-day.test.ts
@@ -1,0 +1,182 @@
+import { Achievement, GAMES_IN_DAY_RECORD_FLOOR } from "../../achievements";
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { TennisTable } from "../../tennis-table";
+
+type GameSpec = { winner: string; loser: string; playedAt: number };
+
+// Timestamps anchored to local noon so every game stays inside its intended
+// calendar day regardless of the timezone the tests run in — the achievement
+// buckets games by local midnight.
+function at(day: number, minute: number): number {
+  return new Date(2024, 0, day, 12, minute).getTime();
+}
+
+function eventsForGames(games: GameSpec[]): EventType[] {
+  const players = Array.from(new Set(games.flatMap((game) => [game.winner, game.loser])));
+  return [
+    ...players.map<EventType>((player, index) => ({
+      type: EventTypeEnum.PLAYER_CREATED,
+      stream: player,
+      time: index + 1,
+      data: { name: player },
+    })),
+    ...games.map<EventType>((game, index) => ({
+      type: EventTypeEnum.GAME_CREATED,
+      stream: `g${index}`,
+      time: game.playedAt,
+      data: { winner: game.winner, loser: game.loser, playedAt: game.playedAt },
+    })),
+  ];
+}
+
+function calculate(games: GameSpec[]): TennisTable {
+  const tt = new TennisTable({ events: eventsForGames(games) });
+  tt.achievements.calculateAchievements();
+  return tt;
+}
+
+function heroAwards(tt: TennisTable, player: string): Extract<Achievement, { type: "hero-of-the-day" }>[] {
+  return tt.achievements
+    .getAchievements(player)
+    .filter(
+      (achievement): achievement is Extract<Achievement, { type: "hero-of-the-day" }> =>
+        achievement.type === "hero-of-the-day",
+    );
+}
+
+/** `count` games between the two players on `day`, all won by `winner`. */
+function gamesOnDay(day: number, winner: string, loser: string, count: number, fromMinute = 0): GameSpec[] {
+  return Array.from({ length: count }, (_, index) => ({
+    winner,
+    loser,
+    playedAt: at(day, fromMinute + index),
+  }));
+}
+
+describe("Hero of the Day achievement", () => {
+  it("does not establish a record below the floor", () => {
+    const tt = calculate(gamesOnDay(1, "alice", "bob", GAMES_IN_DAY_RECORD_FLOOR - 1));
+
+    expect(heroAwards(tt, "alice")).toHaveLength(0);
+    expect(heroAwards(tt, "bob")).toHaveLength(0);
+    expect(tt.achievements.gamesInDayRecord).toStrictEqual({ count: undefined, holder: undefined });
+  });
+
+  it("establishes the first record at the floor, tie going to the winner of the crossing game", () => {
+    // Alice and Bob both reach 10 games on the same game; Alice won it.
+    const tt = calculate(gamesOnDay(1, "alice", "bob", GAMES_IN_DAY_RECORD_FLOOR));
+
+    const aliceAwards = heroAwards(tt, "alice");
+    expect(aliceAwards).toHaveLength(1);
+    expect(aliceAwards[0]).toStrictEqual({
+      type: "hero-of-the-day",
+      earnedBy: "alice",
+      earnedAt: at(1, GAMES_IN_DAY_RECORD_FLOOR - 1),
+      data: {
+        day: new Date(2024, 0, 1).getTime(),
+        gamesPlayed: GAMES_IN_DAY_RECORD_FLOOR,
+        previousRecord: undefined,
+      },
+    });
+    expect(heroAwards(tt, "bob")).toHaveLength(0);
+    expect(tt.achievements.gamesInDayRecord).toStrictEqual({
+      count: GAMES_IN_DAY_RECORD_FLOOR,
+      holder: "alice",
+    });
+  });
+
+  it("grows a single award as the record day continues instead of awarding per game", () => {
+    const tt = calculate(gamesOnDay(1, "alice", "bob", 12));
+
+    const aliceAwards = heroAwards(tt, "alice");
+    expect(aliceAwards).toHaveLength(1);
+    expect(aliceAwards[0].data.gamesPlayed).toBe(12);
+    expect(aliceAwards[0].earnedAt).toBe(at(1, 11));
+    expect(tt.achievements.gamesInDayRecord).toStrictEqual({ count: 12, holder: "alice" });
+  });
+
+  it("requires a later day to strictly beat the record", () => {
+    const tt = calculate([
+      ...gamesOnDay(1, "alice", "bob", 12),
+      // Day 2 only ties the record of 12 — no award.
+      ...gamesOnDay(2, "alice", "bob", 12),
+      // Day 3 beats it with 13.
+      ...gamesOnDay(3, "alice", "bob", 13),
+    ]);
+
+    const aliceAwards = heroAwards(tt, "alice");
+    expect(aliceAwards).toHaveLength(2);
+    expect(aliceAwards[1].data).toStrictEqual({
+      day: new Date(2024, 0, 3).getTime(),
+      gamesPlayed: 13,
+      previousRecord: 12,
+    });
+    expect(tt.achievements.gamesInDayRecord).toStrictEqual({ count: 13, holder: "alice" });
+  });
+
+  it("stops growing a taken-over award and starts a fresh one on re-passing", () => {
+    const tt = calculate([
+      // Day 1: Alice sets the record at 10.
+      ...gamesOnDay(1, "alice", "bob", 10),
+      // Day 2: Alice takes the record at 11 games...
+      ...gamesOnDay(2, "alice", "bob", 11),
+      // ...Bob passes her with a 12th game against Carol...
+      { winner: "bob", loser: "carol", playedAt: at(2, 20) },
+      // ...and Alice re-passes with two more games against Dave: 12 only
+      // ties Bob, 13 takes the record back as a NEW award.
+      { winner: "alice", loser: "dave", playedAt: at(2, 30) },
+      { winner: "alice", loser: "dave", playedAt: at(2, 31) },
+    ]);
+
+    const aliceAwards = heroAwards(tt, "alice");
+    expect(aliceAwards).toHaveLength(3);
+    // The day-2 award taken over by Bob stopped growing at 11.
+    expect(aliceAwards[1].data).toStrictEqual({
+      day: new Date(2024, 0, 2).getTime(),
+      gamesPlayed: 11,
+      previousRecord: 10,
+    });
+    expect(aliceAwards[2].data).toStrictEqual({
+      day: new Date(2024, 0, 2).getTime(),
+      gamesPlayed: 13,
+      previousRecord: 12,
+    });
+
+    const bobAwards = heroAwards(tt, "bob");
+    expect(bobAwards).toHaveLength(1);
+    expect(bobAwards[0].data).toStrictEqual({
+      day: new Date(2024, 0, 2).getTime(),
+      gamesPlayed: 12,
+      previousRecord: 11,
+    });
+
+    expect(tt.achievements.gamesInDayRecord).toStrictEqual({ count: 13, holder: "alice" });
+  });
+
+  it("reports busiest day, league record and earned count in the progression", () => {
+    const tt = calculate([...gamesOnDay(1, "alice", "bob", 10), ...gamesOnDay(2, "alice", "bob", 13)]);
+
+    const alice = tt.achievements.getPlayerProgression("alice")["hero-of-the-day"];
+    expect(alice.current).toBe(0); // no games today
+    expect(alice.personalBest).toBe(13);
+    expect(alice.target).toBe(14); // one beyond the record of 13
+    expect(alice.recordHolder).toBe("alice");
+    expect(alice.earned).toBe(2);
+
+    const bob = tt.achievements.getPlayerProgression("bob")["hero-of-the-day"];
+    expect(bob.personalBest).toBe(13);
+    expect(bob.target).toBe(14);
+    expect(bob.recordHolder).toBe("alice");
+    expect(bob.earned).toBe(0);
+  });
+
+  it("leaves the progression target unset until someone holds the record", () => {
+    const tt = calculate(gamesOnDay(1, "alice", "bob", 3));
+
+    const progression = tt.achievements.getPlayerProgression("alice")["hero-of-the-day"];
+    expect(progression.target).toBeUndefined();
+    expect(progression.recordHolder).toBeUndefined();
+    expect(progression.personalBest).toBe(3);
+    expect(progression.earned).toBe(0);
+  });
+});

--- a/frontend/src/client/client-db/__tests__/achievements/leap-frog.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/leap-frog.test.ts
@@ -159,20 +159,20 @@ describe("Leap Frog Achievement", () => {
 
     const x1 = tt.achievements.getPlayerProgression("x1")["leap-frog"];
     expect(x1.current).toBe(5); // its own biggest jump
-    expect(x1.target).toBe(5); // the league record it now holds
+    expect(x1.target).toBe(6); // one beyond the record of 5 it now holds
     expect(x1.recordHolder).toBe("x1");
     expect(x1.earned).toBe(1);
 
     const x0 = tt.achievements.getPlayerProgression("x0")["leap-frog"];
     expect(x0.current).toBe(2);
-    expect(x0.target).toBe(5);
+    expect(x0.target).toBe(6);
     expect(x0.recordHolder).toBe("x1");
     expect(x0.earned).toBe(1);
 
     // A cluster member that only ever lost never jumped → no progress.
     const c0 = tt.achievements.getPlayerProgression("c0")["leap-frog"];
     expect(c0.current).toBe(0);
-    expect(c0.target).toBe(5);
+    expect(c0.target).toBe(6);
     expect(c0.recordHolder).toBe("x1");
     expect(c0.earned).toBe(0);
   });

--- a/frontend/src/client/client-db/__tests__/achievements/longest-streak.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/longest-streak.test.ts
@@ -245,14 +245,15 @@ describe("Longest Win Streak / Longest Lose Streak achievements", () => {
     const aliceProgression = tt.achievements.getPlayerProgression("alice")["longest-win-streak"];
     expect(aliceProgression.current).toBe(2);
     expect(aliceProgression.personalBest).toBe(5);
-    expect(aliceProgression.target).toBe(5);
+    // The record is 5, so a streak of 6 is what takes it.
+    expect(aliceProgression.target).toBe(6);
     expect(aliceProgression.recordHolder).toBe("alice");
     expect(aliceProgression.earned).toBe(1);
 
     const bobProgression = tt.achievements.getPlayerProgression("bob")["longest-win-streak"];
     expect(bobProgression.current).toBe(0);
     expect(bobProgression.personalBest).toBe(1);
-    expect(bobProgression.target).toBe(5);
+    expect(bobProgression.target).toBe(6);
     expect(bobProgression.recordHolder).toBe("alice");
     expect(bobProgression.earned).toBe(0);
   });

--- a/frontend/src/client/client-db/__tests__/achievements/marathon-set.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/marathon-set.test.ts
@@ -301,19 +301,20 @@ describe("Marathon Set Achievement", () => {
 
     const aliceProg = tt.achievements.getPlayerProgression("alice")["marathon-set"];
     expect(aliceProg.current).toBe(14);
-    expect(aliceProg.target).toBe(14);
+    // The record is 14, so a winning score of 15 is what takes it.
+    expect(aliceProg.target).toBe(15);
     expect(aliceProg.recordHolder).toBe("alice");
     expect(aliceProg.earned).toBe(1);
 
     const bobProg = tt.achievements.getPlayerProgression("bob")["marathon-set"];
     expect(bobProg.current).toBe(13);
-    expect(bobProg.target).toBe(14);
+    expect(bobProg.target).toBe(15);
     expect(bobProg.recordHolder).toBe("alice");
     expect(bobProg.earned).toBe(0);
 
     const carolProg = tt.achievements.getPlayerProgression("carol")["marathon-set"];
     expect(carolProg.current).toBe(0);
-    expect(carolProg.target).toBe(14);
+    expect(carolProg.target).toBe(15);
     expect(carolProg.recordHolder).toBe("alice");
     expect(carolProg.earned).toBe(0);
   });

--- a/frontend/src/client/client-db/__tests__/achievements/retired-back-from-the-dead.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/retired-back-from-the-dead.test.ts
@@ -1,0 +1,74 @@
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { TennisTable } from "../../tennis-table";
+
+describe("Retired and Back From The Dead achievements", () => {
+  const baseEvents: EventType[] = [
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "alice", time: 1, data: { name: "Alice" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "bob", time: 2, data: { name: "Bob" } },
+  ];
+
+  function calculate(events: EventType[]): TennisTable {
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+    return tt;
+  }
+
+  it("awards Retired when a player is deactivated", () => {
+    const tt = calculate([
+      ...baseEvents,
+      { type: EventTypeEnum.PLAYER_DEACTIVATED, stream: "alice", time: 100, data: null },
+    ]);
+
+    const retired = tt.achievements.getAchievements("alice").filter((a) => a.type === "retired");
+    expect(retired).toStrictEqual([{ type: "retired", earnedBy: "alice", earnedAt: 100, data: undefined }]);
+    expect(tt.achievements.getAchievements("bob").filter((a) => a.type === "retired")).toHaveLength(0);
+    expect(tt.achievements.getPlayerProgression("alice")["retired"].earned).toBe(1);
+  });
+
+  it("awards Back From The Dead on reactivation, remembering when the retirement happened", () => {
+    const tt = calculate([
+      ...baseEvents,
+      { type: EventTypeEnum.PLAYER_DEACTIVATED, stream: "alice", time: 100, data: null },
+      { type: EventTypeEnum.PLAYER_REACTIVATED, stream: "alice", time: 500, data: null },
+    ]);
+
+    const comebacks = tt.achievements.getAchievements("alice").filter((a) => a.type === "back-from-the-dead");
+    expect(comebacks).toStrictEqual([
+      { type: "back-from-the-dead", earnedBy: "alice", earnedAt: 500, data: { retiredAt: 100 } },
+    ]);
+    expect(tt.achievements.getPlayerProgression("alice")["back-from-the-dead"].earned).toBe(1);
+  });
+
+  it("awards both once per retirement cycle", () => {
+    const tt = calculate([
+      ...baseEvents,
+      { type: EventTypeEnum.PLAYER_DEACTIVATED, stream: "alice", time: 100, data: null },
+      { type: EventTypeEnum.PLAYER_REACTIVATED, stream: "alice", time: 200, data: null },
+      { type: EventTypeEnum.PLAYER_DEACTIVATED, stream: "alice", time: 300, data: null },
+      { type: EventTypeEnum.PLAYER_REACTIVATED, stream: "alice", time: 400, data: null },
+    ]);
+
+    const achievements = tt.achievements.getAchievements("alice");
+    expect(achievements.filter((a) => a.type === "retired")).toHaveLength(2);
+    const comebacks = achievements.filter((a) => a.type === "back-from-the-dead");
+    expect(comebacks).toHaveLength(2);
+    expect(comebacks.map((a) => a.data)).toStrictEqual([{ retiredAt: 100 }, { retiredAt: 300 }]);
+  });
+
+  it("does not award Back From The Dead for a reactivation without a recorded retirement", () => {
+    const tt = calculate([
+      ...baseEvents,
+      { type: EventTypeEnum.PLAYER_REACTIVATED, stream: "alice", time: 100, data: null },
+    ]);
+
+    expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "back-from-the-dead")).toHaveLength(0);
+  });
+
+  it("awards nothing to players who never retired", () => {
+    const tt = calculate([...baseEvents]);
+
+    const progression = tt.achievements.getPlayerProgression("alice");
+    expect(progression["retired"].earned).toBe(0);
+    expect(progression["back-from-the-dead"].earned).toBe(0);
+  });
+});

--- a/frontend/src/client/client-db/__tests__/achievements/retired-back-from-the-dead.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/retired-back-from-the-dead.test.ts
@@ -23,6 +23,11 @@ describe("Retired and Back From The Dead achievements", () => {
     expect(retired).toStrictEqual([{ type: "retired", earnedBy: "alice", earnedAt: 100, data: undefined }]);
     expect(tt.achievements.getAchievements("bob").filter((a) => a.type === "retired")).toHaveLength(0);
     expect(tt.achievements.getPlayerProgression("alice")["retired"].earned).toBe(1);
+
+    // A currently retired player is halfway to Back From The Dead.
+    const comeback = tt.achievements.getPlayerProgression("alice")["back-from-the-dead"];
+    expect(comeback.current).toBe(1);
+    expect(comeback.target).toBe(2);
   });
 
   it("awards Back From The Dead on reactivation, remembering when the retirement happened", () => {
@@ -36,7 +41,10 @@ describe("Retired and Back From The Dead achievements", () => {
     expect(comebacks).toStrictEqual([
       { type: "back-from-the-dead", earnedBy: "alice", earnedAt: 500, data: { retiredAt: 100 } },
     ]);
-    expect(tt.achievements.getPlayerProgression("alice")["back-from-the-dead"].earned).toBe(1);
+    const progression = tt.achievements.getPlayerProgression("alice")["back-from-the-dead"];
+    expect(progression.earned).toBe(1);
+    // Back and active again — the next chase starts from the beginning.
+    expect(progression.current).toBe(0);
   });
 
   it("awards both once per retirement cycle", () => {
@@ -70,5 +78,6 @@ describe("Retired and Back From The Dead achievements", () => {
     const progression = tt.achievements.getPlayerProgression("alice");
     expect(progression["retired"].earned).toBe(0);
     expect(progression["back-from-the-dead"].earned).toBe(0);
+    expect(progression["back-from-the-dead"].current).toBe(0);
   });
 });

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -604,7 +604,35 @@ export class Achievements {
     this.#calculateEloAchievements();
     this.#checkFullHouseAndHumbledAchievements();
     this.#checkPerfectDayAndWeekAchievements();
+    this.#checkRetirementAchievements();
     this.hasCalculated = true;
+  }
+
+  // Awards "Retired" for every PLAYER_DEACTIVATED event and "Back From The
+  // Dead" for every PLAYER_REACTIVATED that follows one — both earnable once
+  // per retirement. The comeback remembers when the retirement happened so
+  // the display can show how long the player was gone. A reactivation with
+  // no recorded retirement (shouldn't happen, but events are data) awards
+  // nothing.
+  #checkRetirementAchievements() {
+    const lastRetiredAt = new Map<string, number>();
+    for (const event of this.parent.events) {
+      if (event.type === EventTypeEnum.PLAYER_DEACTIVATED) {
+        lastRetiredAt.set(event.stream, event.time);
+        this.#addAchievement(
+          event.stream,
+          this.#createAchievement("retired", event.stream, event.time, undefined),
+        );
+      } else if (event.type === EventTypeEnum.PLAYER_REACTIVATED) {
+        const retiredAt = lastRetiredAt.get(event.stream);
+        if (retiredAt === undefined) continue;
+        lastRetiredAt.delete(event.stream);
+        this.#addAchievement(
+          event.stream,
+          this.#createAchievement("back-from-the-dead", event.stream, event.time, { retiredAt }),
+        );
+      }
+    }
   }
 
   // Awards "Perfect Day" and "Perfect Week".
@@ -2014,11 +2042,14 @@ export class Achievements {
       "perfect-day": { current: 0, target: 5, earned: 0 },
       "perfect-week": { current: 0, target: 5, earned: 0 },
       "streak-ender": { earned: 0 },
+      // Record-chasing achievements are earned by strictly exceeding the
+      // league record, so their target is one beyond it — reaching the
+      // target is what earns the award, same as every other progress bar.
       "longest-win-streak": {
         earned: 0,
         current: 0,
         personalBest: 0,
-        target: this.winStreakRecord.length,
+        target: this.winStreakRecord.length === undefined ? undefined : this.winStreakRecord.length + 1,
         recordHolder: this.winStreakRecord.holder,
       },
 
@@ -2031,7 +2062,7 @@ export class Achievements {
         earned: 0,
         current: 0,
         personalBest: 0,
-        target: this.loseStreakRecord.length,
+        target: this.loseStreakRecord.length === undefined ? undefined : this.loseStreakRecord.length + 1,
         recordHolder: this.loseStreakRecord.holder,
       },
 
@@ -2043,7 +2074,7 @@ export class Achievements {
       "leap-frog": {
         earned: 0,
         current: 0,
-        target: this.leapFrogRecord.ranksJumped,
+        target: this.leapFrogRecord.ranksJumped === undefined ? undefined : this.leapFrogRecord.ranksJumped + 1,
         recordHolder: this.leapFrogRecord.holder,
       },
       "david": { current: 0, target: 30, earned: 0 },
@@ -2064,7 +2095,7 @@ export class Achievements {
       "marathon-set": {
         earned: 0,
         current: 0,
-        target: this.marathonSetRecord.score,
+        target: this.marathonSetRecord.score === undefined ? undefined : this.marathonSetRecord.score + 1,
         recordHolder: this.marathonSetRecord.holder,
       },
       // Record-breaking, no progress bar. recordMinutes is the current league
@@ -2091,6 +2122,8 @@ export class Achievements {
       "back-after-6-months": { earned: 0, target: SIX_MONTHS },
       "back-after-1-year": { earned: 0, target: ONE_YEAR },
       "back-after-2-years": { earned: 0, target: TWO_YEARS },
+      "retired": { earned: 0 },
+      "back-from-the-dead": { earned: 0 },
 
       // Competition
       "tournament-participated": { earned: 0 },
@@ -2624,6 +2657,8 @@ type AchievementDefinitions = {
   "back-after-6-months": { lastGameAt: number };
   "back-after-1-year": { lastGameAt: number };
   "back-after-2-years": { lastGameAt: number };
+  "retired": undefined;
+  "back-from-the-dead": { retiredAt: number };
   "active-6-months": { firstGameInPeriod: number };
   "active-1-year": { firstGameInPeriod: number };
   "active-2-years": { firstGameInPeriod: number };
@@ -2765,9 +2800,9 @@ type MissingPlayersProgression = ProgressionWithTarget & {
 type LeapFrogProgression = BaseProgression & {
   // Player's own biggest single-game leaderboard jump (0 if none).
   current: number;
-  // The league record — ranks the player must strictly exceed to earn the
-  // next Leap Frog award. Undefined when no one has set a record yet (a
-  // ≥ 2-rank jump wins it outright).
+  // One rank beyond the league record — the jump that earns the next Leap
+  // Frog award. Undefined when no one has set a record yet (a ≥ 2-rank
+  // jump wins it outright).
   target?: number;
   // Player who currently holds the league record, if any.
   recordHolder?: string;
@@ -2777,10 +2812,9 @@ type MarathonSetProgression = BaseProgression & {
   // Player's own highest winning set score from a true-deuce set
   // they won (winner ≥ 12, loser ≥ 10). 0 if they have none.
   current: number;
-  // The league-wide record — the winning score this player must
-  // strictly exceed to earn the next Marathon Set award. Undefined
-  // when no one has set a record yet (next qualifying deuce set wins
-  // it outright).
+  // One point beyond the league-wide record — the winning score that
+  // earns the next Marathon Set award. Undefined when no one has set a
+  // record yet (next qualifying deuce set wins it outright).
   target?: number;
   // Player who currently holds the league record, if any.
   recordHolder?: string;
@@ -2791,9 +2825,9 @@ type StreakRecordProgression = BaseProgression & {
   // the other way). Only a live streak can grow into the record, so this is
   // what the progress bar measures.
   current: number;
-  // The league record — the streak this player must strictly exceed to take
-  // it. Undefined while nobody holds it (a streak of STREAK_RECORD_FLOOR
-  // takes it outright).
+  // One beyond the league record — the streak that takes it. Undefined
+  // while nobody holds it (a streak of STREAK_RECORD_FLOOR takes it
+  // outright).
   target?: number;
   // Player who currently holds the league record, if any.
   recordHolder?: string;
@@ -2825,6 +2859,8 @@ export type AchievementProgression = {
   "back-after-6-months": BackAfterProgression;
   "back-after-1-year": BackAfterProgression;
   "back-after-2-years": BackAfterProgression;
+  "retired": BaseProgression;
+  "back-from-the-dead": BaseProgression;
   "active-6-months": ProgressionWithTarget;
   "active-1-year": ProgressionWithTarget;
   "active-2-years": ProgressionWithTarget;

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -12,7 +12,7 @@ export const STREAK_RECORD_FLOOR = 3;
 // the Day record. Below this a day is too ordinary to be a record worth
 // holding. Once a record exists the floor is irrelevant — only beating the
 // record counts.
-export const GAMES_IN_DAY_RECORD_FLOOR = 10;
+export const GAMES_IN_DAY_RECORD_FLOOR = 5;
 
 export class Achievements {
   private parent: TennisTable;

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -12,7 +12,7 @@ export const STREAK_RECORD_FLOOR = 3;
 // the Day record. Below this a day is too ordinary to be a record worth
 // holding. Once a record exists the floor is irrelevant — only beating the
 // record counts.
-export const GAMES_IN_DAY_RECORD_FLOOR = 5;
+export const GAMES_IN_DAY_RECORD_FLOOR = 3;
 
 export class Achievements {
   private parent: TennisTable;
@@ -2221,7 +2221,9 @@ export class Achievements {
       "back-after-1-year": { earned: 0, target: ONE_YEAR },
       "back-after-2-years": { earned: 0, target: TWO_YEARS },
       "retired": { earned: 0 },
-      "back-from-the-dead": { earned: 0 },
+      // A two-step chase: retire, then come back. A currently retired player
+      // is halfway there; current is filled in below.
+      "back-from-the-dead": { current: 0, target: 2, earned: 0 },
 
       // Competition
       "tournament-participated": { earned: 0 },
@@ -2644,6 +2646,14 @@ export class Achievements {
       progression["anniversary"].firstGameAt = firstActiveAt;
     }
 
+    // Back From The Dead progression: a currently retired player has done
+    // step one of two — the comeback is all that's left, so they sit at 50%.
+    // An active player (back or never gone) is at the start of the chase.
+    const isCurrentlyRetired =
+      this.parent.allPlayers.some((player) => player.id === playerId) &&
+      !this.parent.players.some((player) => player.id === playerId);
+    progression["back-from-the-dead"].current = isCurrentlyRetired ? 1 : 0;
+
     // Calculate back-after progression (time since last activity)
     if (lastActiveAt !== null) {
       const now = Date.now();
@@ -2990,7 +3000,7 @@ export type AchievementProgression = {
   "back-after-1-year": BackAfterProgression;
   "back-after-2-years": BackAfterProgression;
   "retired": BaseProgression;
-  "back-from-the-dead": BaseProgression;
+  "back-from-the-dead": ProgressionWithTarget;
   "active-6-months": ProgressionWithTarget;
   "active-1-year": ProgressionWithTarget;
   "active-2-years": ProgressionWithTarget;

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -8,6 +8,12 @@ import { TennisTable } from "./tennis-table";
 // a record exists the floor is irrelevant — only beating the record counts.
 export const STREAK_RECORD_FLOOR = 3;
 
+// Fewest games in one calendar day that can establish the very first Hero of
+// the Day record. Below this a day is too ordinary to be a record worth
+// holding. Once a record exists the floor is irrelevant — only beating the
+// record counts.
+export const GAMES_IN_DAY_RECORD_FLOOR = 10;
+
 export class Achievements {
   private parent: TennisTable;
   private hasCalculated = false;
@@ -65,6 +71,15 @@ export class Achievements {
     length: undefined,
     holder: undefined,
   };
+  // League-wide running record for the Hero of the Day achievement: the most
+  // games a single player has played in one local calendar day. Undefined
+  // until a day reaches GAMES_IN_DAY_RECORD_FLOOR and establishes the first
+  // record. Used by the progression view so players can see the mark they
+  // need to beat.
+  gamesInDayRecord: { count: number | undefined; holder: string | undefined } = {
+    count: undefined,
+    holder: undefined,
+  };
 
   constructor(parent: TennisTable) {
     this.parent = parent;
@@ -86,6 +101,7 @@ export class Achievements {
     this.latestGameRecord = { minutesIntoDay: undefined };
     this.winStreakRecord = { length: undefined, holder: undefined };
     this.loseStreakRecord = { length: undefined, holder: undefined };
+    this.gamesInDayRecord = { count: undefined, holder: undefined };
 
     const playerTracker = new Map<
       string,
@@ -104,6 +120,14 @@ export class Achievements {
         // once another player takes the record over.
         openWinStreakRecord: StreakRecordAchievement | undefined;
         openLoseStreakRecord: StreakRecordAchievement | undefined;
+        // The local calendar day (its midnight timestamp) the player last
+        // played on, how many games they have played on that day so far, and
+        // the Hero of the Day award that day's run earned while the player
+        // holds the record with it — grown game by game like the streak
+        // records, cleared when the day ends.
+        currentDayStart: number;
+        gamesToday: number;
+        openHeroOfTheDayRecord: HeroOfTheDayAchievement | undefined;
         donutCount: number;
         closeCallsCount: number;
         edgeLordCount: number;
@@ -131,6 +155,9 @@ export class Achievements {
           winStreakPlayer: new Map(),
           openWinStreakRecord: undefined,
           openLoseStreakRecord: undefined,
+          currentDayStart: 0,
+          gamesToday: 0,
+          openHeroOfTheDayRecord: undefined,
           donutCount: 0,
           closeCallsCount: 0,
           edgeLordCount: 0,
@@ -153,6 +180,9 @@ export class Achievements {
           winStreakPlayer: new Map(),
           openWinStreakRecord: undefined,
           openLoseStreakRecord: undefined,
+          currentDayStart: 0,
+          gamesToday: 0,
+          openHeroOfTheDayRecord: undefined,
           donutCount: 0,
           closeCallsCount: 0,
           edgeLordCount: 0,
@@ -215,6 +245,12 @@ export class Achievements {
 
       // Check for "Earliest Game" / "Latest Game" record-breaking achievements
       this.#checkTimeOfDayAchievements(game);
+
+      // Check for "Hero of the Day": the record for most games by one player
+      // in a single day. Both players played this game; the winner is checked
+      // first, so when both cross the same count at once the win breaks the tie.
+      this.#checkHeroOfTheDayAchievement(game.winner, winner, game.playedAt);
+      this.#checkHeroOfTheDayAchievement(game.loser, loser, game.playedAt);
 
       // Check for Welcome Committee achievement
       // If this is the loser's first game ever, the winner is their first opponent
@@ -1692,6 +1728,61 @@ export class Achievements {
     return achievement;
   }
 
+  // Hero of the Day: the league-wide record for most games by one player in a
+  // single local calendar day. Works like the streak records: the first day
+  // to reach GAMES_IN_DAY_RECORD_FLOOR games establishes the record, after
+  // that only playing more games in one day than the record takes it. While
+  // the record holder keeps playing on their record day the award grows with
+  // the day instead of handing out one per game; once the day ends (or
+  // someone else takes the record over) a later run is a fresh chase.
+  #checkHeroOfTheDayAchievement(
+    playerId: string,
+    tracker: {
+      currentDayStart: number;
+      gamesToday: number;
+      openHeroOfTheDayRecord: HeroOfTheDayAchievement | undefined;
+    },
+    playedAt: number,
+  ) {
+    const dayDate = new Date(playedAt);
+    dayDate.setHours(0, 0, 0, 0);
+    const day = dayDate.getTime();
+    if (tracker.currentDayStart !== day) {
+      tracker.currentDayStart = day;
+      tracker.gamesToday = 0;
+      tracker.openHeroOfTheDayRecord = undefined;
+    }
+    tracker.gamesToday++;
+
+    const record = this.gamesInDayRecord;
+    const beatsRecord =
+      record.count === undefined
+        ? tracker.gamesToday >= GAMES_IN_DAY_RECORD_FLOOR
+        : tracker.gamesToday > record.count;
+    if (!beatsRecord) {
+      return;
+    }
+
+    // Same day, still the record holder: grow the award instead of handing
+    // out another one.
+    if (tracker.openHeroOfTheDayRecord !== undefined && record.holder === playerId) {
+      tracker.openHeroOfTheDayRecord.data.gamesPlayed = tracker.gamesToday;
+      tracker.openHeroOfTheDayRecord.earnedAt = playedAt;
+      record.count = tracker.gamesToday;
+      return;
+    }
+
+    const achievement = this.#createAchievement("hero-of-the-day", playerId, playedAt, {
+      day,
+      gamesPlayed: tracker.gamesToday,
+      previousRecord: record.count,
+    });
+    this.#addAchievement(playerId, achievement);
+    record.count = tracker.gamesToday;
+    record.holder = playerId;
+    tracker.openHeroOfTheDayRecord = achievement;
+  }
+
   #checkBackAfterAchievement(playerId: string, lastActiveAt: number, currentGameAt: number) {
     const timeDiff = currentGameAt - lastActiveAt;
     const SIX_MONTHS = 6 * 30 * 24 * 60 * 60 * 1000;
@@ -2098,6 +2189,13 @@ export class Achievements {
         target: this.marathonSetRecord.score === undefined ? undefined : this.marathonSetRecord.score + 1,
         recordHolder: this.marathonSetRecord.holder,
       },
+      "hero-of-the-day": {
+        earned: 0,
+        current: 0,
+        personalBest: 0,
+        target: this.gamesInDayRecord.count === undefined ? undefined : this.gamesInDayRecord.count + 1,
+        recordHolder: this.gamesInDayRecord.holder,
+      },
       // Record-breaking, no progress bar. recordMinutes is the current league
       // record; playerMinutes (the player's own best) is filled in below.
       "earliest-game": { earned: 0, recordMinutes: this.earliestGameRecord.minutesIntoDay },
@@ -2362,6 +2460,16 @@ export class Achievements {
     const todayStat = perfectDayStats.get(todayStart.getTime());
     progression["perfect-day"].current =
       todayStat && todayStat.losses === 0 ? Math.min(todayStat.wins, 5) : 0;
+
+    // Hero of the Day: only today's games can still grow into the record, so
+    // that is the progress. The player's busiest day ever is reported
+    // alongside it.
+    progression["hero-of-the-day"].current = todayStat ? todayStat.wins + todayStat.losses : 0;
+    let busiestDay = 0;
+    perfectDayStats.forEach((stats) => {
+      busiestDay = Math.max(busiestDay, stats.wins + stats.losses);
+    });
+    progression["hero-of-the-day"].personalBest = busiestDay;
 
     // Perfect Week progression tracks THIS working week's live attempt: the
     // run of consecutive weekdays from Monday, each with at least one win.
@@ -2659,6 +2767,9 @@ type AchievementDefinitions = {
   "back-after-2-years": { lastGameAt: number };
   "retired": undefined;
   "back-from-the-dead": { retiredAt: number };
+  // `day` is the local midnight of the record day. Undefined previousRecord
+  // means this day established the very first league record.
+  "hero-of-the-day": { day: number; gamesPlayed: number; previousRecord?: number };
   "active-6-months": { firstGameInPeriod: number };
   "active-1-year": { firstGameInPeriod: number };
   "active-2-years": { firstGameInPeriod: number };
@@ -2755,6 +2866,10 @@ type StreakRecordAchievement =
   | GenericAchievement<"longest-win-streak">
   | GenericAchievement<"longest-lose-streak">;
 
+// The award for holding the games-in-a-day record — grown through the day
+// while the player still holds the record with it.
+type HeroOfTheDayAchievement = GenericAchievement<"hero-of-the-day">;
+
 // Progression Types
 type BaseProgression = {
   earned: number; // How many times this achievement has been earned
@@ -2818,6 +2933,21 @@ type MarathonSetProgression = BaseProgression & {
   target?: number;
   // Player who currently holds the league record, if any.
   recordHolder?: string;
+};
+
+type HeroOfTheDayProgression = BaseProgression & {
+  // Games the player has played so far today — only today's total can still
+  // grow into the record, so this is what the progress bar measures.
+  current: number;
+  // One beyond the league record — the single-day games count that takes it.
+  // Undefined while nobody holds it (a GAMES_IN_DAY_RECORD_FLOOR-game day
+  // takes it outright).
+  target?: number;
+  // Player who currently holds the league record, if any.
+  recordHolder?: string;
+  // The player's own busiest day ever, which may be busier than today.
+  // Shown so they can see how their best compares.
+  personalBest: number;
 };
 
 type StreakRecordProgression = BaseProgression & {
@@ -2898,6 +3028,7 @@ export type AchievementProgression = {
   "streak-ender": BaseProgression;
   "longest-win-streak": StreakRecordProgression;
   "longest-lose-streak": StreakRecordProgression;
+  "hero-of-the-day": HeroOfTheDayProgression;
   "group-stage-star": BaseProgression;
   "full-house": MissingPlayersProgression;
   "humbled": MissingPlayersProgression;

--- a/frontend/src/common/achievement-progress.test.ts
+++ b/frontend/src/common/achievement-progress.test.ts
@@ -7,14 +7,15 @@ describe("achievementProgressPercentage", () => {
   });
 
   it("measures marathon-set from 11 instead of 0", () => {
-    // Best deuce set won of 13 against a league record of 15: 2 of 4 points.
-    expect(achievementProgressPercentage("marathon-set", 13, 15)).toBe(50);
-    expect(achievementProgressPercentage("marathon-set", 12, 15)).toBe(25);
-    expect(achievementProgressPercentage("marathon-set", 14, 15)).toBe(75);
+    // Best deuce set won of 13 with a target of 16 (one beyond the league
+    // record of 15): 2 of 5 points.
+    expect(achievementProgressPercentage("marathon-set", 13, 16)).toBe(40);
+    expect(achievementProgressPercentage("marathon-set", 12, 16)).toBe(20);
+    expect(achievementProgressPercentage("marathon-set", 14, 16)).toBe(60);
   });
 
-  it("gives marathon-set the record holder 100%", () => {
-    expect(achievementProgressPercentage("marathon-set", 14, 14)).toBe(100);
+  it("gives marathon-set 100% on reaching the target", () => {
+    expect(achievementProgressPercentage("marathon-set", 15, 15)).toBe(100);
   });
 
   it("gives 0% for marathon-set when the player has won no deuce set", () => {

--- a/frontend/src/common/achievement-progress.ts
+++ b/frontend/src/common/achievement-progress.ts
@@ -4,8 +4,8 @@
 //
 // Marathon Set compares winning scores from true-deuce sets: 11 is an ordinary
 // set win, and the chase only begins at 12. A player whose best deuce set was
-// 13, chasing a league record of 15, is 2 points into a 4-point gap — 50%, not
-// 13/15 = 87%. So the bar measures from 11 instead of 0.
+// 13, needing 16 to beat the league record of 15, is 2 points into a 5-point
+// gap — 40%, not 13/16 = 81%. So the bar measures from 11 instead of 0.
 const PROGRESS_BASELINES: Record<string, number> = {
   "marathon-set": 11,
 };

--- a/frontend/src/pages/achievements/achievements-list.tsx
+++ b/frontend/src/pages/achievements/achievements-list.tsx
@@ -199,6 +199,20 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                         : " (first league record!)"}
                     </span>
                   )}
+                  {achievement.type === "hero-of-the-day" && achievement.data && (
+                    <span className="text-[11px] opacity-80">
+                      {achievement.data.gamesPlayed} games in one day
+                      {achievement.data.previousRecord !== undefined
+                        ? ` (prev record ${achievement.data.previousRecord})`
+                        : " (first league record!)"}
+                    </span>
+                  )}
+                  {achievement.type === "back-from-the-dead" && achievement.data && (
+                    <span className="text-[11px] opacity-80">
+                      Retired for{" "}
+                      {Math.round((achievement.earnedAt - achievement.data.retiredAt) / (24 * 60 * 60 * 1000))} days
+                    </span>
+                  )}
                   {achievement.type === "king-maker" && achievement.data && (
                     <span className="text-[11px] opacity-80">
                       New king: {context.playerName(achievement.data.newKing)} (

--- a/frontend/src/pages/achievements/progress-list.tsx
+++ b/frontend/src/pages/achievements/progress-list.tsx
@@ -19,11 +19,14 @@ export const ProgressList: React.FC<ProgressListProps> = ({ selectedType }) => {
   const isTimePeriod =
     selectedType.startsWith("active-") || selectedType.startsWith("back-after-") || selectedType === "anniversary";
 
-  // Calculate progress for all players when a specific type is selected
+  // Calculate progress for all players when a specific type is selected.
+  // Retired players are included — their progress history is as real as
+  // anyone's — and tagged as retired in the list.
   const playersProgress = useMemo(() => {
     if (selectedType === "all") return [];
 
-    const players = context.players;
+    const activeIds = new Set(context.players.map((player) => player.id));
+    const players = context.allPlayers;
     return players
       .map((player) => {
         const progression = context.achievements.getPlayerProgression(player.id);
@@ -63,6 +66,7 @@ export const ProgressList: React.FC<ProgressListProps> = ({ selectedType }) => {
 
         return {
           player,
+          isRetired: !activeIds.has(player.id),
           current,
           target,
           percent,
@@ -75,7 +79,7 @@ export const ProgressList: React.FC<ProgressListProps> = ({ selectedType }) => {
         if (b.percent !== a.percent) return b.percent - a.percent;
         return b.current - a.current;
       });
-  }, [context.players, context.achievements, selectedType]);
+  }, [context.players, context.allPlayers, context.achievements, selectedType]);
 
   return (
     <div className="max-w-3xl mx-auto">
@@ -102,7 +106,7 @@ export const ProgressList: React.FC<ProgressListProps> = ({ selectedType }) => {
             </p>
           </div>
 
-            {playersProgress.map(({ player, current, target, percent, earned }, index) => {
+            {playersProgress.map(({ player, isRetired, current, target, percent, earned }, index) => {
               const hasEarned = earned > 0;
 
               return (
@@ -139,12 +143,19 @@ export const ProgressList: React.FC<ProgressListProps> = ({ selectedType }) => {
 
                     <div className="flex-1">
                       <div className="flex justify-between items-center mb-1">
-                        <Link
-                          to={`/player/${player.id}`}
-                          className="font-semibold hover:text-accent transition-colors"
-                        >
-                          {player.name}
-                        </Link>
+                        <div className="flex items-center gap-2">
+                          <Link
+                            to={`/player/${player.id}`}
+                            className="font-semibold hover:text-accent transition-colors"
+                          >
+                            {player.name}
+                          </Link>
+                          {isRetired && (
+                            <span className="bg-secondary-background text-secondary-text text-xs px-2 py-0.5 rounded-full font-normal shrink-0 ring-1 ring-primary-text/20">
+                              Retired
+                            </span>
+                          )}
+                        </div>
                         <span className="text-sm font-mono">
                            {isTimePeriod
                             ? `${formatTimePeriod(current)} / ${formatTimePeriod(target)}`

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -2,7 +2,12 @@ import { useEventDbContext } from "../../wrappers/event-db-context";
 import { relativeTimeString } from "../../common/date-utils";
 import { classNames } from "../../common/class-names";
 import { useState } from "react";
-import { Achievement, AchievementProgression, STREAK_RECORD_FLOOR } from "../../client/client-db/achievements";
+import {
+  Achievement,
+  AchievementProgression,
+  GAMES_IN_DAY_RECORD_FLOOR,
+  STREAK_RECORD_FLOOR,
+} from "../../client/client-db/achievements";
 import { Link } from "react-router-dom";
 import { fmtNum } from "../../common/number-utils";
 import { usePlayerLinkSearch } from "../../hooks/use-player-link-search";
@@ -255,6 +260,11 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
     description: "Win a deuce set with the highest winning score in league history",
     icon: "🏓",
   },
+  "hero-of-the-day": {
+    title: "Hero of the Day",
+    description: "Play more games in a single day than anyone in league history",
+    icon: "🦸",
+  },
   "streak-ender": {
     title: "Streak Ender",
     description: "Beat a player who was on an active 10+ game win streak",
@@ -494,6 +504,15 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
                 {achievement.type === "marathon-set" && achievement.data && (
                   <p className="text-xs text-secondary-text/70 mt-2">
                     Set score: {achievement.data.setWinnerScore}–{achievement.data.setLoserScore}
+                    {achievement.data.previousRecord !== undefined
+                      ? ` (previous record: ${achievement.data.previousRecord})`
+                      : " (first league record!)"}
+                  </p>
+                )}
+
+                {achievement.type === "hero-of-the-day" && achievement.data && (
+                  <p className="text-xs text-secondary-text/70 mt-2">
+                    {achievement.data.gamesPlayed} games on {dateString(achievement.data.day)}
                     {achievement.data.previousRecord !== undefined
                       ? ` (previous record: ${achievement.data.previousRecord})`
                       : " (first league record!)"}
@@ -898,6 +917,37 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                         </div>
                       )}
 
+                      {/* Record holder and personal best for hero-of-the-day.
+                          The bar tracks today's games, so the player's busiest
+                          day ever is spelt out separately. */}
+                      {type === "hero-of-the-day" && "recordHolder" in data && (
+                        <div className="mt-2 text-xs text-secondary-text/70 space-y-1">
+                          {"personalBest" in data && (
+                            <p>
+                              Your busiest day ever: {data.personalBest} game{data.personalBest !== 1 ? "s" : ""}
+                            </p>
+                          )}
+                          <p>
+                            {data.recordHolder ? (
+                              <>
+                                League record held by{" "}
+                                <Link to={{ pathname: "/player/" + data.recordHolder, search }}>
+                                  <span className="text-secondary-text underline">
+                                    {context.playerName(data.recordHolder)}
+                                  </span>
+                                </Link>
+                                . Play {data.target} games in one day to take it.
+                              </>
+                            ) : (
+                              <>
+                                No record set yet — play {GAMES_IN_DAY_RECORD_FLOOR} games in one day to start the
+                                record.
+                              </>
+                            )}
+                          </p>
+                        </div>
+                      )}
+
                       {/* Record holder and personal best for the streak records.
                           The bar tracks the live streak, so the player's longest
                           ever run is spelt out separately. */}
@@ -945,6 +995,11 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                     <div className="mt-2 text-xs text-secondary-text/70">
                       No league record yet — {type === "longest-win-streak" ? "win" : "lose"}{" "}
                       {STREAK_RECORD_FLOOR} in a row to set the first record.
+                    </div>
+                  ) : type === "hero-of-the-day" ? (
+                    <div className="mt-2 text-xs text-secondary-text/70">
+                      No league record yet — play {GAMES_IN_DAY_RECORD_FLOOR} games in one day to set the first
+                      record.
                     </div>
                   ) : type === "earliest-game" || type === "latest-game" ? (
                     <div className="mt-2 text-xs text-secondary-text/70 space-y-1">

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -91,9 +91,19 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
     icon: "🙈",
   },
   "back-after-2-years": {
-    title: "Back From The Dead",
+    title: "A Cinderella Story",
     description: "Return after 2 years of inactivity",
-    icon: "💀",
+    icon: "👸",
+  },
+  "retired": {
+    title: "Retired",
+    description: "Retire from the league",
+    icon: "🪦",
+  },
+  "back-from-the-dead": {
+    title: "Back From The Dead",
+    description: "Come back to the league after retiring",
+    icon: "🧟",
   },
   "active-6-months": {
     title: "Regular",
@@ -533,6 +543,13 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
                     </p>
                   )}
 
+                {achievement.type === "back-from-the-dead" && achievement.data && (
+                  <p className="text-xs text-secondary-text/70 mt-2">
+                    Retired for {daysBetween(achievement.data.retiredAt, achievement.earnedAt)} day
+                    {daysBetween(achievement.data.retiredAt, achievement.earnedAt) !== 1 ? "s" : ""}
+                  </p>
+                )}
+
                 {achievement.type === "perfect-day" && achievement.data && (
                   <p className="text-xs text-secondary-text/70 mt-2">
                     {achievement.data.wins} wins, 0 losses on {dateString(achievement.data.day)}
@@ -854,7 +871,7 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                                   {context.playerName(data.recordHolder)}
                                 </span>
                               </Link>
-                              . Beat {data.target} to take it.
+                              . Win a deuce set at {data.target} or higher to take it.
                             </>
                           ) : (
                             <>No record set yet — win a deuce set above 11 to start the record.</>
@@ -873,7 +890,7 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                                   {context.playerName(data.recordHolder)}
                                 </span>
                               </Link>
-                              . Jump more than {data.target} rank{data.target !== 1 ? "s" : ""} in one game to take it.
+                              . Jump {data.target} or more ranks in one game to take it.
                             </>
                           ) : (
                             <>No record set yet — jump 2 or more ranks in a single game to start the record.</>
@@ -902,8 +919,8 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                                       {context.playerName(data.recordHolder)}
                                     </span>
                                   </Link>
-                                  . {type === "longest-win-streak" ? "Win" : "Lose"} {(data.target ?? 0) + 1} in a
-                                  row to take it.
+                                  . {type === "longest-win-streak" ? "Win" : "Lose"} {data.target} in a row to
+                                  take it.
                                 </>
                               ) : (
                                 <>


### PR DESCRIPTION
Record-chasing achievements (Longest Win/Lose Streak, Marathon Set,
Leap Frog) are earned by strictly exceeding the league record, but their
progression target was the record itself - tying it read as 100% without
earning anything. Targets are now one beyond the record, and the UI copy
and marathon-set baseline math follow suit.

Also:
- New "Retired" achievement, awarded on every retirement.
- New "Back From The Dead" achievement for returning from retirement,
  recording how long the player was gone. The 2-year comeback
  achievement that held this name is renamed "A Cinderella Story".
- Everyone's Progress on the achievements page now includes retired
  players, tagged with a Retired badge.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Tp3oNtA5xCAGegdKu2U77J