### PR TITLE
Add player filter dropdown to admin Top Gaming periods widget

### DIFF
--- a/frontend/src/pages/admin/admin-page.tsx
+++ b/frontend/src/pages/admin/admin-page.tsx
@@ -17,6 +17,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { GamesPerMonthChart } from "./games-per-month";
 import { GamesPerWeekChart } from "./games-per-week";
 import { TopGamingDays } from "./top-days";
+import { TopPlayers } from "./top-players";
 import { TopPlayerPairings } from "./top-player-pairings";
 import { GamesPerWeekdayChart } from "./games-weekdays";
 import { GamesPerTimeChart } from "./hour-of-the-day";
@@ -203,6 +204,7 @@ export const AdminPage: React.FC = () => {
           <GamesPerWeekdayChart />
           <GamesPerTimeChart />
           <TopGamingDays />
+          <TopPlayers />
           <TopPlayerPairings />
           <PlayerDiversityChart />
           <h2>Total distribution of games played</h2>

--- a/frontend/src/pages/admin/period-utils.ts
+++ b/frontend/src/pages/admin/period-utils.ts
@@ -1,0 +1,103 @@
+export type Period = "day" | "week" | "month" | "year";
+
+export const PERIOD_LABELS: Record<Period, { singular: string; plural: string }> = {
+  day: { singular: "Day", plural: "Days" },
+  week: { singular: "Week", plural: "Weeks" },
+  month: { singular: "Month", plural: "Months" },
+  year: { singular: "Year", plural: "Years" },
+};
+
+const getWeekStart = (date: Date): Date => {
+  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const day = d.getDay();
+  const diff = day === 0 ? -6 : 1 - day; // Monday as start of week
+  d.setDate(d.getDate() + diff);
+  return d;
+};
+
+const getISOWeek = (date: Date): number => {
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNum = d.getUTCDay() || 7;
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+};
+
+export const getPeriodKey = (date: Date, period: Period): string => {
+  switch (period) {
+    case "day":
+      return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+    case "week": {
+      const ws = getWeekStart(date);
+      return `W-${ws.getFullYear()}-${String(ws.getMonth() + 1).padStart(2, "0")}-${String(ws.getDate()).padStart(2, "0")}`;
+    }
+    case "month":
+      return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+    case "year":
+      return String(date.getFullYear());
+  }
+};
+
+export const getPeriodTimestamp = (date: Date, period: Period): number => {
+  switch (period) {
+    case "day":
+      return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+    case "week":
+      return getWeekStart(date).getTime();
+    case "month":
+      return new Date(date.getFullYear(), date.getMonth(), 1).getTime();
+    case "year":
+      return new Date(date.getFullYear(), 0, 1).getTime();
+  }
+};
+
+export const getPeriodStart = (date: Date, period: Period): Date => new Date(getPeriodTimestamp(date, period));
+
+export const advancePeriod = (date: Date, period: Period): Date => {
+  const d = new Date(date);
+  switch (period) {
+    case "day":
+      d.setDate(d.getDate() + 1);
+      break;
+    case "week":
+      d.setDate(d.getDate() + 7);
+      break;
+    case "month":
+      d.setMonth(d.getMonth() + 1);
+      break;
+    case "year":
+      d.setFullYear(d.getFullYear() + 1);
+      break;
+  }
+  return d;
+};
+
+export const formatPeriod = (timestamp: number, period: Period): string => {
+  const date = new Date(timestamp);
+  switch (period) {
+    case "day":
+      return date.toLocaleDateString("nb-NO", {
+        weekday: "long",
+        month: "long",
+        day: "numeric",
+        year: "numeric",
+      });
+    case "week": {
+      const weekEnd = new Date(date);
+      weekEnd.setDate(weekEnd.getDate() + 6);
+      const weekNumber = getISOWeek(date);
+      const startStr = date.toLocaleDateString("nb-NO", { day: "numeric", month: "short" });
+      const endStr = weekEnd.toLocaleDateString("nb-NO", { day: "numeric", month: "short" });
+      return `Week ${weekNumber}, ${date.getFullYear()} (${startStr} – ${endStr})`;
+    }
+    case "month":
+      return date.toLocaleDateString("nb-NO", {
+        month: "long",
+        year: "numeric",
+      });
+    case "year":
+      return String(date.getFullYear());
+  }
+};
+
+export const pairingKey = (playerA: string, playerB: string): string => [playerA, playerB].sort().join("|");

--- a/frontend/src/pages/admin/top-days.tsx
+++ b/frontend/src/pages/admin/top-days.tsx
@@ -30,6 +30,14 @@ const METRIC_LABELS: Record<Metric, { option: string; column: string }> = {
   achievements: { option: "Achievements earned", column: "Achievements" },
 };
 
+// With a single player selected, "active players" in their games means their unique
+// opponents, and "pairings" would count the exact same thing — so it is not offered.
+const PLAYER_METRIC_LABELS: Record<Exclude<Metric, "pairings">, { option: string; column: string }> = {
+  games: { option: "Games played", column: "Games" },
+  activePlayers: { option: "Unique opponents", column: "Opponents" },
+  achievements: { option: "Achievements earned", column: "Achievements" },
+};
+
 const PERIOD_LABELS: Record<Period, { singular: string; plural: string }> = {
   day: { singular: "Day", plural: "Days" },
   week: { singular: "Week", plural: "Weeks" },
@@ -182,11 +190,12 @@ const addGameToBucket = (
   timestamp: number,
   winner: string,
   loser: string,
+  excludedPlayer: string | null,
 ) => {
   const bucket = getBucket(map, key, timestamp);
   bucket.games++;
-  bucket.players.add(winner);
-  bucket.players.add(loser);
+  if (winner !== excludedPlayer) bucket.players.add(winner);
+  if (loser !== excludedPlayer) bucket.players.add(loser);
   bucket.pairings.add(pairingKey(winner, loser));
 };
 
@@ -211,6 +220,12 @@ export const TopGamingDays: React.FC = () => {
   const context = useEventDbContext();
   const [period, setPeriod] = useState<Period>("day");
   const [metric, setMetric] = useState<Metric>("games");
+  const [playerId, setPlayerId] = useState<string>("");
+
+  const players = useMemo(
+    () => [...context.allPlayers].sort((a, b) => a.name.localeCompare(b.name)),
+    [context],
+  );
 
   const recentCutoff = useMemo(() => Date.now() - RECENT_WINDOW_MS[period], [period]);
 
@@ -218,16 +233,23 @@ export const TopGamingDays: React.FC = () => {
 
   const { topAllTime, topRecent } = useMemo(() => {
     const empty: TopPeriodsResult = { top: [], current: null };
-    if (context.games.length === 0) {
+    const games = playerId
+      ? context.games.filter(({ winner, loser }) => winner === playerId || loser === playerId)
+      : context.games;
+    if (games.length === 0) {
       return { topAllTime: empty, topRecent: empty };
     }
 
     const allTimeBuckets = new Map<string, PeriodBucket>();
     const recentBuckets = new Map<string, PeriodBucket>();
 
+    // The selected player is in every one of their games, so counting them as an
+    // "active player" would only shift the opponent count by one.
+    const excludedPlayer = playerId || null;
+
     let earliestPlayedAt = Infinity;
 
-    context.games.forEach(({ playedAt, winner, loser }) => {
+    games.forEach(({ playedAt, winner, loser }) => {
       if (playedAt < earliestPlayedAt) {
         earliestPlayedAt = playedAt;
       }
@@ -236,10 +258,10 @@ export const TopGamingDays: React.FC = () => {
       const key = getPeriodKey(date, period);
       const timestamp = getPeriodTimestamp(date, period);
 
-      addGameToBucket(allTimeBuckets, key, timestamp, winner, loser);
+      addGameToBucket(allTimeBuckets, key, timestamp, winner, loser, excludedPlayer);
 
       if (playedAt >= recentCutoff) {
-        addGameToBucket(recentBuckets, key, timestamp, winner, loser);
+        addGameToBucket(recentBuckets, key, timestamp, winner, loser, excludedPlayer);
       }
     });
 
@@ -248,7 +270,10 @@ export const TopGamingDays: React.FC = () => {
     // since calculating them the first time is expensive.
     if (metric === "achievements") {
       context.achievements.calculateAchievements();
-      context.achievements.achievementMap.forEach((playerAchievements) => {
+      context.achievements.achievementMap.forEach((playerAchievements, achievementPlayerId) => {
+        if (playerId && achievementPlayerId !== playerId) {
+          return;
+        }
         playerAchievements.forEach(({ earnedAt }) => {
           const date = new Date(earnedAt);
           const key = getPeriodKey(date, period);
@@ -302,10 +327,10 @@ export const TopGamingDays: React.FC = () => {
       topAllTime: buildResult(allTimeBuckets),
       topRecent: buildResult(recentBuckets),
     };
-  }, [context.games, context.achievements, period, metric, recentCutoff, currentKey]);
+  }, [context.games, context.achievements, period, metric, playerId, recentCutoff, currentKey]);
 
   const periodLabel = PERIOD_LABELS[period];
-  const metricLabel = METRIC_LABELS[metric];
+  const metricLabel = playerId && metric !== "pairings" ? PLAYER_METRIC_LABELS[metric] : METRIC_LABELS[metric];
 
   if (context.games.length === 0) {
     return (
@@ -408,14 +433,36 @@ export const TopGamingDays: React.FC = () => {
         <h2 className="text-lg font-semibold">Top Gaming {periodLabel.plural}</h2>
         <div className="flex flex-wrap items-center gap-2">
           <select
+            value={playerId}
+            onChange={(e) => {
+              const newPlayerId = e.target.value;
+              // Pairings is not offered per player (it equals unique opponents there),
+              // so fall over to the closest metric instead of an invalid selection.
+              if (newPlayerId && metric === "pairings") {
+                setMetric("activePlayers");
+              }
+              setPlayerId(newPlayerId);
+            }}
+            aria-label="Filter by player"
+            className="px-2 py-1 text-xs border rounded border-primary-text/20 bg-primary-background max-w-40"
+          >
+            <option value="">All players</option>
+            {players.map((player) => (
+              <option key={player.id} value={player.id}>
+                {player.name}
+                {player.active ? "" : " (deactivated)"}
+              </option>
+            ))}
+          </select>
+          <select
             value={metric}
             onChange={(e) => setMetric(e.target.value as Metric)}
             aria-label="Metric to count"
             className="px-2 py-1 text-xs border rounded border-primary-text/20 bg-primary-background"
           >
-            {(Object.keys(METRIC_LABELS) as Metric[]).map((m) => (
+            {(Object.keys(playerId ? PLAYER_METRIC_LABELS : METRIC_LABELS) as Metric[]).map((m) => (
               <option key={m} value={m}>
-                {METRIC_LABELS[m].option}
+                {(playerId && m !== "pairings" ? PLAYER_METRIC_LABELS[m] : METRIC_LABELS[m]).option}
               </option>
             ))}
           </select>

--- a/frontend/src/pages/admin/top-days.tsx
+++ b/frontend/src/pages/admin/top-days.tsx
@@ -1,8 +1,16 @@
 import React, { useMemo, useState } from "react";
 import { useEventDbContext } from "../../wrappers/event-db-context";
 import { relativeTimeString } from "../../common/date-utils";
-
-type Period = "day" | "week" | "month" | "year";
+import {
+  Period,
+  PERIOD_LABELS,
+  getPeriodKey,
+  getPeriodTimestamp,
+  getPeriodStart,
+  advancePeriod,
+  formatPeriod,
+  pairingKey,
+} from "./period-utils";
 
 type Metric = "games" | "activePlayers" | "pairings" | "achievements";
 
@@ -38,13 +46,6 @@ const PLAYER_METRIC_LABELS: Record<Exclude<Metric, "pairings">, { option: string
   achievements: { option: "Achievements earned", column: "Achievements" },
 };
 
-const PERIOD_LABELS: Record<Period, { singular: string; plural: string }> = {
-  day: { singular: "Day", plural: "Days" },
-  week: { singular: "Week", plural: "Weeks" },
-  month: { singular: "Month", plural: "Months" },
-  year: { singular: "Year", plural: "Years" },
-};
-
 const RECENT_WINDOW_MS: Record<Period, number> = {
   day: 6 * 30 * 24 * 60 * 60 * 1000, // 6 months
   week: 365 * 24 * 60 * 60 * 1000, // 1 year
@@ -57,99 +58,6 @@ const RECENT_WINDOW_LABELS: Record<Period, string> = {
   week: "Last Year",
   month: "Last 2 Years",
   year: "Last 10 Years",
-};
-
-const getWeekStart = (date: Date): Date => {
-  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
-  const day = d.getDay();
-  const diff = day === 0 ? -6 : 1 - day; // Monday as start of week
-  d.setDate(d.getDate() + diff);
-  return d;
-};
-
-const getISOWeek = (date: Date): number => {
-  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
-  const dayNum = d.getUTCDay() || 7;
-  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
-  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-  return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
-};
-
-const getPeriodKey = (date: Date, period: Period): string => {
-  switch (period) {
-    case "day":
-      return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
-    case "week": {
-      const ws = getWeekStart(date);
-      return `W-${ws.getFullYear()}-${String(ws.getMonth() + 1).padStart(2, "0")}-${String(ws.getDate()).padStart(2, "0")}`;
-    }
-    case "month":
-      return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
-    case "year":
-      return String(date.getFullYear());
-  }
-};
-
-const getPeriodTimestamp = (date: Date, period: Period): number => {
-  switch (period) {
-    case "day":
-      return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
-    case "week":
-      return getWeekStart(date).getTime();
-    case "month":
-      return new Date(date.getFullYear(), date.getMonth(), 1).getTime();
-    case "year":
-      return new Date(date.getFullYear(), 0, 1).getTime();
-  }
-};
-
-const getPeriodStart = (date: Date, period: Period): Date => new Date(getPeriodTimestamp(date, period));
-
-const advancePeriod = (date: Date, period: Period): Date => {
-  const d = new Date(date);
-  switch (period) {
-    case "day":
-      d.setDate(d.getDate() + 1);
-      break;
-    case "week":
-      d.setDate(d.getDate() + 7);
-      break;
-    case "month":
-      d.setMonth(d.getMonth() + 1);
-      break;
-    case "year":
-      d.setFullYear(d.getFullYear() + 1);
-      break;
-  }
-  return d;
-};
-
-const formatPeriod = (timestamp: number, period: Period): string => {
-  const date = new Date(timestamp);
-  switch (period) {
-    case "day":
-      return date.toLocaleDateString("nb-NO", {
-        weekday: "long",
-        month: "long",
-        day: "numeric",
-        year: "numeric",
-      });
-    case "week": {
-      const weekEnd = new Date(date);
-      weekEnd.setDate(weekEnd.getDate() + 6);
-      const weekNumber = getISOWeek(date);
-      const startStr = date.toLocaleDateString("nb-NO", { day: "numeric", month: "short" });
-      const endStr = weekEnd.toLocaleDateString("nb-NO", { day: "numeric", month: "short" });
-      return `Week ${weekNumber}, ${date.getFullYear()} (${startStr} – ${endStr})`;
-    }
-    case "month":
-      return date.toLocaleDateString("nb-NO", {
-        month: "long",
-        year: "numeric",
-      });
-    case "year":
-      return String(date.getFullYear());
-  }
 };
 
 /**
@@ -172,8 +80,6 @@ const emptyBucket = (timestamp: number): PeriodBucket => ({
   pairings: new Set(),
   achievements: 0,
 });
-
-const pairingKey = (playerA: string, playerB: string): string => [playerA, playerB].sort().join("|");
 
 const getBucket = (map: Map<string, PeriodBucket>, key: string, timestamp: number): PeriodBucket => {
   let bucket = map.get(key);

--- a/frontend/src/pages/admin/top-players.tsx
+++ b/frontend/src/pages/admin/top-players.tsx
@@ -1,0 +1,229 @@
+import React, { useMemo, useState } from "react";
+import { useEventDbContext } from "../../wrappers/event-db-context";
+import { relativeTimeString } from "../../common/date-utils";
+import { Period, PERIOD_LABELS, getPeriodKey, getPeriodTimestamp, formatPeriod, pairingKey } from "./period-utils";
+
+type Metric = "games" | "pairings" | "achievements";
+
+const METRIC_LABELS: Record<Metric, { option: string; column: string }> = {
+  games: { option: "Games played", column: "Games" },
+  pairings: { option: "Player pairings", column: "Pairings" },
+  achievements: { option: "Achievements earned", column: "Achievements" },
+};
+
+interface PlayerBucket {
+  key: string;
+  timestamp: number;
+  games: number;
+  pairings: Set<string>;
+  achievements: number;
+}
+
+interface PlayerBestEntry {
+  playerId: string;
+  key: string;
+  timestamp: number;
+  count: number;
+}
+
+const bucketCount = (bucket: PlayerBucket, metric: Metric): number => {
+  switch (metric) {
+    case "games":
+      return bucket.games;
+    case "pairings":
+      return bucket.pairings.size;
+    case "achievements":
+      return bucket.achievements;
+  }
+};
+
+export const TopPlayers: React.FC = () => {
+  const context = useEventDbContext();
+  const [period, setPeriod] = useState<Period>("day");
+  const [metric, setMetric] = useState<Metric>("games");
+
+  const currentKey = useMemo(() => getPeriodKey(new Date(), period), [period]);
+
+  const inactivePlayerIds = useMemo(
+    () => new Set(context.allPlayers.filter((player) => !player.active).map((player) => player.id)),
+    [context],
+  );
+
+  const rows = useMemo(() => {
+    const playerBuckets = new Map<string, Map<string, PlayerBucket>>();
+
+    const getBucket = (playerId: string, key: string, timestamp: number): PlayerBucket => {
+      let buckets = playerBuckets.get(playerId);
+      if (!buckets) {
+        buckets = new Map();
+        playerBuckets.set(playerId, buckets);
+      }
+      let bucket = buckets.get(key);
+      if (!bucket) {
+        bucket = { key, timestamp, games: 0, pairings: new Set(), achievements: 0 };
+        buckets.set(key, bucket);
+      }
+      return bucket;
+    };
+
+    if (metric === "achievements") {
+      // Achievements carry their own earnedAt and are expensive to calculate,
+      // so they are only projected when they are the selected metric.
+      context.achievements.calculateAchievements();
+      context.achievements.achievementMap.forEach((playerAchievements, playerId) => {
+        playerAchievements.forEach(({ earnedAt }) => {
+          const date = new Date(earnedAt);
+          getBucket(playerId, getPeriodKey(date, period), getPeriodTimestamp(date, period)).achievements++;
+        });
+      });
+    } else {
+      context.games.forEach(({ playedAt, winner, loser }) => {
+        const date = new Date(playedAt);
+        const key = getPeriodKey(date, period);
+        const timestamp = getPeriodTimestamp(date, period);
+        const pairing = pairingKey(winner, loser);
+
+        for (const playerId of [winner, loser]) {
+          const bucket = getBucket(playerId, key, timestamp);
+          bucket.games++;
+          bucket.pairings.add(pairing);
+        }
+      });
+    }
+
+    const best: PlayerBestEntry[] = [];
+    playerBuckets.forEach((buckets, playerId) => {
+      let bestEntry: PlayerBestEntry | null = null;
+      for (const bucket of Array.from(buckets.values())) {
+        const count = bucketCount(bucket, metric);
+        // Highest count wins, ties broken in favour of the earlier period.
+        if (
+          !bestEntry ||
+          count > bestEntry.count ||
+          (count === bestEntry.count && bucket.timestamp < bestEntry.timestamp)
+        ) {
+          bestEntry = { playerId, key: bucket.key, timestamp: bucket.timestamp, count };
+        }
+      }
+      if (bestEntry !== null && bestEntry.count > 0) {
+        best.push(bestEntry);
+      }
+    });
+
+    return best.sort(
+      (a, b) =>
+        b.count - a.count ||
+        a.timestamp - b.timestamp ||
+        context.playerName(a.playerId).localeCompare(context.playerName(b.playerId)),
+    );
+  }, [context, metric, period]);
+
+  const periodLabel = PERIOD_LABELS[period];
+  const metricLabel = METRIC_LABELS[metric];
+  const maxCount = rows.length > 0 ? rows[0].count : 0;
+  const hasCurrent = rows.some((row) => row.key === currentKey);
+
+  return (
+    <div className="bg-primary-background text-primary-text rounded-lg p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
+        <h2 className="text-lg font-semibold">Top Players</h2>
+        <div className="flex flex-wrap items-center gap-2">
+          <select
+            value={metric}
+            onChange={(e) => setMetric(e.target.value as Metric)}
+            aria-label="Metric to count"
+            className="px-2 py-1 text-xs border rounded border-primary-text/20 bg-primary-background"
+          >
+            {(Object.keys(METRIC_LABELS) as Metric[]).map((m) => (
+              <option key={m} value={m}>
+                {METRIC_LABELS[m].option}
+              </option>
+            ))}
+          </select>
+          <div className="flex gap-1" role="tablist" aria-label="Group by period">
+            {(Object.keys(PERIOD_LABELS) as Period[]).map((p) => (
+              <button
+                key={p}
+                type="button"
+                role="tab"
+                aria-selected={period === p}
+                onClick={() => setPeriod(p)}
+                className={`px-3 py-1 text-xs rounded border border-primary-text/20 transition-colors ${
+                  period === p
+                    ? "bg-secondary-background text-secondary-text font-semibold"
+                    : "bg-primary-background hover:bg-secondary-background/50"
+                }`}
+              >
+                {PERIOD_LABELS[p].plural}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+      <p className="text-xs text-primary-text/70 mb-2">
+        Each player's best {periodLabel.singular.toLowerCase()} by {metricLabel.option.toLowerCase()}.
+      </p>
+      {rows.length === 0 ? (
+        <div className="text-center text-primary-text p-4 bg-secondary-background rounded-lg text-xs">
+          No data available
+        </div>
+      ) : (
+        <table className="w-full text-xs border-collapse">
+          <thead>
+            <tr className="bg-secondary-background text-secondary-text">
+              <th className="px-2 py-1 text-left border border-primary-text/20">#</th>
+              <th className="px-2 py-1 text-left border border-primary-text/20">Player</th>
+              <th className="px-2 py-1 text-left border border-primary-text/20">Best {periodLabel.singular}</th>
+              <th className="px-2 py-1 text-left border border-primary-text/20">When</th>
+              <th className="px-2 py-1 text-right border border-primary-text/20">{metricLabel.column}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, index) => {
+              const isCurrent = row.key === currentKey;
+              const countPercent = maxCount > 0 ? Math.max(0, Math.min(100, (row.count / maxCount) * 100)) : 0;
+
+              return (
+                <tr
+                  key={row.playerId}
+                  className={
+                    isCurrent ? "bg-tertiary-background text-tertiary-text" : "hover:bg-secondary-background/50"
+                  }
+                >
+                  <td className="px-2 py-1 border border-primary-text/20 font-medium whitespace-nowrap">
+                    {index + 1}
+                  </td>
+                  <td className="px-2 py-1 border border-primary-text/20 whitespace-nowrap">
+                    {context.playerName(row.playerId)}
+                    {inactivePlayerIds.has(row.playerId) && (
+                      <span className="text-primary-text/50"> (deactivated)</span>
+                    )}
+                  </td>
+                  <td className="px-2 py-1 border border-primary-text/20 whitespace-nowrap">
+                    {formatPeriod(row.timestamp, period)}
+                  </td>
+                  <td className="px-2 py-1 border border-primary-text/20 whitespace-nowrap">
+                    {relativeTimeString(new Date(row.timestamp))}
+                  </td>
+                  <td className="px-2 py-1 border border-primary-text/20 text-right font-bold relative overflow-hidden">
+                    {row.count}
+                    <div
+                      className={`absolute bottom-0 left-0 h-[2px] ${isCurrent ? "bg-tertiary-text" : "bg-current"}`}
+                      style={{ width: `${countPercent}%` }}
+                    />
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+      {hasCurrent && (
+        <div className="mt-3 text-xs flex items-center gap-2">
+          <span className="inline-block w-3 h-3 rounded-sm bg-tertiary-background border border-primary-text/20" />
+          <span>Best {periodLabel.singular.toLowerCase()} is the current {periodLabel.singular.toLowerCase()}</span>
+        </div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
A single-select dropdown filters the top periods to games involving one
player. With a player selected, "Active players" becomes their unique
opponents, and "Player pairings" is not offered since it would count the
same thing.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017SZwZkNSzhKjryrKTeuJyj