### PR TITLE
Add Hero of the Week and Hero of the Month achievements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,9 @@ to end up knowing something useful. When it is a close call, skip it.
 - Slugs are permalinks - do not change one once it has shipped.
 - It is a static content list and needs no tests.
 
-The page is at `/changelog` and is intentionally **not** in the nav menu yet -
-reachable by direct url only until the navigation structure is reworked.
+The page is at `/changelog`. Until the navigation structure is reworked it is
+only in the nav menu for logged-in admins - everyone else reaches it by direct
+url.
 
 ## Context Files
 - Root Instructions: `./GEMINI.md`

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -31,6 +31,26 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "hero-of-the-week-and-month-achievements",
+    title: "2 new achievements: Hero of the Week and Hero of the Month",
+    date: "2026-08-03",
+    tags: ["new-feature"],
+    summary:
+      "Hero of the Week 🦸‍♂️ and Hero of the Month 🦸‍♀️ extend the Hero of the Day record to bigger periods: the most games played in a single week and in a single calendar month.",
+    body: [
+      list(
+        "Hero of the Week 🦸‍♂️ - the league record for most games played in a single week (Monday to Sunday). The first week with 10 games sets the record.",
+        "Hero of the Month 🦸‍♀️ - the league record for most games played in a single calendar month. The first month with 20 games sets the record.",
+      ),
+      text(
+        "Both work exactly like Hero of the Day: they are records that are held, not just earned. Wins and losses both count, one award grows with the whole record period, and only a strictly busier week or month takes the record over. The three records run independently - a monster day feeds its week's and month's counts too.",
+      ),
+      text(
+        "The progress view shows your current week and month against the records, your busiest ever, and who holds them.",
+      ),
+    ],
+  },
+  {
     slug: "hero-of-the-day-achievement",
     title: "New achievement: Hero of the Day",
     date: "2026-08-03",

--- a/frontend/src/client/client-db/__tests__/achievements/hero-of-the-week-and-month.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/hero-of-the-week-and-month.test.ts
@@ -1,0 +1,254 @@
+import { Achievement, GAMES_IN_MONTH_RECORD_FLOOR, GAMES_IN_WEEK_RECORD_FLOOR } from "../../achievements";
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { TennisTable } from "../../tennis-table";
+
+type GameSpec = { winner: string; loser: string; playedAt: number };
+
+// Timestamps anchored to local noon so every game stays inside its intended
+// calendar day regardless of the timezone the tests run in — the achievements
+// bucket games by local midnight. January 2024 starts on a Monday, so day 1–7
+// is one week, day 8 starts the next, and day 32 rolls into February.
+function at(day: number, minute: number): number {
+  return new Date(2024, 0, day, 12, minute).getTime();
+}
+
+function eventsForGames(games: GameSpec[]): EventType[] {
+  const players = Array.from(new Set(games.flatMap((game) => [game.winner, game.loser])));
+  return [
+    ...players.map<EventType>((player, index) => ({
+      type: EventTypeEnum.PLAYER_CREATED,
+      stream: player,
+      time: index + 1,
+      data: { name: player },
+    })),
+    ...games.map<EventType>((game, index) => ({
+      type: EventTypeEnum.GAME_CREATED,
+      stream: `g${index}`,
+      time: game.playedAt,
+      data: { winner: game.winner, loser: game.loser, playedAt: game.playedAt },
+    })),
+  ];
+}
+
+function calculate(games: GameSpec[]): TennisTable {
+  const tt = new TennisTable({ events: eventsForGames(games) });
+  tt.achievements.calculateAchievements();
+  return tt;
+}
+
+function weekAwards(tt: TennisTable, player: string): Extract<Achievement, { type: "hero-of-the-week" }>[] {
+  return tt.achievements
+    .getAchievements(player)
+    .filter(
+      (achievement): achievement is Extract<Achievement, { type: "hero-of-the-week" }> =>
+        achievement.type === "hero-of-the-week",
+    );
+}
+
+function monthAwards(tt: TennisTable, player: string): Extract<Achievement, { type: "hero-of-the-month" }>[] {
+  return tt.achievements
+    .getAchievements(player)
+    .filter(
+      (achievement): achievement is Extract<Achievement, { type: "hero-of-the-month" }> =>
+        achievement.type === "hero-of-the-month",
+    );
+}
+
+/** `count` games between the two players on `day`, all won by `winner`. */
+function gamesOnDay(day: number, winner: string, loser: string, count: number, fromMinute = 0): GameSpec[] {
+  return Array.from({ length: count }, (_, index) => ({
+    winner,
+    loser,
+    playedAt: at(day, fromMinute + index),
+  }));
+}
+
+describe("Hero of the Week achievement", () => {
+  it("does not establish a record below the floor", () => {
+    // 9 games spread over two days of the same week — one short of the floor.
+    const tt = calculate([
+      ...gamesOnDay(1, "alice", "bob", 4),
+      ...gamesOnDay(3, "alice", "bob", GAMES_IN_WEEK_RECORD_FLOOR - 5),
+    ]);
+
+    expect(weekAwards(tt, "alice")).toHaveLength(0);
+    expect(weekAwards(tt, "bob")).toHaveLength(0);
+    expect(tt.achievements.gamesInWeekRecord).toStrictEqual({ count: undefined, holder: undefined });
+  });
+
+  it("establishes the first record accumulated across the days of a week, tie going to the winner", () => {
+    // 5 games on Monday + 5 on Wednesday reach the floor of 10 mid-week.
+    const tt = calculate([...gamesOnDay(1, "alice", "bob", 5), ...gamesOnDay(3, "alice", "bob", 5)]);
+
+    const aliceAwards = weekAwards(tt, "alice");
+    expect(aliceAwards).toHaveLength(1);
+    expect(aliceAwards[0]).toStrictEqual({
+      type: "hero-of-the-week",
+      earnedBy: "alice",
+      earnedAt: at(3, 4),
+      data: {
+        weekStart: new Date(2024, 0, 1).getTime(),
+        gamesPlayed: GAMES_IN_WEEK_RECORD_FLOOR,
+        previousRecord: undefined,
+      },
+    });
+    expect(weekAwards(tt, "bob")).toHaveLength(0);
+    expect(tt.achievements.gamesInWeekRecord).toStrictEqual({
+      count: GAMES_IN_WEEK_RECORD_FLOOR,
+      holder: "alice",
+    });
+  });
+
+  it("grows a single award as the record week continues instead of awarding per game", () => {
+    const tt = calculate([...gamesOnDay(1, "alice", "bob", 6), ...gamesOnDay(5, "alice", "bob", 6)]);
+
+    const aliceAwards = weekAwards(tt, "alice");
+    expect(aliceAwards).toHaveLength(1);
+    expect(aliceAwards[0].data.gamesPlayed).toBe(12);
+    expect(aliceAwards[0].earnedAt).toBe(at(5, 5));
+    expect(tt.achievements.gamesInWeekRecord).toStrictEqual({ count: 12, holder: "alice" });
+  });
+
+  it("resets the count at the week boundary and requires strictly beating the record", () => {
+    const tt = calculate([
+      // Week of Jan 1: record set at 10.
+      ...gamesOnDay(1, "alice", "bob", 10),
+      // Week of Jan 8: 10 games only tie the record — no award...
+      ...gamesOnDay(8, "alice", "bob", 10),
+      // ...an 11th game in the same week takes it.
+      { winner: "alice", loser: "bob", playedAt: at(9, 0) },
+    ]);
+
+    const aliceAwards = weekAwards(tt, "alice");
+    expect(aliceAwards).toHaveLength(2);
+    expect(aliceAwards[1].data).toStrictEqual({
+      weekStart: new Date(2024, 0, 8).getTime(),
+      gamesPlayed: 11,
+      previousRecord: 10,
+    });
+    expect(weekAwards(tt, "bob")).toHaveLength(0);
+    expect(tt.achievements.gamesInWeekRecord).toStrictEqual({ count: 11, holder: "alice" });
+  });
+
+  it("reports busiest week, league record and earned count in the progression", () => {
+    const tt = calculate([
+      ...gamesOnDay(1, "alice", "bob", 10),
+      ...gamesOnDay(8, "alice", "bob", 6),
+      ...gamesOnDay(9, "alice", "bob", 7),
+    ]);
+
+    const alice = tt.achievements.getPlayerProgression("alice")["hero-of-the-week"];
+    expect(alice.current).toBe(0); // no games this week
+    expect(alice.personalBest).toBe(13);
+    expect(alice.target).toBe(14); // one beyond the record of 13
+    expect(alice.recordHolder).toBe("alice");
+    expect(alice.earned).toBe(2);
+
+    const bob = tt.achievements.getPlayerProgression("bob")["hero-of-the-week"];
+    expect(bob.personalBest).toBe(13);
+    expect(bob.target).toBe(14);
+    expect(bob.recordHolder).toBe("alice");
+    expect(bob.earned).toBe(0);
+  });
+
+  it("leaves the progression target unset until someone holds the record", () => {
+    const tt = calculate(gamesOnDay(1, "alice", "bob", GAMES_IN_WEEK_RECORD_FLOOR - 1));
+
+    const progression = tt.achievements.getPlayerProgression("alice")["hero-of-the-week"];
+    expect(progression.target).toBeUndefined();
+    expect(progression.recordHolder).toBeUndefined();
+    expect(progression.personalBest).toBe(GAMES_IN_WEEK_RECORD_FLOOR - 1);
+    expect(progression.earned).toBe(0);
+  });
+});
+
+describe("Hero of the Month achievement", () => {
+  it("does not establish a record below the floor", () => {
+    // 19 games spread over two weeks of January — one short of the floor.
+    const tt = calculate([
+      ...gamesOnDay(1, "alice", "bob", 10),
+      ...gamesOnDay(15, "alice", "bob", GAMES_IN_MONTH_RECORD_FLOOR - 11),
+    ]);
+
+    expect(monthAwards(tt, "alice")).toHaveLength(0);
+    expect(monthAwards(tt, "bob")).toHaveLength(0);
+    expect(tt.achievements.gamesInMonthRecord).toStrictEqual({ count: undefined, holder: undefined });
+  });
+
+  it("establishes the first record accumulated across the weeks of a month, tie going to the winner", () => {
+    const tt = calculate([...gamesOnDay(1, "alice", "bob", 10), ...gamesOnDay(15, "alice", "bob", 10)]);
+
+    const aliceAwards = monthAwards(tt, "alice");
+    expect(aliceAwards).toHaveLength(1);
+    expect(aliceAwards[0]).toStrictEqual({
+      type: "hero-of-the-month",
+      earnedBy: "alice",
+      earnedAt: at(15, 9),
+      data: {
+        monthStart: new Date(2024, 0, 1).getTime(),
+        gamesPlayed: GAMES_IN_MONTH_RECORD_FLOOR,
+        previousRecord: undefined,
+      },
+    });
+    expect(monthAwards(tt, "bob")).toHaveLength(0);
+    expect(tt.achievements.gamesInMonthRecord).toStrictEqual({
+      count: GAMES_IN_MONTH_RECORD_FLOOR,
+      holder: "alice",
+    });
+  });
+
+  it("resets the count at the month boundary and requires strictly beating the record", () => {
+    const tt = calculate([
+      // January: record set at 20.
+      ...gamesOnDay(1, "alice", "bob", 10),
+      ...gamesOnDay(15, "alice", "bob", 10),
+      // February (day 32 = Feb 1): 20 games only tie the record — no award...
+      ...gamesOnDay(32, "alice", "bob", 10),
+      ...gamesOnDay(40, "alice", "bob", 10),
+      // ...a 21st game in the same month takes it.
+      { winner: "alice", loser: "bob", playedAt: at(41, 0) },
+    ]);
+
+    const aliceAwards = monthAwards(tt, "alice");
+    expect(aliceAwards).toHaveLength(2);
+    expect(aliceAwards[1].data).toStrictEqual({
+      monthStart: new Date(2024, 1, 1).getTime(),
+      gamesPlayed: 21,
+      previousRecord: 20,
+    });
+    expect(monthAwards(tt, "bob")).toHaveLength(0);
+    expect(tt.achievements.gamesInMonthRecord).toStrictEqual({ count: 21, holder: "alice" });
+  });
+
+  it("reports busiest month, league record and earned count in the progression", () => {
+    const tt = calculate([
+      ...gamesOnDay(1, "alice", "bob", 10),
+      ...gamesOnDay(15, "alice", "bob", 10),
+      ...gamesOnDay(32, "alice", "bob", 13),
+      ...gamesOnDay(33, "alice", "bob", 12),
+    ]);
+
+    const alice = tt.achievements.getPlayerProgression("alice")["hero-of-the-month"];
+    expect(alice.current).toBe(0); // no games this month
+    expect(alice.personalBest).toBe(25);
+    expect(alice.target).toBe(26); // one beyond the record of 25
+    expect(alice.recordHolder).toBe("alice");
+    expect(alice.earned).toBe(2);
+
+    const bob = tt.achievements.getPlayerProgression("bob")["hero-of-the-month"];
+    expect(bob.personalBest).toBe(25);
+    expect(bob.target).toBe(26);
+    expect(bob.recordHolder).toBe("alice");
+    expect(bob.earned).toBe(0);
+  });
+
+  it("leaves the progression target unset until someone holds the record", () => {
+    const tt = calculate(gamesOnDay(1, "alice", "bob", GAMES_IN_MONTH_RECORD_FLOOR - 1));
+
+    const progression = tt.achievements.getPlayerProgression("alice")["hero-of-the-month"];
+    expect(progression.target).toBeUndefined();
+    expect(progression.recordHolder).toBeUndefined();
+    expect(progression.personalBest).toBe(GAMES_IN_MONTH_RECORD_FLOOR - 1);
+    expect(progression.earned).toBe(0);
+  });
+});

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -8,11 +8,13 @@ import { TennisTable } from "./tennis-table";
 // a record exists the floor is irrelevant — only beating the record counts.
 export const STREAK_RECORD_FLOOR = 3;
 
-// Fewest games in one calendar day that can establish the very first Hero of
-// the Day record. Below this a day is too ordinary to be a record worth
-// holding. Once a record exists the floor is irrelevant — only beating the
-// record counts.
+// Fewest games in one calendar day / week / month that can establish the very
+// first Hero of the Day / Week / Month record. Below these a period is too
+// ordinary to be a record worth holding. Once a record exists the floor is
+// irrelevant — only beating the record counts.
 export const GAMES_IN_DAY_RECORD_FLOOR = 3;
+export const GAMES_IN_WEEK_RECORD_FLOOR = 10;
+export const GAMES_IN_MONTH_RECORD_FLOOR = 20;
 
 export class Achievements {
   private parent: TennisTable;
@@ -71,12 +73,20 @@ export class Achievements {
     length: undefined,
     holder: undefined,
   };
-  // League-wide running record for the Hero of the Day achievement: the most
-  // games a single player has played in one local calendar day. Undefined
-  // until a day reaches GAMES_IN_DAY_RECORD_FLOOR and establishes the first
-  // record. Used by the progression view so players can see the mark they
-  // need to beat.
+  // League-wide running records for the Hero of the Day / Week / Month
+  // achievements: the most games a single player has played in one local
+  // calendar day / week (Monday-start) / month. Undefined until a period
+  // reaches its record floor and establishes the first record. Used by the
+  // progression view so players can see the mark they need to beat.
   gamesInDayRecord: { count: number | undefined; holder: string | undefined } = {
+    count: undefined,
+    holder: undefined,
+  };
+  gamesInWeekRecord: { count: number | undefined; holder: string | undefined } = {
+    count: undefined,
+    holder: undefined,
+  };
+  gamesInMonthRecord: { count: number | undefined; holder: string | undefined } = {
     count: undefined,
     holder: undefined,
   };
@@ -102,6 +112,8 @@ export class Achievements {
     this.winStreakRecord = { length: undefined, holder: undefined };
     this.loseStreakRecord = { length: undefined, holder: undefined };
     this.gamesInDayRecord = { count: undefined, holder: undefined };
+    this.gamesInWeekRecord = { count: undefined, holder: undefined };
+    this.gamesInMonthRecord = { count: undefined, holder: undefined };
 
     const playerTracker = new Map<
       string,
@@ -120,14 +132,15 @@ export class Achievements {
         // once another player takes the record over.
         openWinStreakRecord: StreakRecordAchievement | undefined;
         openLoseStreakRecord: StreakRecordAchievement | undefined;
-        // The local calendar day (its midnight timestamp) the player last
-        // played on, how many games they have played on that day so far, and
-        // the Hero of the Day award that day's run earned while the player
-        // holds the record with it — grown game by game like the streak
-        // records, cleared when the day ends.
-        currentDayStart: number;
-        gamesToday: number;
-        openHeroOfTheDayRecord: HeroOfTheDayAchievement | undefined;
+        // Per-period state for the Hero of the Day / Week / Month records:
+        // the local calendar period (its start timestamp) the player last
+        // played in, how many games they have played in it so far, and the
+        // Hero award that period's run earned while the player holds the
+        // record with it — grown game by game like the streak records,
+        // cleared when the period ends.
+        heroOfTheDay: HeroPeriodState;
+        heroOfTheWeek: HeroPeriodState;
+        heroOfTheMonth: HeroPeriodState;
         donutCount: number;
         closeCallsCount: number;
         edgeLordCount: number;
@@ -155,9 +168,9 @@ export class Achievements {
           winStreakPlayer: new Map(),
           openWinStreakRecord: undefined,
           openLoseStreakRecord: undefined,
-          currentDayStart: 0,
-          gamesToday: 0,
-          openHeroOfTheDayRecord: undefined,
+          heroOfTheDay: { periodStart: 0, gamesInPeriod: 0, openRecord: undefined },
+          heroOfTheWeek: { periodStart: 0, gamesInPeriod: 0, openRecord: undefined },
+          heroOfTheMonth: { periodStart: 0, gamesInPeriod: 0, openRecord: undefined },
           donutCount: 0,
           closeCallsCount: 0,
           edgeLordCount: 0,
@@ -180,9 +193,9 @@ export class Achievements {
           winStreakPlayer: new Map(),
           openWinStreakRecord: undefined,
           openLoseStreakRecord: undefined,
-          currentDayStart: 0,
-          gamesToday: 0,
-          openHeroOfTheDayRecord: undefined,
+          heroOfTheDay: { periodStart: 0, gamesInPeriod: 0, openRecord: undefined },
+          heroOfTheWeek: { periodStart: 0, gamesInPeriod: 0, openRecord: undefined },
+          heroOfTheMonth: { periodStart: 0, gamesInPeriod: 0, openRecord: undefined },
           donutCount: 0,
           closeCallsCount: 0,
           edgeLordCount: 0,
@@ -246,11 +259,12 @@ export class Achievements {
       // Check for "Earliest Game" / "Latest Game" record-breaking achievements
       this.#checkTimeOfDayAchievements(game);
 
-      // Check for "Hero of the Day": the record for most games by one player
-      // in a single day. Both players played this game; the winner is checked
-      // first, so when both cross the same count at once the win breaks the tie.
-      this.#checkHeroOfTheDayAchievement(game.winner, winner, game.playedAt);
-      this.#checkHeroOfTheDayAchievement(game.loser, loser, game.playedAt);
+      // Check for "Hero of the Day / Week / Month": the records for most games
+      // by one player in a single day / week / month. Both players played this
+      // game; the winner is checked first, so when both cross the same count
+      // at once the win breaks the tie.
+      this.#checkHeroAchievements(game.winner, winner, game.playedAt);
+      this.#checkHeroAchievements(game.loser, loser, game.playedAt);
 
       // Check for Welcome Committee achievement
       // If this is the loser's first game ever, the winner is their first opponent
@@ -1728,59 +1742,128 @@ export class Achievements {
     return achievement;
   }
 
-  // Hero of the Day: the league-wide record for most games by one player in a
-  // single local calendar day. Works like the streak records: the first day
-  // to reach GAMES_IN_DAY_RECORD_FLOOR games establishes the record, after
-  // that only playing more games in one day than the record takes it. While
-  // the record holder keeps playing on their record day the award grows with
-  // the day instead of handing out one per game; once the day ends (or
-  // someone else takes the record over) a later run is a fresh chase.
-  #checkHeroOfTheDayAchievement(
+  // Local midnight of the day containing `ms`.
+  #dayStartOf(ms: number): number {
+    const d = new Date(ms);
+    d.setHours(0, 0, 0, 0);
+    return d.getTime();
+  }
+
+  // Local Monday-midnight of the week containing `ms` (matching Perfect Week).
+  #weekStartOf(ms: number): number {
+    const d = new Date(ms);
+    d.setHours(0, 0, 0, 0);
+    const daysSinceMonday = (d.getDay() + 6) % 7; // getDay: 0=Sun..6=Sat
+    d.setDate(d.getDate() - daysSinceMonday);
+    return d.getTime();
+  }
+
+  // Local midnight of the 1st of the month containing `ms`.
+  #monthStartOf(ms: number): number {
+    const d = new Date(ms);
+    return new Date(d.getFullYear(), d.getMonth(), 1).getTime();
+  }
+
+  // Hero of the Day / Week / Month: the league-wide records for most games by
+  // one player in a single local calendar day / week / month. All three work
+  // like the streak records: the first period to reach the record floor
+  // establishes the record, after that only playing more games in one period
+  // than the record takes it. While the record holder keeps playing in their
+  // record period the award grows with the period instead of handing out one
+  // per game; once the period ends (or someone else takes the record over) a
+  // later run is a fresh chase. The three periods run independently — a busy
+  // record day also feeds that week's and month's counts.
+  #checkHeroAchievements(
     playerId: string,
-    tracker: {
-      currentDayStart: number;
-      gamesToday: number;
-      openHeroOfTheDayRecord: HeroOfTheDayAchievement | undefined;
-    },
+    tracker: { heroOfTheDay: HeroPeriodState; heroOfTheWeek: HeroPeriodState; heroOfTheMonth: HeroPeriodState },
     playedAt: number,
   ) {
-    const dayDate = new Date(playedAt);
-    dayDate.setHours(0, 0, 0, 0);
-    const day = dayDate.getTime();
-    if (tracker.currentDayStart !== day) {
-      tracker.currentDayStart = day;
-      tracker.gamesToday = 0;
-      tracker.openHeroOfTheDayRecord = undefined;
-    }
-    tracker.gamesToday++;
+    this.#checkHeroRecordAchievement(
+      "hero-of-the-day",
+      playerId,
+      tracker.heroOfTheDay,
+      this.gamesInDayRecord,
+      GAMES_IN_DAY_RECORD_FLOOR,
+      this.#dayStartOf(playedAt),
+      playedAt,
+    );
+    this.#checkHeroRecordAchievement(
+      "hero-of-the-week",
+      playerId,
+      tracker.heroOfTheWeek,
+      this.gamesInWeekRecord,
+      GAMES_IN_WEEK_RECORD_FLOOR,
+      this.#weekStartOf(playedAt),
+      playedAt,
+    );
+    this.#checkHeroRecordAchievement(
+      "hero-of-the-month",
+      playerId,
+      tracker.heroOfTheMonth,
+      this.gamesInMonthRecord,
+      GAMES_IN_MONTH_RECORD_FLOOR,
+      this.#monthStartOf(playedAt),
+      playedAt,
+    );
+  }
 
