### PR TITLE
Use one shared record floor for all Hero period records

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -39,11 +39,11 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
       "Hero of the Week 🦸‍♂️ and Hero of the Month 🦸‍♀️ extend the Hero of the Day record to bigger periods: the most games played in a single week and in a single calendar month.",
     body: [
       list(
-        "Hero of the Week 🦸‍♂️ - the league record for most games played in a single week (Monday to Sunday). The first week with 10 games sets the record.",
-        "Hero of the Month 🦸‍♀️ - the league record for most games played in a single calendar month. The first month with 20 games sets the record.",
+        "Hero of the Week 🦸‍♂️ - the league record for most games played in a single week (Monday to Sunday).",
+        "Hero of the Month 🦸‍♀️ - the league record for most games played in a single calendar month.",
       ),
       text(
-        "Both work exactly like Hero of the Day: they are records that are held, not just earned. Wins and losses both count, one award grows with the whole record period, and only a strictly busier week or month takes the record over. The three records run independently - a monster day feeds its week's and month's counts too.",
+        "Both work exactly like Hero of the Day: they are records that are held, not just earned. The first week or month with 3 games sets its record, wins and losses both count, one award grows with the whole record period, and only a strictly busier week or month takes the record over. The three records run independently - a monster day feeds its week's and month's counts too.",
       ),
       text(
         "The progress view shows your current week and month against the records, your busiest ever, and who holds them.",

--- a/frontend/src/client/client-db/__tests__/achievements/hero-of-the-day.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/hero-of-the-day.test.ts
@@ -1,4 +1,4 @@
-import { Achievement, GAMES_IN_DAY_RECORD_FLOOR } from "../../achievements";
+import { Achievement, GAMES_IN_PERIOD_RECORD_FLOOR } from "../../achievements";
 import { EventType, EventTypeEnum } from "../../event-store/event-types";
 import { TennisTable } from "../../tennis-table";
 
@@ -55,7 +55,7 @@ function gamesOnDay(day: number, winner: string, loser: string, count: number, f
 
 describe("Hero of the Day achievement", () => {
   it("does not establish a record below the floor", () => {
-    const tt = calculate(gamesOnDay(1, "alice", "bob", GAMES_IN_DAY_RECORD_FLOOR - 1));
+    const tt = calculate(gamesOnDay(1, "alice", "bob", GAMES_IN_PERIOD_RECORD_FLOOR - 1));
 
     expect(heroAwards(tt, "alice")).toHaveLength(0);
     expect(heroAwards(tt, "bob")).toHaveLength(0);
@@ -64,23 +64,23 @@ describe("Hero of the Day achievement", () => {
 
   it("establishes the first record at the floor, tie going to the winner of the crossing game", () => {
     // Alice and Bob both reach 10 games on the same game; Alice won it.
-    const tt = calculate(gamesOnDay(1, "alice", "bob", GAMES_IN_DAY_RECORD_FLOOR));
+    const tt = calculate(gamesOnDay(1, "alice", "bob", GAMES_IN_PERIOD_RECORD_FLOOR));
 
     const aliceAwards = heroAwards(tt, "alice");
     expect(aliceAwards).toHaveLength(1);
     expect(aliceAwards[0]).toStrictEqual({
       type: "hero-of-the-day",
       earnedBy: "alice",
-      earnedAt: at(1, GAMES_IN_DAY_RECORD_FLOOR - 1),
+      earnedAt: at(1, GAMES_IN_PERIOD_RECORD_FLOOR - 1),
       data: {
         day: new Date(2024, 0, 1).getTime(),
-        gamesPlayed: GAMES_IN_DAY_RECORD_FLOOR,
+        gamesPlayed: GAMES_IN_PERIOD_RECORD_FLOOR,
         previousRecord: undefined,
       },
     });
     expect(heroAwards(tt, "bob")).toHaveLength(0);
     expect(tt.achievements.gamesInDayRecord).toStrictEqual({
-      count: GAMES_IN_DAY_RECORD_FLOOR,
+      count: GAMES_IN_PERIOD_RECORD_FLOOR,
       holder: "alice",
     });
   });
@@ -171,12 +171,12 @@ describe("Hero of the Day achievement", () => {
   });
 
   it("leaves the progression target unset until someone holds the record", () => {
-    const tt = calculate(gamesOnDay(1, "alice", "bob", GAMES_IN_DAY_RECORD_FLOOR - 1));
+    const tt = calculate(gamesOnDay(1, "alice", "bob", GAMES_IN_PERIOD_RECORD_FLOOR - 1));
 
     const progression = tt.achievements.getPlayerProgression("alice")["hero-of-the-day"];
     expect(progression.target).toBeUndefined();
     expect(progression.recordHolder).toBeUndefined();
-    expect(progression.personalBest).toBe(GAMES_IN_DAY_RECORD_FLOOR - 1);
+    expect(progression.personalBest).toBe(GAMES_IN_PERIOD_RECORD_FLOOR - 1);
     expect(progression.earned).toBe(0);
   });
 });

--- a/frontend/src/client/client-db/__tests__/achievements/hero-of-the-week-and-month.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/hero-of-the-week-and-month.test.ts
@@ -1,4 +1,4 @@
-import { Achievement, GAMES_IN_MONTH_RECORD_FLOOR, GAMES_IN_WEEK_RECORD_FLOOR } from "../../achievements";
+import { Achievement, GAMES_IN_PERIOD_RECORD_FLOOR } from "../../achievements";
 import { EventType, EventTypeEnum } from "../../event-store/event-types";
 import { TennisTable } from "../../tennis-table";
 
@@ -65,11 +65,7 @@ function gamesOnDay(day: number, winner: string, loser: string, count: number, f
 
 describe("Hero of the Week achievement", () => {
   it("does not establish a record below the floor", () => {
-    // 9 games spread over two days of the same week — one short of the floor.
-    const tt = calculate([
-      ...gamesOnDay(1, "alice", "bob", 4),
-      ...gamesOnDay(3, "alice", "bob", GAMES_IN_WEEK_RECORD_FLOOR - 5),
-    ]);
+    const tt = calculate(gamesOnDay(1, "alice", "bob", GAMES_IN_PERIOD_RECORD_FLOOR - 1));
 
     expect(weekAwards(tt, "alice")).toHaveLength(0);
     expect(weekAwards(tt, "bob")).toHaveLength(0);
@@ -77,24 +73,27 @@ describe("Hero of the Week achievement", () => {
   });
 
   it("establishes the first record accumulated across the days of a week, tie going to the winner", () => {
-    // 5 games on Monday + 5 on Wednesday reach the floor of 10 mid-week.
-    const tt = calculate([...gamesOnDay(1, "alice", "bob", 5), ...gamesOnDay(3, "alice", "bob", 5)]);
+    // 2 games on Monday + 1 on Wednesday reach the floor of 3 mid-week.
+    const tt = calculate([
+      ...gamesOnDay(1, "alice", "bob", GAMES_IN_PERIOD_RECORD_FLOOR - 1),
+      ...gamesOnDay(3, "alice", "bob", 1),
+    ]);
 
     const aliceAwards = weekAwards(tt, "alice");
     expect(aliceAwards).toHaveLength(1);
     expect(aliceAwards[0]).toStrictEqual({
       type: "hero-of-the-week",
       earnedBy: "alice",
-      earnedAt: at(3, 4),
+      earnedAt: at(3, 0),
       data: {
         weekStart: new Date(2024, 0, 1).getTime(),
-        gamesPlayed: GAMES_IN_WEEK_RECORD_FLOOR,
+        gamesPlayed: GAMES_IN_PERIOD_RECORD_FLOOR,
         previousRecord: undefined,
       },
     });
     expect(weekAwards(tt, "bob")).toHaveLength(0);
     expect(tt.achievements.gamesInWeekRecord).toStrictEqual({
-      count: GAMES_IN_WEEK_RECORD_FLOOR,
+      count: GAMES_IN_PERIOD_RECORD_FLOOR,
       holder: "alice",
     });
   });
@@ -111,7 +110,7 @@ describe("Hero of the Week achievement", () => {
 
   it("resets the count at the week boundary and requires strictly beating the record", () => {
     const tt = calculate([
-      // Week of Jan 1: record set at 10.
+      // Week of Jan 1: record set and grown to 10.
       ...gamesOnDay(1, "alice", "bob", 10),
       // Week of Jan 8: 10 games only tie the record — no award...
       ...gamesOnDay(8, "alice", "bob", 10),
@@ -152,23 +151,19 @@ describe("Hero of the Week achievement", () => {
   });
 
   it("leaves the progression target unset until someone holds the record", () => {
-    const tt = calculate(gamesOnDay(1, "alice", "bob", GAMES_IN_WEEK_RECORD_FLOOR - 1));
+    const tt = calculate(gamesOnDay(1, "alice", "bob", GAMES_IN_PERIOD_RECORD_FLOOR - 1));
 
     const progression = tt.achievements.getPlayerProgression("alice")["hero-of-the-week"];
     expect(progression.target).toBeUndefined();
     expect(progression.recordHolder).toBeUndefined();
-    expect(progression.personalBest).toBe(GAMES_IN_WEEK_RECORD_FLOOR - 1);
+    expect(progression.personalBest).toBe(GAMES_IN_PERIOD_RECORD_FLOOR - 1);
     expect(progression.earned).toBe(0);
   });
 });
 
 describe("Hero of the Month achievement", () => {
   it("does not establish a record below the floor", () => {
-    // 19 games spread over two weeks of January — one short of the floor.
-    const tt = calculate([
-      ...gamesOnDay(1, "alice", "bob", 10),
-      ...gamesOnDay(15, "alice", "bob", GAMES_IN_MONTH_RECORD_FLOOR - 11),
-    ]);
+    const tt = calculate(gamesOnDay(1, "alice", "bob", GAMES_IN_PERIOD_RECORD_FLOOR - 1));
 
     expect(monthAwards(tt, "alice")).toHaveLength(0);
     expect(monthAwards(tt, "bob")).toHaveLength(0);
@@ -176,30 +171,44 @@ describe("Hero of the Month achievement", () => {
   });
 
   it("establishes the first record accumulated across the weeks of a month, tie going to the winner", () => {
-    const tt = calculate([...gamesOnDay(1, "alice", "bob", 10), ...gamesOnDay(15, "alice", "bob", 10)]);
+    // 2 games in the first week + 1 in the third reach the floor of 3.
+    const tt = calculate([
+      ...gamesOnDay(1, "alice", "bob", GAMES_IN_PERIOD_RECORD_FLOOR - 1),
+      ...gamesOnDay(15, "alice", "bob", 1),
+    ]);
 
     const aliceAwards = monthAwards(tt, "alice");
     expect(aliceAwards).toHaveLength(1);
     expect(aliceAwards[0]).toStrictEqual({
       type: "hero-of-the-month",
       earnedBy: "alice",
-      earnedAt: at(15, 9),
+      earnedAt: at(15, 0),
       data: {
         monthStart: new Date(2024, 0, 1).getTime(),
-        gamesPlayed: GAMES_IN_MONTH_RECORD_FLOOR,
+        gamesPlayed: GAMES_IN_PERIOD_RECORD_FLOOR,
         previousRecord: undefined,
       },
     });
     expect(monthAwards(tt, "bob")).toHaveLength(0);
     expect(tt.achievements.gamesInMonthRecord).toStrictEqual({
-      count: GAMES_IN_MONTH_RECORD_FLOOR,
+      count: GAMES_IN_PERIOD_RECORD_FLOOR,
       holder: "alice",
     });
   });
 
+  it("grows a single award as the record month continues instead of awarding per game", () => {
+    const tt = calculate([...gamesOnDay(1, "alice", "bob", 10), ...gamesOnDay(15, "alice", "bob", 10)]);
+
+    const aliceAwards = monthAwards(tt, "alice");
+    expect(aliceAwards).toHaveLength(1);
+    expect(aliceAwards[0].data.gamesPlayed).toBe(20);
+    expect(aliceAwards[0].earnedAt).toBe(at(15, 9));
+    expect(tt.achievements.gamesInMonthRecord).toStrictEqual({ count: 20, holder: "alice" });
+  });
+
   it("resets the count at the month boundary and requires strictly beating the record", () => {
     const tt = calculate([
-      // January: record set at 20.
+      // January: record set and grown to 20.
       ...gamesOnDay(1, "alice", "bob", 10),
       ...gamesOnDay(15, "alice", "bob", 10),
       // February (day 32 = Feb 1): 20 games only tie the record — no award...
@@ -243,12 +252,12 @@ describe("Hero of the Month achievement", () => {
   });
 
   it("leaves the progression target unset until someone holds the record", () => {
-    const tt = calculate(gamesOnDay(1, "alice", "bob", GAMES_IN_MONTH_RECORD_FLOOR - 1));
+    const tt = calculate(gamesOnDay(1, "alice", "bob", GAMES_IN_PERIOD_RECORD_FLOOR - 1));
 
     const progression = tt.achievements.getPlayerProgression("alice")["hero-of-the-month"];
     expect(progression.target).toBeUndefined();
     expect(progression.recordHolder).toBeUndefined();
-    expect(progression.personalBest).toBe(GAMES_IN_MONTH_RECORD_FLOOR - 1);
+    expect(progression.personalBest).toBe(GAMES_IN_PERIOD_RECORD_FLOOR - 1);
     expect(progression.earned).toBe(0);
   });
 });

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -9,12 +9,12 @@ import { TennisTable } from "./tennis-table";
 export const STREAK_RECORD_FLOOR = 3;
 
 // Fewest games in one calendar day / week / month that can establish the very
-// first Hero of the Day / Week / Month record. Below these a period is too
-// ordinary to be a record worth holding. Once a record exists the floor is
-// irrelevant — only beating the record counts.
-export const GAMES_IN_DAY_RECORD_FLOOR = 3;
-export const GAMES_IN_WEEK_RECORD_FLOOR = 10;
-export const GAMES_IN_MONTH_RECORD_FLOOR = 20;
+// first Hero of the Day / Week / Month record. Below this a period is too
+// ordinary to be a record worth holding. The floor is deliberately the same
+// low bar for all three periods — it only matters until the first record
+// exists; after that only beating the record counts, and the longer periods
+// naturally accumulate higher records on their own.
+export const GAMES_IN_PERIOD_RECORD_FLOOR = 3;
 
 export class Achievements {
   private parent: TennisTable;
@@ -1783,7 +1783,6 @@ export class Achievements {
       playerId,
       tracker.heroOfTheDay,
       this.gamesInDayRecord,
-      GAMES_IN_DAY_RECORD_FLOOR,
       this.#dayStartOf(playedAt),
       playedAt,
     );
@@ -1792,7 +1791,6 @@ export class Achievements {
       playerId,
       tracker.heroOfTheWeek,
       this.gamesInWeekRecord,
-      GAMES_IN_WEEK_RECORD_FLOOR,
       this.#weekStartOf(playedAt),
       playedAt,
     );
@@ -1801,7 +1799,6 @@ export class Achievements {
       playerId,
       tracker.heroOfTheMonth,
       this.gamesInMonthRecord,
-      GAMES_IN_MONTH_RECORD_FLOOR,
       this.#monthStartOf(playedAt),
       playedAt,
     );
@@ -1812,7 +1809,6 @@ export class Achievements {
     playerId: string,
     state: HeroPeriodState,
     record: { count: number | undefined; holder: string | undefined },
-    floor: number,
     periodStart: number,
     playedAt: number,
   ) {
@@ -1824,7 +1820,9 @@ export class Achievements {
     state.gamesInPeriod++;
 
     const beatsRecord =
-      record.count === undefined ? state.gamesInPeriod >= floor : state.gamesInPeriod > record.count;
+      record.count === undefined
+        ? state.gamesInPeriod >= GAMES_IN_PERIOD_RECORD_FLOOR
+        : state.gamesInPeriod > record.count;
     if (!beatsRecord) {
       return;
     }

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -5,9 +5,7 @@ import { useState } from "react";
 import {
   Achievement,
   AchievementProgression,
-  GAMES_IN_DAY_RECORD_FLOOR,
-  GAMES_IN_MONTH_RECORD_FLOOR,
-  GAMES_IN_WEEK_RECORD_FLOOR,
+  GAMES_IN_PERIOD_RECORD_FLOOR,
   STREAK_RECORD_FLOOR,
 } from "../../client/client-db/achievements";
 import { Link } from "react-router-dom";
@@ -323,12 +321,12 @@ export function getAchievementLabel(
   return label;
 }
 
-// Wording and record floors for the Hero of the Day / Week / Month records —
-// they share the same progression UI at different period sizes.
-const HERO_RECORD_PERIODS: Record<string, { noun: string; floor: number }> = {
-  "hero-of-the-day": { noun: "day", floor: GAMES_IN_DAY_RECORD_FLOOR },
-  "hero-of-the-week": { noun: "week", floor: GAMES_IN_WEEK_RECORD_FLOOR },
-  "hero-of-the-month": { noun: "month", floor: GAMES_IN_MONTH_RECORD_FLOOR },
+// Wording for the Hero of the Day / Week / Month records — they share the
+// same progression UI (and record floor) at different period sizes.
+const HERO_RECORD_PERIODS: Record<string, { noun: string }> = {
+  "hero-of-the-day": { noun: "day" },
+  "hero-of-the-week": { noun: "week" },
+  "hero-of-the-month": { noun: "month" },
 };
 
 type TabType = "earned" | "progress";
@@ -980,7 +978,7 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                               </>
                             ) : (
                               <>
-                                No record set yet — play {HERO_RECORD_PERIODS[type].floor} games in one{" "}
+                                No record set yet — play {GAMES_IN_PERIOD_RECORD_FLOOR} games in one{" "}
                                 {HERO_RECORD_PERIODS[type].noun} to start the record.
                               </>
                             )}
@@ -1038,7 +1036,7 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                     </div>
                   ) : type in HERO_RECORD_PERIODS ? (
                     <div className="mt-2 text-xs text-secondary-text/70">
-                      No league record yet — play {HERO_RECORD_PERIODS[type].floor} games in one{" "}
+                      No league record yet — play {GAMES_IN_PERIOD_RECORD_FLOOR} games in one{" "}
                       {HERO_RECORD_PERIODS[type].noun} to set the first record.
                     </div>
                   ) : type === "earliest-game" || type === "latest-game" ? (


### PR DESCRIPTION
Follow-up to #127 (Hero of the Week / Month achievements), rebased onto master after its merge.

The day, week and month Hero records now share a single low floor of **3 games** (`GAMES_IN_PERIOD_RECORD_FLOOR`) to establish the very first record, instead of week and month having scaled-up floors (10 and 20). The floor only matters until a record exists — after that only beating the record counts, and the longer periods accumulate higher records on their own.

- The per-period checker no longer takes a floor parameter; the shared constant lives in `achievements.ts`.
- Progress-tab texts ("play 3 games in one day/week/month to start the record") read the shared constant.
- Week/month tests reworked for the lower floor, plus a new month-record growth test.
- Changelog post updated to match.

## Testing

Full suite: 49 suites, 455 tests passing. Lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BEiRErYFwQ8CGqfEYWi9M