-    const record = this.gamesInDayRecord;
+  #checkHeroRecordAchievement(
+    type: "hero-of-the-day" | "hero-of-the-week" | "hero-of-the-month",
+    playerId: string,
+    state: HeroPeriodState,
+    record: { count: number | undefined; holder: string | undefined },
+    floor: number,
+    periodStart: number,
+    playedAt: number,
+  ) {
+    if (state.periodStart !== periodStart) {
+      state.periodStart = periodStart;
+      state.gamesInPeriod = 0;
+      state.openRecord = undefined;
+    }
+    state.gamesInPeriod++;
+
     const beatsRecord =
-      record.count === undefined
-        ? tracker.gamesToday >= GAMES_IN_DAY_RECORD_FLOOR
-        : tracker.gamesToday > record.count;
+      record.count === undefined ? state.gamesInPeriod >= floor : state.gamesInPeriod > record.count;
     if (!beatsRecord) {
       return;
     }
 
-    // Same day, still the record holder: grow the award instead of handing
+    // Same period, still the record holder: grow the award instead of handing
     // out another one.
-    if (tracker.openHeroOfTheDayRecord !== undefined && record.holder === playerId) {
-      tracker.openHeroOfTheDayRecord.data.gamesPlayed = tracker.gamesToday;
-      tracker.openHeroOfTheDayRecord.earnedAt = playedAt;
-      record.count = tracker.gamesToday;
+    if (state.openRecord !== undefined && record.holder === playerId) {
+      state.openRecord.data.gamesPlayed = state.gamesInPeriod;
+      state.openRecord.earnedAt = playedAt;
+      record.count = state.gamesInPeriod;
       return;
     }
 
-    const achievement = this.#createAchievement("hero-of-the-day", playerId, playedAt, {
-      day,
-      gamesPlayed: tracker.gamesToday,
-      previousRecord: record.count,
-    });
+    const gamesPlayed = state.gamesInPeriod;
+    const previousRecord = record.count;
+    let achievement: HeroRecordAchievement;
+    if (type === "hero-of-the-day") {
+      achievement = this.#createAchievement("hero-of-the-day", playerId, playedAt, {
+        day: periodStart,
+        gamesPlayed,
+        previousRecord,
+      });
+    } else if (type === "hero-of-the-week") {
+      achievement = this.#createAchievement("hero-of-the-week", playerId, playedAt, {
+        weekStart: periodStart,
+        gamesPlayed,
+        previousRecord,
+      });
+    } else {
+      achievement = this.#createAchievement("hero-of-the-month", playerId, playedAt, {
+        monthStart: periodStart,
+        gamesPlayed,
+        previousRecord,
+      });
+    }
     this.#addAchievement(playerId, achievement);
-    record.count = tracker.gamesToday;
+    record.count = gamesPlayed;
     record.holder = playerId;
-    tracker.openHeroOfTheDayRecord = achievement;
+    state.openRecord = achievement;
   }
 
   #checkBackAfterAchievement(playerId: string, lastActiveAt: number, currentGameAt: number) {
@@ -2196,6 +2279,20 @@ export class Achievements {
         target: this.gamesInDayRecord.count === undefined ? undefined : this.gamesInDayRecord.count + 1,
         recordHolder: this.gamesInDayRecord.holder,
       },
+      "hero-of-the-week": {
+        earned: 0,
+        current: 0,
+        personalBest: 0,
+        target: this.gamesInWeekRecord.count === undefined ? undefined : this.gamesInWeekRecord.count + 1,
+        recordHolder: this.gamesInWeekRecord.holder,
+      },
+      "hero-of-the-month": {
+        earned: 0,
+        current: 0,
+        personalBest: 0,
+        target: this.gamesInMonthRecord.count === undefined ? undefined : this.gamesInMonthRecord.count + 1,
+        recordHolder: this.gamesInMonthRecord.holder,
+      },
       // Record-breaking, no progress bar. recordMinutes is the current league
       // record; playerMinutes (the player's own best) is filled in below.
       "earliest-game": { earned: 0, recordMinutes: this.earliestGameRecord.minutesIntoDay },
@@ -2249,6 +2346,10 @@ export class Achievements {
     const streaksPerOpponent = new Map<string, number>();
     // Perfect Day progression: wins / losses grouped by local calendar day.
     const perfectDayStats = new Map<number, { wins: number; losses: number }>();
+    // Hero of the Week / Month progression: the player's games per local
+    // calendar week / month, keyed by the period's start timestamp.
+    const gamesPerWeek = new Map<number, number>();
+    const gamesPerMonth = new Map<number, number>();
     // Perfect Week progression: distinct weekdays (Mon–Fri) won per working week.
     const perfectWeekWeekdays = new Map<number, Set<number>>();
     const opponentsPlayed = new Set<string>();
@@ -2332,6 +2433,12 @@ export class Achievements {
       } else {
         dayStat.losses++;
       }
+
+      // Hero of the Week / Month progression: tally games per week / month.
+      const heroWeekKey = this.#weekStartOf(game.playedAt);
+      gamesPerWeek.set(heroWeekKey, (gamesPerWeek.get(heroWeekKey) ?? 0) + 1);
+      const heroMonthKey = this.#monthStartOf(game.playedAt);
+      gamesPerMonth.set(heroMonthKey, (gamesPerMonth.get(heroMonthKey) ?? 0) + 1);
 
       // Perfect Week progression: collect distinct Mon–Fri weekdays won.
       const weekday = new Date(game.playedAt).getDay(); // 0=Sun..6=Sat
@@ -2463,15 +2570,29 @@ export class Achievements {
     progression["perfect-day"].current =
       todayStat && todayStat.losses === 0 ? Math.min(todayStat.wins, 5) : 0;
 
-    // Hero of the Day: only today's games can still grow into the record, so
-    // that is the progress. The player's busiest day ever is reported
-    // alongside it.
+    // Hero of the Day / Week / Month: only the current period's games can
+    // still grow into the record, so that is the progress. The player's
+    // busiest period ever is reported alongside it.
     progression["hero-of-the-day"].current = todayStat ? todayStat.wins + todayStat.losses : 0;
     let busiestDay = 0;
     perfectDayStats.forEach((stats) => {
       busiestDay = Math.max(busiestDay, stats.wins + stats.losses);
     });
     progression["hero-of-the-day"].personalBest = busiestDay;
+
+    progression["hero-of-the-week"].current = gamesPerWeek.get(this.#weekStartOf(nowMs)) ?? 0;
+    let busiestWeek = 0;
+    gamesPerWeek.forEach((count) => {
+      busiestWeek = Math.max(busiestWeek, count);
+    });
+    progression["hero-of-the-week"].personalBest = busiestWeek;
+
+    progression["hero-of-the-month"].current = gamesPerMonth.get(this.#monthStartOf(nowMs)) ?? 0;
+    let busiestMonth = 0;
+    gamesPerMonth.forEach((count) => {
+      busiestMonth = Math.max(busiestMonth, count);
+    });
+    progression["hero-of-the-month"].personalBest = busiestMonth;
 
     // Perfect Week progression tracks THIS working week's live attempt: the
     // run of consecutive weekdays from Monday, each with at least one win.
@@ -2777,9 +2898,12 @@ type AchievementDefinitions = {
   "back-after-2-years": { lastGameAt: number };
   "retired": undefined;
   "back-from-the-dead": { retiredAt: number };
-  // `day` is the local midnight of the record day. Undefined previousRecord
-  // means this day established the very first league record.
+  // `day` / `weekStart` / `monthStart` is the local midnight starting the
+  // record period (weeks start on Monday, months on the 1st). Undefined
+  // previousRecord means the period established the very first league record.
   "hero-of-the-day": { day: number; gamesPlayed: number; previousRecord?: number };
+  "hero-of-the-week": { weekStart: number; gamesPlayed: number; previousRecord?: number };
+  "hero-of-the-month": { monthStart: number; gamesPlayed: number; previousRecord?: number };
   "active-6-months": { firstGameInPeriod: number };
   "active-1-year": { firstGameInPeriod: number };
   "active-2-years": { firstGameInPeriod: number };
@@ -2876,9 +3000,23 @@ type StreakRecordAchievement =
   | GenericAchievement<"longest-win-streak">
   | GenericAchievement<"longest-lose-streak">;
 
-// The award for holding the games-in-a-day record — grown through the day
-// while the player still holds the record with it.
-type HeroOfTheDayAchievement = GenericAchievement<"hero-of-the-day">;
+// The award for holding a games-in-a-period record — grown through the
+// day / week / month while the player still holds the record with it. The
+// three share `gamesPlayed`, so the code that grows one as the period
+// continues can treat them interchangeably.
+type HeroRecordAchievement =
+  | GenericAchievement<"hero-of-the-day">
+  | GenericAchievement<"hero-of-the-week">
+  | GenericAchievement<"hero-of-the-month">;
+
+// Per-player, per-period chase state for a Hero record: the period being
+// played (its start timestamp), the games in it so far, and the open award
+// still growing with it (if the player holds the record with this period).
+type HeroPeriodState = {
+  periodStart: number;
+  gamesInPeriod: number;
+  openRecord: HeroRecordAchievement | undefined;
+};
 
 // Progression Types
 type BaseProgression = {
@@ -2945,18 +3083,19 @@ type MarathonSetProgression = BaseProgression & {
   recordHolder?: string;
 };
 
-type HeroOfTheDayProgression = BaseProgression & {
-  // Games the player has played so far today — only today's total can still
-  // grow into the record, so this is what the progress bar measures.
+type HeroRecordProgression = BaseProgression & {
+  // Games the player has played so far in the current period (today / this
+  // week / this month) — only the current period's total can still grow into
+  // the record, so this is what the progress bar measures.
   current: number;
-  // One beyond the league record — the single-day games count that takes it.
-  // Undefined while nobody holds it (a GAMES_IN_DAY_RECORD_FLOOR-game day
-  // takes it outright).
+  // One beyond the league record — the single-period games count that takes
+  // it. Undefined while nobody holds it (a floor-reaching period takes it
+  // outright).
   target?: number;
   // Player who currently holds the league record, if any.
   recordHolder?: string;
-  // The player's own busiest day ever, which may be busier than today.
-  // Shown so they can see how their best compares.
+  // The player's own busiest period ever, which may be busier than the
+  // current one. Shown so they can see how their best compares.
   personalBest: number;
 };
 
@@ -3038,7 +3177,9 @@ export type AchievementProgression = {
   "streak-ender": BaseProgression;
   "longest-win-streak": StreakRecordProgression;
   "longest-lose-streak": StreakRecordProgression;
-  "hero-of-the-day": HeroOfTheDayProgression;
+  "hero-of-the-day": HeroRecordProgression;
+  "hero-of-the-week": HeroRecordProgression;
+  "hero-of-the-month": HeroRecordProgression;
   "group-stage-star": BaseProgression;
   "full-house": MissingPlayersProgression;
   "humbled": MissingPlayersProgression;

--- a/frontend/src/pages/achievements/achievements-list.tsx
+++ b/frontend/src/pages/achievements/achievements-list.tsx
@@ -207,6 +207,22 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                         : " (first league record!)"}
                     </span>
                   )}
+                  {achievement.type === "hero-of-the-week" && achievement.data && (
+                    <span className="text-[11px] opacity-80">
+                      {achievement.data.gamesPlayed} games in one week
+                      {achievement.data.previousRecord !== undefined
+                        ? ` (prev record ${achievement.data.previousRecord})`
+                        : " (first league record!)"}
+                    </span>
+                  )}
+                  {achievement.type === "hero-of-the-month" && achievement.data && (
+                    <span className="text-[11px] opacity-80">
+                      {achievement.data.gamesPlayed} games in one month
+                      {achievement.data.previousRecord !== undefined
+                        ? ` (prev record ${achievement.data.previousRecord})`
+                        : " (first league record!)"}
+                    </span>
+                  )}
                   {achievement.type === "back-from-the-dead" && achievement.data && (
                     <span className="text-[11px] opacity-80">
                       Retired for{" "}

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -6,6 +6,8 @@ import {
   Achievement,
   AchievementProgression,
   GAMES_IN_DAY_RECORD_FLOOR,
+  GAMES_IN_MONTH_RECORD_FLOOR,
+  GAMES_IN_WEEK_RECORD_FLOOR,
   STREAK_RECORD_FLOOR,
 } from "../../client/client-db/achievements";
 import { Link } from "react-router-dom";
@@ -265,6 +267,16 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
     description: "Play more games in a single day than anyone in league history",
     icon: "🦸",
   },
+  "hero-of-the-week": {
+    title: "Hero of the Week",
+    description: "Play more games in a single week than anyone in league history",
+    icon: "🦸‍♂️",
+  },
+  "hero-of-the-month": {
+    title: "Hero of the Month",
+    description: "Play more games in a single month than anyone in league history",
+    icon: "🦸‍♀️",
+  },
   "streak-ender": {
     title: "Streak Ender",
     description: "Beat a player who was on an active 10+ game win streak",
@@ -310,6 +322,14 @@ export function getAchievementLabel(
   }
   return label;
 }
+
+// Wording and record floors for the Hero of the Day / Week / Month records —
+// they share the same progression UI at different period sizes.
+const HERO_RECORD_PERIODS: Record<string, { noun: string; floor: number }> = {
+  "hero-of-the-day": { noun: "day", floor: GAMES_IN_DAY_RECORD_FLOOR },
+  "hero-of-the-week": { noun: "week", floor: GAMES_IN_WEEK_RECORD_FLOOR },
+  "hero-of-the-month": { noun: "month", floor: GAMES_IN_MONTH_RECORD_FLOOR },
+};
 
 type TabType = "earned" | "progress";
 const tabs: { id: TabType; label: string }[] = [
@@ -513,6 +533,24 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
                 {achievement.type === "hero-of-the-day" && achievement.data && (
                   <p className="text-xs text-secondary-text/70 mt-2">
                     {achievement.data.gamesPlayed} games on {dateString(achievement.data.day)}
+                    {achievement.data.previousRecord !== undefined
+                      ? ` (previous record: ${achievement.data.previousRecord})`
+                      : " (first league record!)"}
+                  </p>
+                )}
+
+                {achievement.type === "hero-of-the-week" && achievement.data && (
+                  <p className="text-xs text-secondary-text/70 mt-2">
+                    {achievement.data.gamesPlayed} games in the week of {dateString(achievement.data.weekStart)}
+                    {achievement.data.previousRecord !== undefined
+                      ? ` (previous record: ${achievement.data.previousRecord})`
+                      : " (first league record!)"}
+                  </p>
+                )}
+
+                {achievement.type === "hero-of-the-month" && achievement.data && (
+                  <p className="text-xs text-secondary-text/70 mt-2">
+                    {achievement.data.gamesPlayed} games in {monthString(achievement.data.monthStart)}
                     {achievement.data.previousRecord !== undefined
                       ? ` (previous record: ${achievement.data.previousRecord})`
                       : " (first league record!)"}
@@ -917,14 +955,16 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                         </div>
                       )}
 
-                      {/* Record holder and personal best for hero-of-the-day.
-                          The bar tracks today's games, so the player's busiest
-                          day ever is spelt out separately. */}
-                      {type === "hero-of-the-day" && "recordHolder" in data && (
+                      {/* Record holder and personal best for the Hero of the
+                          Day / Week / Month records. The bar tracks the current
+                          period's games, so the player's busiest period ever is
+                          spelt out separately. */}
+                      {type in HERO_RECORD_PERIODS && "recordHolder" in data && (
                         <div className="mt-2 text-xs text-secondary-text/70 space-y-1">
                           {"personalBest" in data && (
                             <p>
-                              Your busiest day ever: {data.personalBest} game{data.personalBest !== 1 ? "s" : ""}
+                              Your busiest {HERO_RECORD_PERIODS[type].noun} ever: {data.personalBest} game
+                              {data.personalBest !== 1 ? "s" : ""}
                             </p>
                           )}
                           <p>
@@ -936,12 +976,12 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                                     {context.playerName(data.recordHolder)}
                                   </span>
                                 </Link>
-                                . Play {data.target} games in one day to take it.
+                                . Play {data.target} games in one {HERO_RECORD_PERIODS[type].noun} to take it.
                               </>
                             ) : (
                               <>
-                                No record set yet — play {GAMES_IN_DAY_RECORD_FLOOR} games in one day to start the
-                                record.
+                                No record set yet — play {HERO_RECORD_PERIODS[type].floor} games in one{" "}
+                                {HERO_RECORD_PERIODS[type].noun} to start the record.
                               </>
                             )}
                           </p>
@@ -996,10 +1036,10 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                       No league record yet — {type === "longest-win-streak" ? "win" : "lose"}{" "}
                       {STREAK_RECORD_FLOOR} in a row to set the first record.
                     </div>
-                  ) : type === "hero-of-the-day" ? (
+                  ) : type in HERO_RECORD_PERIODS ? (
                     <div className="mt-2 text-xs text-secondary-text/70">
-                      No league record yet — play {GAMES_IN_DAY_RECORD_FLOOR} games in one day to set the first
-                      record.
+                      No league record yet — play {HERO_RECORD_PERIODS[type].floor} games in one{" "}
+                      {HERO_RECORD_PERIODS[type].noun} to set the first record.
                     </div>
                   ) : type === "earliest-game" || type === "latest-game" ? (
                     <div className="mt-2 text-xs text-secondary-text/70 space-y-1">
@@ -1048,6 +1088,15 @@ function formatTimePeriod(ms?: number): string {
 export function dateString(time: number) {
   return new Date(time).toLocaleDateString("nb-NO", {
     day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+// Month-granularity variant of dateString, for periods that span a whole
+// calendar month (e.g. "januar 2026").
+export function monthString(time: number) {
+  return new Date(time).toLocaleDateString("nb-NO", {
     month: "long",
     year: "numeric",
   });

--- a/frontend/src/wrappers/nav-menu.tsx
+++ b/frontend/src/wrappers/nav-menu.tsx
@@ -34,11 +34,12 @@ export const NavMenu: React.FC = () => {
       { name: "🎖️ Achievements", to: "/achievements" },
       { name: "🏛️ Hall of Fame", to: "/hall-of-fame" },
       { name: "🤖 Simulations", to: "/simulations" },
-      // Changelog (/changelog) is deliberately left out until the navigation
-      // structure is reworked. Reachable by direct url in the meantime.
       { name: "🔧 Settings", to: "/settings" },
     ];
     if (session.isAuthenticated && session.sessionData?.role === "admin") {
+      // Changelog (/changelog) is deliberately admin-only until the navigation
+      // structure is reworked. Reachable by direct url for everyone else.
+      items.push({ name: "📜 Changelog", to: "/changelog" });
       items.push({ name: "📺 Live Game", to: "/live-game" });
       items.push({ name: "🔐 Admin Page", to: "/admin" });
     }


### PR DESCRIPTION
Extend the Hero of the Day games-in-a-period league record to two new
periods: a single week (Monday-start, matching Perfect Week) and a single
calendar month. The record machinery is generalized into one per-period
checker shared by all three, each with its own record floor (day 3, week
10, month 20) and independent league record.

Both new achievements behave exactly like Hero of the Day: the award grows
while the record holder keeps playing in their record period, and only a
strictly busier period takes the record over. Progression shows the current
period's games, the player's busiest period ever, the record target and the
record holder.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019BEiRErYFwQ8CGqfEYWi9M