### PR TITLE
Add Shootout, Season Opener, Milestone Game achievements

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -41,7 +41,7 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
       list(
         "Shootout 💥 - the league record for the most combined points in a single game. Only the 3 highest-scoring sets count, so a best-of-5 final competes on equal terms with an ordinary best-of-3. A 60+ point game sets the first record.",
         "Season Opener 🌱 - earned by both players of a season's very first game. Awarded per season, so it comes around again every quarter.",
-        "Milestone Game 🏁 - earned by both players of the league's 100th, 500th, 1,000th and every following thousandth game. Deleted games do not count. The progress view shows the league's shared count toward the next milestone.",
+        "Milestone Game 🏁 - earned by both players of the league's 100th, 500th, 1,000th and every following thousandth game. Deleted games do not count. The progress view is shared by everyone and restarts at each milestone, showing how many games remain until the next milestone game.",
       ),
       text(
         "David 🪨 and Goliath 🗿 are now league records rather than fixed thresholds. Previously every single-game swing of 30+ Score earned them; now the first 20+ Score swing set the record, and only a strictly bigger single-game gain (David, for the winner) or loss (Goliath, for the loser) takes it over. Score is zero-sum, so one upset always moves both records together. Because achievements are recomputed from history, some previously earned David and Goliath badges are gone - only the record-breaking upsets remain, and the progress view now shows the record and its holder.",

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -32,21 +32,22 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
     slug: "shootout-season-opener-and-record-david-goliath",
-    title: "2 new achievements, and David & Goliath become league records",
+    title: "3 new achievements, and David & Goliath become league records",
     date: "2026-08-04",
     tags: ["new-feature", "feature-update"],
     summary:
-      "Shootout 💥 is the record for the most points in one game, Season Opener 🌱 goes to the players of a season's first game, David 🪨 and Goliath 🗿 are now league records instead of fixed thresholds, and Perfect Week 🗓️ accepts any 5 consecutive days within a week.",
+      "Shootout 💥 is the record for the most points in one game, Season Opener 🌱 goes to the players of a season's first game, Milestone Game 🏁 marks the league's 100th, 500th and every thousandth game, David 🪨 and Goliath 🗿 are now league records, and Perfect Week 🗓️ accepts any 5 consecutive days within a week.",
     body: [
       list(
         "Shootout 💥 - the league record for the most combined points in a single game. Only the 3 highest-scoring sets count, so a best-of-5 final competes on equal terms with an ordinary best-of-3. A 60+ point game sets the first record.",
         "Season Opener 🌱 - earned by both players of a season's very first game. Awarded per season, so it comes around again every quarter.",
+        "Milestone Game 🏁 - earned by both players of the league's 100th, 500th, 1,000th and every following thousandth game. Deleted games do not count. The progress view shows the league's shared count toward the next milestone.",
       ),
       text(
-        "David 🪨 and Goliath 🗿 are now league records rather than fixed thresholds. Previously every single-game swing of 30+ Score earned them; now the first such swing set the record, and only a strictly bigger single-game gain (David, for the winner) or loss (Goliath, for the loser) takes it over. Score is zero-sum, so one upset always moves both records together. Because achievements are recomputed from history, some previously earned David and Goliath badges are gone - only the record-breaking upsets remain, and the progress view now shows the record and its holder.",
+        "David 🪨 and Goliath 🗿 are now league records rather than fixed thresholds. Previously every single-game swing of 30+ Score earned them; now the first 20+ Score swing set the record, and only a strictly bigger single-game gain (David, for the winner) or loss (Goliath, for the loser) takes it over. Score is zero-sum, so one upset always moves both records together. Because achievements are recomputed from history, some previously earned David and Goliath badges are gone - only the record-breaking upsets remain, and the progress view now shows the record and its holder.",
       ),
       text(
-        "Perfect Week 🗓️ no longer demands wins Monday through Friday specifically: winning on any 5 consecutive days within the same week now counts - Mon-Fri, Tue-Sat or Wed-Sun. A run that crosses into the next week does not.",
+        "Perfect Week 🗓️ no longer demands wins Monday through Friday specifically: winning on any 5 consecutive days within the same week now counts - Mon-Fri, Tue-Sat or Wed-Sun. A run that crosses into the next week does not, and losses never spoil a run - only the wins matter.",
       ),
     ],
   },

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -39,7 +39,7 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
       "Shootout 💥 is the record for the most points in one game, Season Opener 🌱 goes to the players of a season's first game, Milestone Game 🏁 marks every 500th game the league plays, David 🪨 and Goliath 🗿 are now league records, and Perfect Week 🗓️ accepts any 5 consecutive days within a week.",
     body: [
       list(
-        "Shootout 💥 - the league record for the most combined points in a single game. Only the 3 highest-scoring sets count, so a best-of-5 final competes on equal terms with an ordinary best-of-3. A 60+ point game sets the first record. Games containing an invalid set score (like 15-12 - above 11 a set must be won by exactly 2) do not compete, so house rules that award bonus points cannot inflate a total past what legit games can reach.",
+        "Shootout 💥 - the league record for the most combined points in a single game. Only the 3 highest-scoring legal sets count, so a best-of-5 final competes on equal terms with an ordinary best-of-3. A 60+ point game sets the first record. Games containing an illegal set score (like 15-12 - above 11 a set must be won by exactly 2) do not compete at all, so house rules that award bonus points cannot inflate a total past what legitimate games can reach.",
         "Season Opener 🌱 - earned by both players of a season's very first game. Awarded per season, so it comes around again every quarter.",
         "Milestone Game 🏁 - earned by both players of every 500th game the league plays. Deleted games do not count. The progress view is shared by everyone and restarts at each milestone, showing how many games remain until the next milestone game.",
       ),

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -31,6 +31,26 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "shootout-season-opener-and-record-david-goliath",
+    title: "2 new achievements, and David & Goliath become league records",
+    date: "2026-08-04",
+    tags: ["new-feature", "feature-update"],
+    summary:
+      "Shootout 💥 is the record for the most points in one game, Season Opener 🌱 goes to the players of a season's first game, David 🪨 and Goliath 🗿 are now league records instead of fixed thresholds, and Perfect Week 🗓️ accepts any 5 consecutive days within a week.",
+    body: [
+      list(
+        "Shootout 💥 - the league record for the most combined points in a single game. Only the 3 highest-scoring sets count, so a best-of-5 final competes on equal terms with an ordinary best-of-3. A 60+ point game sets the first record.",
+        "Season Opener 🌱 - earned by both players of a season's very first game. Awarded per season, so it comes around again every quarter.",
+      ),
+      text(
+        "David 🪨 and Goliath 🗿 are now league records rather than fixed thresholds. Previously every single-game swing of 30+ Score earned them; now the first such swing set the record, and only a strictly bigger single-game gain (David, for the winner) or loss (Goliath, for the loser) takes it over. Score is zero-sum, so one upset always moves both records together. Because achievements are recomputed from history, some previously earned David and Goliath badges are gone - only the record-breaking upsets remain, and the progress view now shows the record and its holder.",
+      ),
+      text(
+        "Perfect Week 🗓️ no longer demands wins Monday through Friday specifically: winning on any 5 consecutive days within the same week now counts - Mon-Fri, Tue-Sat or Wed-Sun. A run that crosses into the next week does not.",
+      ),
+    ],
+  },
+  {
     slug: "hero-of-the-week-and-month-achievements",
     title: "2 new achievements: Hero of the Week and Hero of the Month",
     date: "2026-08-03",

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -36,12 +36,12 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
     date: "2026-08-04",
     tags: ["new-feature", "feature-update"],
     summary:
-      "Shootout 💥 is the record for the most points in one game, Season Opener 🌱 goes to the players of a season's first game, Milestone Game 🏁 marks the league's 100th, 500th and every thousandth game, David 🪨 and Goliath 🗿 are now league records, and Perfect Week 🗓️ accepts any 5 consecutive days within a week.",
+      "Shootout 💥 is the record for the most points in one game, Season Opener 🌱 goes to the players of a season's first game, Milestone Game 🏁 marks every 500th game the league plays, David 🪨 and Goliath 🗿 are now league records, and Perfect Week 🗓️ accepts any 5 consecutive days within a week.",
     body: [
       list(
         "Shootout 💥 - the league record for the most combined points in a single game. Only the 3 highest-scoring sets count, so a best-of-5 final competes on equal terms with an ordinary best-of-3. A 60+ point game sets the first record.",
         "Season Opener 🌱 - earned by both players of a season's very first game. Awarded per season, so it comes around again every quarter.",
-        "Milestone Game 🏁 - earned by both players of the league's 100th, 500th, 1,000th and every following thousandth game. Deleted games do not count. The progress view is shared by everyone and restarts at each milestone, showing how many games remain until the next milestone game.",
+        "Milestone Game 🏁 - earned by both players of every 500th game the league plays. Deleted games do not count. The progress view is shared by everyone and restarts at each milestone, showing how many games remain until the next milestone game.",
       ),
       text(
         "David 🪨 and Goliath 🗿 are now league records rather than fixed thresholds. Previously every single-game swing of 30+ Score earned them; now the first 20+ Score swing set the record, and only a strictly bigger single-game gain (David, for the winner) or loss (Goliath, for the loser) takes it over. Score is zero-sum, so one upset always moves both records together. Because achievements are recomputed from history, some previously earned David and Goliath badges are gone - only the record-breaking upsets remain, and the progress view now shows the record and its holder.",

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -39,7 +39,7 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
       "Shootout 💥 is the record for the most points in one game, Season Opener 🌱 goes to the players of a season's first game, Milestone Game 🏁 marks every 500th game the league plays, David 🪨 and Goliath 🗿 are now league records, and Perfect Week 🗓️ accepts any 5 consecutive days within a week.",
     body: [
       list(
-        "Shootout 💥 - the league record for the most combined points in a single game. Only the 3 highest-scoring sets count, so a best-of-5 final competes on equal terms with an ordinary best-of-3. A 60+ point game sets the first record.",
+        "Shootout 💥 - the league record for the most combined points in a single game. Only the 3 highest-scoring sets count, so a best-of-5 final competes on equal terms with an ordinary best-of-3. A 60+ point game sets the first record. Games containing an invalid set score (like 15-12 - above 11 a set must be won by exactly 2) do not compete, so house rules that award bonus points cannot inflate a total past what legit games can reach.",
         "Season Opener 🌱 - earned by both players of a season's very first game. Awarded per season, so it comes around again every quarter.",
         "Milestone Game 🏁 - earned by both players of every 500th game the league plays. Deleted games do not count. The progress view is shared by everyone and restarts at each milestone, showing how many games remain until the next milestone game.",
       ),

--- a/frontend/src/client/client-db/__tests__/achievements/david.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/david.test.ts
@@ -2,10 +2,11 @@ import { TennisTable } from "../../tennis-table";
 import { EventType, EventTypeEnum } from "../../event-store/event-types";
 
 // David is the league record for the biggest single-game Elo gain. A gain of
-// UPSET_RECORD_FLOOR (30 — requiring the loser to have been roughly 470+ Elo
+// UPSET_RECORD_FLOOR (20 — requiring the loser to have been roughly 90+ Elo
 // above the winner) establishes the first record; after that only a strictly
 // bigger gain takes the record over and awards again. Both players must be
-// ranked at the time of the match.
+// ranked at the time of the match. The fixtures here produce ≥30-point
+// swings, comfortably past the floor.
 
 describe("David Achievement", () => {
   const createPlayer = (id: string, time: number): EventType => ({
@@ -36,7 +37,7 @@ describe("David Achievement", () => {
     return events;
   };
 
-  it("awards David when a ≥30 Elo gain establishes the first league record", () => {
+  it("awards David when a gain past the record floor establishes the first league record", () => {
     // Goliath beats 200 fresh opponents → Elo well above 1500.
     // David beats 5 fresh opponents → ranked at Elo ~1073.
     // David then beats Goliath — the upset yields a ≥30 Elo swing.
@@ -137,8 +138,9 @@ describe("David Achievement", () => {
   });
 
   it("does NOT fire for a typical match with similar-rated players", () => {
-    // Standard 5-player double round-robin — Elos stay within ~200 of
-    // each other so no swing reaches 30.
+    // Standard 5-player double round-robin where the stronger player always
+    // wins — every gain is at most the evenly-matched 16 points, under the
+    // 20-point record floor.
     const events: EventType[] = [
       createPlayer("a", 1),
       createPlayer("b", 2),

--- a/frontend/src/client/client-db/__tests__/achievements/david.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/david.test.ts
@@ -1,9 +1,11 @@
 import { TennisTable } from "../../tennis-table";
 import { EventType, EventTypeEnum } from "../../event-store/event-types";
 
-// David fires when the winner gains ≥ 30 Elo from a single match, which
-// requires the loser to have been roughly 470+ Elo above the winner. Both
-// players must be ranked at the time of the match.
+// David is the league record for the biggest single-game Elo gain. A gain of
+// UPSET_RECORD_FLOOR (30 — requiring the loser to have been roughly 470+ Elo
+// above the winner) establishes the first record; after that only a strictly
+// bigger gain takes the record over and awards again. Both players must be
+// ranked at the time of the match.
 
 describe("David Achievement", () => {
   const createPlayer = (id: string, time: number): EventType => ({
@@ -34,7 +36,7 @@ describe("David Achievement", () => {
     return events;
   };
 
-  it("awards David when the winner gains ≥30 Elo from a single match", () => {
+  it("awards David when a ≥30 Elo gain establishes the first league record", () => {
     // Goliath beats 200 fresh opponents → Elo well above 1500.
     // David beats 5 fresh opponents → ranked at Elo ~1073.
     // David then beats Goliath — the upset yields a ≥30 Elo swing.
@@ -57,6 +59,81 @@ describe("David Achievement", () => {
     expect(davids).toHaveLength(1);
     expect(davids[0].data).toMatchObject({ opponent: "goliath", gameId: "upset" });
     expect(davids[0].data?.eloGain).toBeGreaterThanOrEqual(30);
+    // First league record — nothing to break yet.
+    expect(davids[0].data?.previousRecord).toBeUndefined();
+    expect(tt.achievements.davidRecord).toStrictEqual({
+      eloGain: davids[0].data?.eloGain,
+      holder: "david",
+    });
+  });
+
+  it("does NOT award again for a swing that fails to beat the standing record", () => {
+    // After the first upset the Elo gap between the pair has narrowed, so a
+    // rematch win yields a strictly smaller gain — no new award.
+    const events: EventType[] = [
+      ...buildGoliath(200),
+      createPlayer("david", 5000),
+    ];
+    for (let i = 0; i < 5; i++) {
+      events.push(createPlayer(`dopp-${i}`, 5010 + i));
+    }
+    for (let i = 0; i < 5; i++) {
+      events.push(game(`dg-${i}`, 6000 + i, "david", `dopp-${i}`));
+    }
+    events.push(game("upset", 10000, "david", "goliath"));
+    events.push(game("rematch", 10001, "david", "goliath"));
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const davids = tt.achievements.getAchievements("david").filter((a) => a.type === "david");
+    expect(davids).toHaveLength(1);
+    expect(davids[0].data?.gameId).toBe("upset");
+  });
+
+  it("awards again with previousRecord when a strictly bigger swing breaks the record", () => {
+    // First record: david-1 (5 wins, ~1073) beats goliath-1 (200 wins).
+    // Then david-2, in an identical position, beats goliath-2 who has 400
+    // wins — a bigger Elo gap with the same K-factor, so a strictly bigger
+    // gain that takes the record over.
+    const events: EventType[] = [
+      ...buildGoliath(200),
+      createPlayer("david", 5000),
+    ];
+    for (let i = 0; i < 5; i++) {
+      events.push(createPlayer(`dopp-${i}`, 5010 + i));
+    }
+    for (let i = 0; i < 5; i++) {
+      events.push(game(`dg-${i}`, 6000 + i, "david", `dopp-${i}`));
+    }
+    events.push(game("upset", 10000, "david", "goliath"));
+
+    events.push(createPlayer("goliath-2", 20000));
+    for (let i = 0; i < 400; i++) {
+      events.push(createPlayer(`g2opp-${i}`, 20010 + i));
+    }
+    for (let i = 0; i < 400; i++) {
+      events.push(game(`g2g-${i}`, 21000 + i, "goliath-2", `g2opp-${i}`));
+    }
+    events.push(createPlayer("david-2", 30000));
+    for (let i = 0; i < 5; i++) {
+      events.push(createPlayer(`d2opp-${i}`, 30010 + i));
+    }
+    for (let i = 0; i < 5; i++) {
+      events.push(game(`d2g-${i}`, 31000 + i, "david-2", `d2opp-${i}`));
+    }
+    events.push(game("upset-2", 40000, "david-2", "goliath-2"));
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const firstBadge = tt.achievements.getAchievements("david").find((a) => a.type === "david");
+    const secondBadge = tt.achievements.getAchievements("david-2").find((a) => a.type === "david");
+    expect(firstBadge).toBeDefined();
+    expect(secondBadge).toBeDefined();
+    expect(secondBadge?.data?.eloGain).toBeGreaterThan(firstBadge?.data?.eloGain ?? Infinity);
+    expect(secondBadge?.data?.previousRecord).toBe(firstBadge?.data?.eloGain);
+    expect(tt.achievements.davidRecord.holder).toBe("david-2");
   });
 
   it("does NOT fire for a typical match with similar-rated players", () => {
@@ -109,12 +186,28 @@ describe("David Achievement", () => {
     tt.achievements.calculateAchievements();
     const progression = tt.achievements.getPlayerProgression("david");
 
-    expect(progression.david.target).toBe(30);
     expect(progression.david.earned).toBe(1);
     expect(progression.david.current).toBeGreaterThanOrEqual(30);
-    // The progression value should equal the Elo gain stored on the badge.
+    // The progression value should equal the Elo gain stored on the badge,
+    // and the badge's gain is the league record to beat.
     const badge = tt.achievements.getAchievements("david").find((a) => a.type === "david");
     expect(progression.david.current).toBe(badge?.data?.eloGain);
+    expect(progression.david.target).toBe(badge?.data?.eloGain);
+    expect(progression.david.recordHolder).toBe("david");
+  });
+
+  it("progression has no target while nobody holds the record", () => {
+    const events: EventType[] = [
+      createPlayer("alice", 1),
+      createPlayer("bob", 2),
+      game("g1", 100, "bob", "alice"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getPlayerProgression("bob").david.target).toBeUndefined();
+    expect(tt.achievements.getPlayerProgression("bob").david.recordHolder).toBeUndefined();
   });
 
   it("progression current is 0 when the player has no wins", () => {

--- a/frontend/src/client/client-db/__tests__/achievements/goliath.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/goliath.test.ts
@@ -2,11 +2,12 @@ import { TennisTable } from "../../tennis-table";
 import { EventType, EventTypeEnum } from "../../event-store/event-types";
 
 // Goliath is the league record for the biggest single-game Elo loss. A loss
-// of UPSET_RECORD_FLOOR (30 — requiring the winner to have been roughly 470+
+// of UPSET_RECORD_FLOOR (20 — requiring the winner to have been roughly 90+
 // Elo below the loser) establishes the first record; after that only a
 // strictly bigger loss takes the record over and awards again. Both players
 // must be ranked at the time of the match. It is the mirror of David — the
-// game that sets the David record sets the Goliath record too.
+// game that sets the David record sets the Goliath record too. The fixtures
+// here produce ≥30-point swings, comfortably past the floor.
 
 describe("Goliath Achievement", () => {
   const createPlayer = (id: string, time: number): EventType => ({
@@ -37,7 +38,7 @@ describe("Goliath Achievement", () => {
     return events;
   };
 
-  it("awards Goliath when a ≥30 Elo loss establishes the first league record", () => {
+  it("awards Goliath when a loss past the record floor establishes the first league record", () => {
     // Goliath beats 200 fresh opponents → Elo well above 1500.
     // David beats 5 fresh opponents → ranked at Elo ~1073.
     // David then beats Goliath — the upset yields a ≥30 Elo swing.
@@ -69,8 +70,9 @@ describe("Goliath Achievement", () => {
   });
 
   it("does NOT fire for a typical match with similar-rated players", () => {
-    // Standard 5-player double round-robin — Elos stay within ~200 of
-    // each other so no swing reaches 30.
+    // Standard 5-player double round-robin where the stronger player always
+    // wins — every loss is at most the evenly-matched 16 points, under the
+    // 20-point record floor.
     const events: EventType[] = [
       createPlayer("a", 1),
       createPlayer("b", 2),

--- a/frontend/src/client/client-db/__tests__/achievements/goliath.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/goliath.test.ts
@@ -1,11 +1,12 @@
 import { TennisTable } from "../../tennis-table";
 import { EventType, EventTypeEnum } from "../../event-store/event-types";
 
-// Goliath fires when the loser drops ≥ 30 Elo from a single match, which
-// requires the winner to have been roughly 470+ Elo below the loser. Both
-// players must be ranked at the time of the match. It is the mirror of
-// David — when David fires for the winner, Goliath fires for the loser of
-// the same game.
+// Goliath is the league record for the biggest single-game Elo loss. A loss
+// of UPSET_RECORD_FLOOR (30 — requiring the winner to have been roughly 470+
+// Elo below the loser) establishes the first record; after that only a
+// strictly bigger loss takes the record over and awards again. Both players
+// must be ranked at the time of the match. It is the mirror of David — the
+// game that sets the David record sets the Goliath record too.
 
 describe("Goliath Achievement", () => {
   const createPlayer = (id: string, time: number): EventType => ({
@@ -36,7 +37,7 @@ describe("Goliath Achievement", () => {
     return events;
   };
 
-  it("awards Goliath to the loser when they lose ≥30 Elo from a single match", () => {
+  it("awards Goliath when a ≥30 Elo loss establishes the first league record", () => {
     // Goliath beats 200 fresh opponents → Elo well above 1500.
     // David beats 5 fresh opponents → ranked at Elo ~1073.
     // David then beats Goliath — the upset yields a ≥30 Elo swing.
@@ -59,6 +60,12 @@ describe("Goliath Achievement", () => {
     expect(goliaths).toHaveLength(1);
     expect(goliaths[0].data).toMatchObject({ opponent: "david", gameId: "upset" });
     expect(goliaths[0].data?.eloLoss).toBeGreaterThanOrEqual(30);
+    // First league record — nothing to break yet.
+    expect(goliaths[0].data?.previousRecord).toBeUndefined();
+    expect(tt.achievements.goliathRecord).toStrictEqual({
+      eloLoss: goliaths[0].data?.eloLoss,
+      holder: "goliath",
+    });
   });
 
   it("does NOT fire for a typical match with similar-rated players", () => {
@@ -112,12 +119,14 @@ describe("Goliath Achievement", () => {
     tt.achievements.calculateAchievements();
     const progression = tt.achievements.getPlayerProgression("goliath");
 
-    expect(progression.goliath.target).toBe(30);
     expect(progression.goliath.earned).toBe(1);
     expect(progression.goliath.current).toBeGreaterThanOrEqual(30);
-    // The progression value should equal the Elo loss stored on the badge.
+    // The progression value should equal the Elo loss stored on the badge,
+    // and the badge's loss is the league record to beat.
     const badge = tt.achievements.getAchievements("goliath").find((a) => a.type === "goliath");
     expect(progression.goliath.current).toBe(badge?.data?.eloLoss);
+    expect(progression.goliath.target).toBe(badge?.data?.eloLoss);
+    expect(progression.goliath.recordHolder).toBe("goliath");
   });
 
   it("progression current is 0 when the player has no losses", () => {

--- a/frontend/src/client/client-db/__tests__/achievements/milestone-game.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/milestone-game.test.ts
@@ -1,0 +1,106 @@
+import { TennisTable } from "../../tennis-table";
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+
+// Milestone Game is awarded to BOTH players of the league's 100th, 500th,
+// 1,000th and every following thousandth game. Deleted games do not count —
+// the numbering follows the games that still exist.
+describe("Milestone Game Achievement", () => {
+  const baseEvents: EventType[] = [
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "alice", time: 1, data: { name: "Alice" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "bob", time: 2, data: { name: "Bob" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "carol", time: 3, data: { name: "Carol" } },
+  ];
+
+  const game = (id: string, playedAt: number, winner: string, loser: string): EventType => ({
+    type: EventTypeEnum.GAME_CREATED,
+    stream: id,
+    time: playedAt,
+    data: { winner, loser, playedAt },
+  });
+
+  // `count` alice-vs-bob games at increasing timestamps, ids g-1..g-count.
+  const games = (count: number): EventType[] =>
+    Array.from({ length: count }, (_, i) => game(`g-${i + 1}`, 1000 + i, "alice", "bob"));
+
+  it("awards BOTH players of the 100th game — and not the games around it", () => {
+    const events: EventType[] = [...baseEvents, ...games(101)];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const alice = tt.achievements.getAchievements("alice").filter((a) => a.type === "milestone-game");
+    const bob = tt.achievements.getAchievements("bob").filter((a) => a.type === "milestone-game");
+    expect(alice).toHaveLength(1);
+    expect(bob).toHaveLength(1);
+    expect(alice[0]).toStrictEqual({
+      type: "milestone-game",
+      earnedBy: "alice",
+      earnedAt: 1000 + 99,
+      data: { gameId: "g-100", opponent: "bob", milestone: 100 },
+    });
+    expect(bob[0].data?.opponent).toBe("alice");
+  });
+
+  it("does NOT award before the first milestone", () => {
+    const events: EventType[] = [...baseEvents, ...games(99)];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "milestone-game")).toHaveLength(0);
+  });
+
+  it("awards at 100, 500 and 1,000 — one badge per milestone", () => {
+    const events: EventType[] = [...baseEvents, ...games(1000)];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const alice = tt.achievements.getAchievements("alice").filter((a) => a.type === "milestone-game");
+    expect(alice.map((a) => a.data?.milestone)).toStrictEqual([100, 500, 1000]);
+  });
+
+  it("deleted games do not count toward the milestone numbering", () => {
+    // 100 games are created, but one early game is deleted — so the game
+    // created 100th is only league game #99, and the 101st created game
+    // becomes the real #100.
+    const events: EventType[] = [
+      ...baseEvents,
+      ...games(100),
+      { type: EventTypeEnum.GAME_DELETED, stream: "g-50", time: 5000, data: null },
+      game("g-101", 6000, "carol", "alice"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const carol = tt.achievements.getAchievements("carol").filter((a) => a.type === "milestone-game");
+    expect(carol).toHaveLength(1);
+    expect(carol[0].data).toStrictEqual({ gameId: "g-101", opponent: "alice", milestone: 100 });
+
+    // Alice was in every game; her only milestone badge is g-101 too — the
+    // originally-100th created game never counted as #100.
+    const alice = tt.achievements.getAchievements("alice").filter((a) => a.type === "milestone-game");
+    expect(alice).toHaveLength(1);
+    expect(alice[0].data?.gameId).toBe("g-101");
+  });
+
+  it("progression counts the league's games toward the next milestone", () => {
+    const events: EventType[] = [...baseEvents, ...games(120)];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const alice = tt.achievements.getPlayerProgression("alice")["milestone-game"];
+    expect(alice.current).toBe(120);
+    expect(alice.target).toBe(500);
+    expect(alice.earned).toBe(1);
+
+    // League-wide chase: a player who was in none of the games sees the
+    // same progress, just nothing earned.
+    const carol = tt.achievements.getPlayerProgression("carol")["milestone-game"];
+    expect(carol.current).toBe(120);
+    expect(carol.target).toBe(500);
+    expect(carol.earned).toBe(0);
+  });
+});

--- a/frontend/src/client/client-db/__tests__/achievements/milestone-game.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/milestone-game.test.ts
@@ -1,9 +1,9 @@
 import { TennisTable } from "../../tennis-table";
 import { EventType, EventTypeEnum } from "../../event-store/event-types";
 
-// Milestone Game is awarded to BOTH players of the league's 100th, 500th,
-// 1,000th and every following thousandth game. Deleted games do not count —
-// the numbering follows the games that still exist.
+// Milestone Game is awarded to BOTH players of every 500th league game
+// (the 500th, 1,000th, 1,500th, ...). Deleted games do not count — the
+// numbering follows the games that still exist.
 describe("Milestone Game Achievement", () => {
   const baseEvents: EventType[] = [
     { type: EventTypeEnum.PLAYER_CREATED, stream: "alice", time: 1, data: { name: "Alice" } },
@@ -22,8 +22,8 @@ describe("Milestone Game Achievement", () => {
   const games = (count: number): EventType[] =>
     Array.from({ length: count }, (_, i) => game(`g-${i + 1}`, 1000 + i, "alice", "bob"));
 
-  it("awards BOTH players of the 100th game — and not the games around it", () => {
-    const events: EventType[] = [...baseEvents, ...games(101)];
+  it("awards BOTH players of the 500th game — and not the games around it", () => {
+    const events: EventType[] = [...baseEvents, ...games(501)];
 
     const tt = new TennisTable({ events });
     tt.achievements.calculateAchievements();
@@ -35,14 +35,14 @@ describe("Milestone Game Achievement", () => {
     expect(alice[0]).toStrictEqual({
       type: "milestone-game",
       earnedBy: "alice",
-      earnedAt: 1000 + 99,
-      data: { gameId: "g-100", opponent: "bob", milestone: 100 },
+      earnedAt: 1000 + 499,
+      data: { gameId: "g-500", opponent: "bob", milestone: 500 },
     });
     expect(bob[0].data?.opponent).toBe("alice");
   });
 
   it("does NOT award before the first milestone", () => {
-    const events: EventType[] = [...baseEvents, ...games(99)];
+    const events: EventType[] = [...baseEvents, ...games(499)];
 
     const tt = new TennisTable({ events });
     tt.achievements.calculateAchievements();
@@ -50,25 +50,25 @@ describe("Milestone Game Achievement", () => {
     expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "milestone-game")).toHaveLength(0);
   });
 
-  it("awards at 100, 500 and 1,000 — one badge per milestone", () => {
-    const events: EventType[] = [...baseEvents, ...games(1000)];
+  it("awards at every 500th game — one badge per milestone", () => {
+    const events: EventType[] = [...baseEvents, ...games(1500)];
 
     const tt = new TennisTable({ events });
     tt.achievements.calculateAchievements();
 
     const alice = tt.achievements.getAchievements("alice").filter((a) => a.type === "milestone-game");
-    expect(alice.map((a) => a.data?.milestone)).toStrictEqual([100, 500, 1000]);
+    expect(alice.map((a) => a.data?.milestone)).toStrictEqual([500, 1000, 1500]);
   });
 
   it("deleted games do not count toward the milestone numbering", () => {
-    // 100 games are created, but one early game is deleted — so the game
-    // created 100th is only league game #99, and the 101st created game
-    // becomes the real #100.
+    // 500 games are created, but one early game is deleted — so the game
+    // created 500th is only league game #499, and the 501st created game
+    // becomes the real #500.
     const events: EventType[] = [
       ...baseEvents,
-      ...games(100),
-      { type: EventTypeEnum.GAME_DELETED, stream: "g-50", time: 5000, data: null },
-      game("g-101", 6000, "carol", "alice"),
+      ...games(500),
+      { type: EventTypeEnum.GAME_DELETED, stream: "g-250", time: 5000, data: null },
+      game("g-501", 6000, "carol", "alice"),
     ];
 
     const tt = new TennisTable({ events });
@@ -76,47 +76,46 @@ describe("Milestone Game Achievement", () => {
 
     const carol = tt.achievements.getAchievements("carol").filter((a) => a.type === "milestone-game");
     expect(carol).toHaveLength(1);
-    expect(carol[0].data).toStrictEqual({ gameId: "g-101", opponent: "alice", milestone: 100 });
+    expect(carol[0].data).toStrictEqual({ gameId: "g-501", opponent: "alice", milestone: 500 });
 
-    // Alice was in every game; her only milestone badge is g-101 too — the
-    // originally-100th created game never counted as #100.
+    // Alice was in every game; her only milestone badge is g-501 too — the
+    // originally-500th created game never counted as #500.
     const alice = tt.achievements.getAchievements("alice").filter((a) => a.type === "milestone-game");
     expect(alice).toHaveLength(1);
-    expect(alice[0].data?.gameId).toBe("g-101");
+    expect(alice[0].data?.gameId).toBe("g-501");
   });
 
-  it("progression restarts at each milestone and spans to the next", () => {
-    // 120 games: the 100 milestone has passed, so the chase is 20 games into
-    // the 400-game span from 100 to 500 — 380 games until the next milestone.
-    const events: EventType[] = [...baseEvents, ...games(120)];
+  it("progression restarts at each milestone and spans the 500-game interval", () => {
+    // 620 games: 120 into the 500-game stretch toward 1,000 — 380 to go.
+    const events: EventType[] = [...baseEvents, ...games(620)];
 
     const tt = new TennisTable({ events });
     tt.achievements.calculateAchievements();
 
     const alice = tt.achievements.getPlayerProgression("alice")["milestone-game"];
-    expect(alice.current).toBe(20);
-    expect(alice.target).toBe(400);
+    expect(alice.current).toBe(120);
+    expect(alice.target).toBe(500);
     expect(alice.earned).toBe(1);
 
     // League-wide chase: a player who was in none of the games sees the
     // same progress, just nothing earned.
     const carol = tt.achievements.getPlayerProgression("carol")["milestone-game"];
-    expect(carol.current).toBe(20);
-    expect(carol.target).toBe(400);
+    expect(carol.current).toBe(120);
+    expect(carol.target).toBe(500);
     expect(carol.earned).toBe(0);
   });
 
-  it("progression starts from 0 before the first milestone and resets to 0 at one", () => {
-    const before = new TennisTable({ events: [...baseEvents, ...games(99)] });
+  it("progression starts from 0 and resets to 0 at a milestone", () => {
+    const before = new TennisTable({ events: [...baseEvents, ...games(499)] });
     before.achievements.calculateAchievements();
     const beforeProgress = before.achievements.getPlayerProgression("alice")["milestone-game"];
-    expect(beforeProgress.current).toBe(99);
-    expect(beforeProgress.target).toBe(100);
+    expect(beforeProgress.current).toBe(499);
+    expect(beforeProgress.target).toBe(500);
 
-    const at = new TennisTable({ events: [...baseEvents, ...games(100)] });
+    const at = new TennisTable({ events: [...baseEvents, ...games(500)] });
     at.achievements.calculateAchievements();
     const atProgress = at.achievements.getPlayerProgression("alice")["milestone-game"];
     expect(atProgress.current).toBe(0);
-    expect(atProgress.target).toBe(400);
+    expect(atProgress.target).toBe(500);
   });
 });

--- a/frontend/src/client/client-db/__tests__/achievements/milestone-game.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/milestone-game.test.ts
@@ -85,22 +85,38 @@ describe("Milestone Game Achievement", () => {
     expect(alice[0].data?.gameId).toBe("g-101");
   });
 
-  it("progression counts the league's games toward the next milestone", () => {
+  it("progression restarts at each milestone and spans to the next", () => {
+    // 120 games: the 100 milestone has passed, so the chase is 20 games into
+    // the 400-game span from 100 to 500 — 380 games until the next milestone.
     const events: EventType[] = [...baseEvents, ...games(120)];
 
     const tt = new TennisTable({ events });
     tt.achievements.calculateAchievements();
 
     const alice = tt.achievements.getPlayerProgression("alice")["milestone-game"];
-    expect(alice.current).toBe(120);
-    expect(alice.target).toBe(500);
+    expect(alice.current).toBe(20);
+    expect(alice.target).toBe(400);
     expect(alice.earned).toBe(1);
 
     // League-wide chase: a player who was in none of the games sees the
     // same progress, just nothing earned.
     const carol = tt.achievements.getPlayerProgression("carol")["milestone-game"];
-    expect(carol.current).toBe(120);
-    expect(carol.target).toBe(500);
+    expect(carol.current).toBe(20);
+    expect(carol.target).toBe(400);
     expect(carol.earned).toBe(0);
+  });
+
+  it("progression starts from 0 before the first milestone and resets to 0 at one", () => {
+    const before = new TennisTable({ events: [...baseEvents, ...games(99)] });
+    before.achievements.calculateAchievements();
+    const beforeProgress = before.achievements.getPlayerProgression("alice")["milestone-game"];
+    expect(beforeProgress.current).toBe(99);
+    expect(beforeProgress.target).toBe(100);
+
+    const at = new TennisTable({ events: [...baseEvents, ...games(100)] });
+    at.achievements.calculateAchievements();
+    const atProgress = at.achievements.getPlayerProgression("alice")["milestone-game"];
+    expect(atProgress.current).toBe(0);
+    expect(atProgress.target).toBe(400);
   });
 });

--- a/frontend/src/client/client-db/__tests__/achievements/perfect-week.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/perfect-week.test.ts
@@ -1,6 +1,10 @@
 import { TennisTable } from "../../tennis-table";
 import { EventType, EventTypeEnum } from "../../event-store/event-types";
 
+// Perfect Week: win a game on each of 5 consecutive calendar days, all
+// within the same Monday-start week — Mon–Fri, Tue–Sat or Wed–Sun. A run
+// crossing a week boundary does not count, and each week awards at most once.
+//
 // Jan 15 2024 is a Monday, so 15=Mon, 16=Tue, 17=Wed, 18=Thu, 19=Fri,
 // 20=Sat, 21=Sun. Jan 22 2024 is the following Monday.
 describe("Perfect Week Achievement Tests", () => {
@@ -24,7 +28,7 @@ describe("Perfect Week Achievement Tests", () => {
     };
   }
 
-  it("awards perfect-week for a win on every weekday Mon–Fri", () => {
+  it("awards perfect-week for wins on Mon–Fri", () => {
     const events: EventType[] = [
       ...baseEvents,
       win(2024, 0, 15, "player-1", "player-2", "mon"),
@@ -40,34 +44,17 @@ describe("Perfect Week Achievement Tests", () => {
     const perfectWeeks = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-week");
     expect(perfectWeeks).toHaveLength(1);
     expect(perfectWeeks[0].data.weekStart).toBe(new Date(2024, 0, 15).getTime());
-    // Earned at the Friday win that completed the set.
+    expect(perfectWeeks[0].data.startDay).toBe(new Date(2024, 0, 15).getTime());
+    // Earned at the Friday win that completed the run.
     expect(perfectWeeks[0].earnedAt).toBe(new Date(2024, 0, 19, 12).getTime());
   });
 
-  it("does NOT award when only Mon–Thu are won", () => {
+  it("awards perfect-week for wins on Wed–Sun (weekend days count)", () => {
     const events: EventType[] = [
       ...baseEvents,
-      win(2024, 0, 15, "player-1", "player-2", "mon"),
-      win(2024, 0, 16, "player-1", "player-2", "tue"),
       win(2024, 0, 17, "player-1", "player-2", "wed"),
       win(2024, 0, 18, "player-1", "player-2", "thu"),
-    ];
-
-    const tennisTable = new TennisTable({ events });
-    tennisTable.achievements.calculateAchievements();
-
-    const perfectWeeks = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-week");
-    expect(perfectWeeks).toHaveLength(0);
-  });
-
-  it("does NOT count weekend wins toward the working week", () => {
-    const events: EventType[] = [
-      ...baseEvents,
-      win(2024, 0, 15, "player-1", "player-2", "mon"),
-      win(2024, 0, 16, "player-1", "player-2", "tue"),
-      win(2024, 0, 17, "player-1", "player-2", "wed"),
-      win(2024, 0, 18, "player-1", "player-2", "thu"),
-      // Saturday + Sunday wins — do not substitute for Friday.
+      win(2024, 0, 19, "player-1", "player-2", "fri"),
       win(2024, 0, 20, "player-1", "player-2", "sat"),
       win(2024, 0, 21, "player-1", "player-2", "sun"),
     ];
@@ -76,19 +63,20 @@ describe("Perfect Week Achievement Tests", () => {
     tennisTable.achievements.calculateAchievements();
 
     const perfectWeeks = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-week");
-    expect(perfectWeeks).toHaveLength(0);
+    expect(perfectWeeks).toHaveLength(1);
+    expect(perfectWeeks[0].data.weekStart).toBe(new Date(2024, 0, 15).getTime());
+    expect(perfectWeeks[0].data.startDay).toBe(new Date(2024, 0, 17).getTime());
+    expect(perfectWeeks[0].earnedAt).toBe(new Date(2024, 0, 21, 12).getTime());
   });
 
-  it("does NOT award when weekday wins are split across two different weeks", () => {
+  it("does NOT award for 5 consecutive days crossing a week boundary (Fri–Tue)", () => {
     const events: EventType[] = [
       ...baseEvents,
-      // Week 1: Mon, Tue, Wed
-      win(2024, 0, 15, "player-1", "player-2", "w1-mon"),
-      win(2024, 0, 16, "player-1", "player-2", "w1-tue"),
-      win(2024, 0, 17, "player-1", "player-2", "w1-wed"),
-      // Week 2: Thu, Fri
-      win(2024, 0, 25, "player-1", "player-2", "w2-thu"),
-      win(2024, 0, 26, "player-1", "player-2", "w2-fri"),
+      win(2024, 0, 19, "player-1", "player-2", "fri"),
+      win(2024, 0, 20, "player-1", "player-2", "sat"),
+      win(2024, 0, 21, "player-1", "player-2", "sun"),
+      win(2024, 0, 22, "player-1", "player-2", "mon"),
+      win(2024, 0, 23, "player-1", "player-2", "tue"),
     ];
 
     const tennisTable = new TennisTable({ events });
@@ -98,21 +86,77 @@ describe("Perfect Week Achievement Tests", () => {
     expect(perfectWeeks).toHaveLength(0);
   });
 
+  it("does NOT award for only 4 consecutive won days", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      win(2024, 0, 15, "player-1", "player-2", "mon"),
+      win(2024, 0, 16, "player-1", "player-2", "tue"),
+      win(2024, 0, 17, "player-1", "player-2", "wed"),
+      win(2024, 0, 18, "player-1", "player-2", "thu"),
+    ];
+
+    const tennisTable = new TennisTable({ events });
+    tennisTable.achievements.calculateAchievements();
+
+    const perfectWeeks = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-week");
+    expect(perfectWeeks).toHaveLength(0);
+  });
+
+  it("does NOT award for 5 won days that are not consecutive", () => {
+    // Mon, Tue, Thu, Fri, Sat — Wednesday breaks every possible run.
+    const events: EventType[] = [
+      ...baseEvents,
+      win(2024, 0, 15, "player-1", "player-2", "mon"),
+      win(2024, 0, 16, "player-1", "player-2", "tue"),
+      win(2024, 0, 18, "player-1", "player-2", "thu"),
+      win(2024, 0, 19, "player-1", "player-2", "fri"),
+      win(2024, 0, 20, "player-1", "player-2", "sat"),
+    ];
+
+    const tennisTable = new TennisTable({ events });
+    tennisTable.achievements.calculateAchievements();
+
+    const perfectWeeks = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-week");
+    expect(perfectWeeks).toHaveLength(0);
+  });
+
+  it("awards only once per week even when more than one run completes", () => {
+    // Mon–Sat won: Mon–Fri completes on Friday and Tue–Sat would complete on
+    // Saturday — one award, stamped at the Friday win.
+    const events: EventType[] = [
+      ...baseEvents,
+      win(2024, 0, 15, "player-1", "player-2", "mon"),
+      win(2024, 0, 16, "player-1", "player-2", "tue"),
+      win(2024, 0, 17, "player-1", "player-2", "wed"),
+      win(2024, 0, 18, "player-1", "player-2", "thu"),
+      win(2024, 0, 19, "player-1", "player-2", "fri"),
+      win(2024, 0, 20, "player-1", "player-2", "sat"),
+    ];
+
+    const tennisTable = new TennisTable({ events });
+    tennisTable.achievements.calculateAchievements();
+
+    const perfectWeeks = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-week");
+    expect(perfectWeeks).toHaveLength(1);
+    expect(perfectWeeks[0].data.startDay).toBe(new Date(2024, 0, 15).getTime());
+    expect(perfectWeeks[0].earnedAt).toBe(new Date(2024, 0, 19, 12).getTime());
+  });
+
   it("awards a separate perfect-week for each qualifying week", () => {
     const events: EventType[] = [
       ...baseEvents,
-      // Week of Jan 15
+      // Week of Jan 15: Mon–Fri
       win(2024, 0, 15, "player-1", "player-2", "w1-mon"),
       win(2024, 0, 16, "player-1", "player-2", "w1-tue"),
       win(2024, 0, 17, "player-1", "player-2", "w1-wed"),
       win(2024, 0, 18, "player-1", "player-2", "w1-thu"),
       win(2024, 0, 19, "player-1", "player-2", "w1-fri"),
-      // Week of Jan 22
-      win(2024, 0, 22, "player-1", "player-2", "w2-mon"),
+      // Week of Jan 22: Tue–Sat
       win(2024, 0, 23, "player-1", "player-2", "w2-tue"),
       win(2024, 0, 24, "player-1", "player-2", "w2-wed"),
       win(2024, 0, 25, "player-1", "player-2", "w2-thu"),
       win(2024, 0, 26, "player-1", "player-2", "w2-fri"),
+      win(2024, 0, 27, "player-1", "player-2", "w2-sat"),
     ];
 
     const tennisTable = new TennisTable({ events });
@@ -120,16 +164,19 @@ describe("Perfect Week Achievement Tests", () => {
 
     const perfectWeeks = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-week");
     expect(perfectWeeks).toHaveLength(2);
+    expect(perfectWeeks[0].data.startDay).toBe(new Date(2024, 0, 15).getTime());
+    expect(perfectWeeks[1].data.startDay).toBe(new Date(2024, 0, 23).getTime());
   });
 
-  it("only counts wins, not losses, toward a weekday", () => {
+  it("only counts wins, not losses, toward a day", () => {
     const events: EventType[] = [
       ...baseEvents,
       win(2024, 0, 15, "player-1", "player-2", "mon"),
       win(2024, 0, 16, "player-1", "player-2", "tue"),
       win(2024, 0, 17, "player-1", "player-2", "wed"),
       win(2024, 0, 18, "player-1", "player-2", "thu"),
-      // Friday: player-1 LOSES — does not count as a Friday win.
+      // Friday: player-1 LOSES — does not count as a Friday win, and no
+      // other run is completable from these days.
       win(2024, 0, 19, "player-2", "player-1", "fri"),
     ];
 
@@ -140,10 +187,28 @@ describe("Perfect Week Achievement Tests", () => {
     expect(perfectWeeks).toHaveLength(0);
   });
 
-  it("awards immediately on the Friday win, without waiting for the week to end", () => {
-    // "now" is Friday afternoon, right after the fifth weekday win. Unlike
-    // Perfect Day, nothing later in the week can disqualify it — losses do not
-    // count against a perfect week — so it is awarded on the spot.
+  it("losses on run days do not disqualify the run", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      win(2024, 0, 15, "player-1", "player-2", "mon"),
+      win(2024, 0, 16, "player-1", "player-2", "tue"),
+      // A Wednesday loss alongside the Wednesday win — still a won day.
+      win(2024, 0, 17, "player-2", "player-1", "wed-loss"),
+      win(2024, 0, 17, "player-1", "player-2", "wed"),
+      win(2024, 0, 18, "player-1", "player-2", "thu"),
+      win(2024, 0, 19, "player-1", "player-2", "fri"),
+    ];
+
+    const tennisTable = new TennisTable({ events });
+    tennisTable.achievements.calculateAchievements();
+
+    const perfectWeeks = tennisTable.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-week");
+    expect(perfectWeeks).toHaveLength(1);
+  });
+
+  it("awards immediately on the completing win, without waiting for the week to end", () => {
+    // "now" is Friday afternoon, right after the fifth consecutive won day.
+    // Losses never disqualify a perfect week, so it is awarded on the spot.
     jest.useFakeTimers();
     jest.setSystemTime(new Date(2024, 0, 19, 13));
 
@@ -166,7 +231,7 @@ describe("Perfect Week Achievement Tests", () => {
     jest.useRealTimers();
   });
 
-  describe("Progression (live, resets on a missed weekday)", () => {
+  describe("Progression (best still-completable run this week)", () => {
     afterEach(() => {
       jest.useRealTimers();
     });
@@ -187,7 +252,7 @@ describe("Perfect Week Achievement Tests", () => {
       expect(progression["perfect-week"].earned).toBe(0);
     });
 
-    it("counts the current weekday once it is won (Mon+Tue on Tuesday = 2/5)", () => {
+    it("counts the current day once it is won (Mon+Tue on Tuesday = 2/5)", () => {
       jest.useFakeTimers();
       jest.setSystemTime(new Date(2024, 0, 16, 20));
 
@@ -204,8 +269,9 @@ describe("Perfect Week Achievement Tests", () => {
       expect(progression["perfect-week"].current).toBe(2);
     });
 
-    it("drops to 0 on Wednesday when Tuesday passed with no win", () => {
-      // "now" is Wednesday; Monday and Wednesday won, but Tuesday was missed.
+    it("falls back to the Wed–Sun run when Tuesday passed with no win", () => {
+      // "now" is Wednesday; Monday and Wednesday won, Tuesday missed. The
+      // Mon–Fri and Tue–Sat runs are dead, but Wed–Sun is alive at 1.
       jest.useFakeTimers();
       jest.setSystemTime(new Date(2024, 0, 17, 12));
 
@@ -219,11 +285,45 @@ describe("Perfect Week Achievement Tests", () => {
       tennisTable.achievements.calculateAchievements();
 
       const progression = tennisTable.achievements.getPlayerProgression("player-1");
+      expect(progression["perfect-week"].current).toBe(1);
+    });
+
+    it("drops to 0 on Thursday when Wednesday also passed with no win", () => {
+      // Monday won, Tuesday and Wednesday missed — every run this week is
+      // dead (Wed–Sun needs Wednesday, which has elapsed).
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2024, 0, 18, 12));
+
+      const events: EventType[] = [...baseEvents, win(2024, 0, 15, "player-1", "player-2", "mon")];
+
+      const tennisTable = new TennisTable({ events });
+      tennisTable.achievements.calculateAchievements();
+
+      const progression = tennisTable.achievements.getPlayerProgression("player-1");
       expect(progression["perfect-week"].current).toBe(0);
     });
 
+    it("weekend wins count toward the late runs (Wed–Sat won on Saturday = 4/5)", () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2024, 0, 20, 18));
+
+      const events: EventType[] = [
+        ...baseEvents,
+        win(2024, 0, 17, "player-1", "player-2", "wed"),
+        win(2024, 0, 18, "player-1", "player-2", "thu"),
+        win(2024, 0, 19, "player-1", "player-2", "fri"),
+        win(2024, 0, 20, "player-1", "player-2", "sat"),
+      ];
+
+      const tennisTable = new TennisTable({ events });
+      tennisTable.achievements.calculateAchievements();
+
+      const progression = tennisTable.achievements.getPlayerProgression("player-1");
+      expect(progression["perfect-week"].current).toBe(4);
+    });
+
     it("resets to 0 the following week (last week's wins do not carry over)", () => {
-      // "now" is the Monday after a fully-won week — new attempt, no games yet.
+      // "now" is the Monday after a nearly-won week — new attempt, no games yet.
       jest.useFakeTimers();
       jest.setSystemTime(new Date(2024, 0, 22, 8));
 

--- a/frontend/src/client/client-db/__tests__/achievements/season-opener.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/season-opener.test.ts
@@ -1,0 +1,101 @@
+import { TennisTable } from "../../tennis-table";
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { determineSeason } from "../../seasons/seasons";
+
+// Season Opener is awarded to BOTH players of a season's very first game,
+// stamped at the game itself. Games in the grace period between seasons
+// belong to no season and can never be an opener.
+describe("Season Opener Achievement", () => {
+  const baseEvents: EventType[] = [
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "alice", time: 1, data: { name: "Alice" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "bob", time: 2, data: { name: "Bob" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "carol", time: 3, data: { name: "Carol" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "dave", time: 4, data: { name: "Dave" } },
+  ];
+
+  const game = (id: string, playedAt: number, winner: string, loser: string): EventType => ({
+    type: EventTypeEnum.GAME_CREATED,
+    stream: id,
+    time: playedAt,
+    data: { winner, loser, playedAt },
+  });
+
+  // Mid-January 2024: safely inside the Q1 2024 season (starts the first
+  // Monday of January at 08:00).
+  const q1Game1 = new Date(2024, 0, 10, 12).getTime();
+  const q1Game2 = new Date(2024, 0, 11, 12).getTime();
+  // Mid-April 2024: safely inside the Q2 2024 season.
+  const q2Game1 = new Date(2024, 3, 10, 12).getTime();
+
+  it("awards BOTH players of the season's first game — and nobody else", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      game("g1", q1Game1, "alice", "bob"),
+      game("g2", q1Game2, "carol", "dave"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const alice = tt.achievements.getAchievements("alice").filter((a) => a.type === "season-opener");
+    const bob = tt.achievements.getAchievements("bob").filter((a) => a.type === "season-opener");
+    expect(alice).toHaveLength(1);
+    expect(bob).toHaveLength(1);
+    expect(alice[0]).toStrictEqual({
+      type: "season-opener",
+      earnedBy: "alice",
+      earnedAt: q1Game1,
+      data: {
+        seasonStart: determineSeason(q1Game1).start,
+        gameId: "g1",
+        opponent: "bob",
+      },
+    });
+    expect(bob[0].data?.opponent).toBe("alice");
+
+    expect(tt.achievements.getAchievements("carol").filter((a) => a.type === "season-opener")).toHaveLength(0);
+    expect(tt.achievements.getAchievements("dave").filter((a) => a.type === "season-opener")).toHaveLength(0);
+  });
+
+  it("awards once per season — opening two seasons earns it twice", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      game("g1", q1Game1, "alice", "bob"),
+      game("g2", q2Game1, "alice", "carol"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const alice = tt.achievements.getAchievements("alice").filter((a) => a.type === "season-opener");
+    expect(alice).toHaveLength(2);
+    expect(alice[0].data?.seasonStart).toBe(determineSeason(q1Game1).start);
+    expect(alice[1].data?.seasonStart).toBe(determineSeason(q2Game1).start);
+    expect(tt.achievements.getPlayerProgression("alice")["season-opener"].earned).toBe(2);
+  });
+
+  it("a grace-period game belongs to no season and is not an opener", () => {
+    // The Q1 2024 season ends Friday Mar 22 17:00 (10 days before the Q2
+    // season starts Monday Apr 1 08:00). A game between those moments sits
+    // in the grace period.
+    const q1 = determineSeason(q1Game1);
+    const graceGame = q1.end + 60 * 60 * 1000; // one hour after the season ended
+    expect(graceGame).toBeLessThan(determineSeason(q2Game1).start);
+
+    const events: EventType[] = [
+      ...baseEvents,
+      game("g1", q1Game1, "alice", "bob"),
+      game("g2", graceGame, "carol", "dave"),
+      game("g3", q2Game1, "carol", "alice"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    // Carol's grace game earned nothing; her Q2 opener did.
+    const carol = tt.achievements.getAchievements("carol").filter((a) => a.type === "season-opener");
+    expect(carol).toHaveLength(1);
+    expect(carol[0].data?.gameId).toBe("g3");
+    expect(tt.achievements.getAchievements("dave").filter((a) => a.type === "season-opener")).toHaveLength(0);
+  });
+});

--- a/frontend/src/client/client-db/__tests__/achievements/shootout.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/shootout.test.ts
@@ -56,7 +56,6 @@ describe("Shootout Achievement", () => {
       gameId: "g1",
       opponent: "bob",
       points: 66,
-      setsCounted: 3,
       sets: [
         { playerPoints: 12, opponentPoints: 10 },
         { playerPoints: 13, opponentPoints: 11 },
@@ -109,7 +108,6 @@ describe("Shootout Achievement", () => {
     const alice = tt.achievements.getAchievements("alice").filter((a) => a.type === "shootout");
     expect(alice).toHaveLength(1);
     expect(alice[0].data?.points).toBe(66);
-    expect(alice[0].data?.setsCounted).toBe(3);
     // Only the counted sets are stored, kept in game order.
     expect(alice[0].data?.sets).toStrictEqual([
       { playerPoints: 12, opponentPoints: 10 },

--- a/frontend/src/client/client-db/__tests__/achievements/shootout.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/shootout.test.ts
@@ -1,0 +1,185 @@
+import { TennisTable } from "../../tennis-table";
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+
+// Shootout is the league record for the most combined points in a single
+// game, counting only the 3 highest-scoring sets so one-set games and
+// best-of-5 finals compete on equal terms. A 60-point game establishes the
+// first record; after that only a strictly higher score takes it. Both
+// players of the record game are awarded — the points were scored together.
+describe("Shootout Achievement", () => {
+  const baseEvents: EventType[] = [
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "alice", time: 1, data: { name: "Alice" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "bob", time: 2, data: { name: "Bob" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "carol", time: 3, data: { name: "Carol" } },
+  ];
+
+  const scoredGame = (
+    id: string,
+    time: number,
+    winner: string,
+    loser: string,
+    setPoints: { gameWinner: number; gameLoser: number }[],
+  ): EventType[] => {
+    const setsWon = {
+      gameWinner: setPoints.filter((set) => set.gameWinner > set.gameLoser).length,
+      gameLoser: setPoints.filter((set) => set.gameLoser > set.gameWinner).length,
+    };
+    return [
+      { type: EventTypeEnum.GAME_CREATED, stream: id, time, data: { winner, loser, playedAt: time } },
+      { type: EventTypeEnum.GAME_SCORE, stream: id, time: time + 1, data: { setsWon, setPoints } },
+    ];
+  };
+
+  it("awards BOTH players with undefined previousRecord when first establishing the record", () => {
+    // 22 + 21 + 20 = 63 points ≥ the 60-point floor.
+    const events: EventType[] = [
+      ...baseEvents,
+      ...scoredGame("g1", 100, "alice", "bob", [
+        { gameWinner: 12, gameLoser: 10 },
+        { gameWinner: 11, gameLoser: 10 },
+        { gameWinner: 11, gameLoser: 9 },
+      ]),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const alice = tt.achievements.getAchievements("alice").filter((a) => a.type === "shootout");
+    const bob = tt.achievements.getAchievements("bob").filter((a) => a.type === "shootout");
+    expect(alice).toHaveLength(1);
+    expect(bob).toHaveLength(1);
+    expect(alice[0].data).toStrictEqual({
+      gameId: "g1",
+      opponent: "bob",
+      points: 63,
+      setsCounted: 3,
+      previousRecord: undefined,
+    });
+    expect(bob[0].data?.opponent).toBe("alice");
+    expect(tt.achievements.shootoutRecord).toStrictEqual({ points: 63, holders: ["alice", "bob"] });
+  });
+
+  it("does NOT award below the 60-point floor", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      ...scoredGame("g1", 100, "alice", "bob", [
+        { gameWinner: 11, gameLoser: 5 },
+        { gameWinner: 11, gameLoser: 7 },
+      ]),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "shootout")).toHaveLength(0);
+    expect(tt.achievements.shootoutRecord.points).toBeUndefined();
+  });
+
+  it("counts only the 3 highest-scoring sets of a best-of-5 game", () => {
+    // Set sums: 22, 21, 20, 11, 11 — top 3 give 63, not the 85 total.
+    const events: EventType[] = [
+      ...baseEvents,
+      ...scoredGame("g1", 100, "alice", "bob", [
+        { gameWinner: 12, gameLoser: 10 },
+        { gameWinner: 10, gameLoser: 11 },
+        { gameWinner: 11, gameLoser: 9 },
+        { gameWinner: 11, gameLoser: 0 },
+        { gameWinner: 11, gameLoser: 0 },
+      ]),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const alice = tt.achievements.getAchievements("alice").filter((a) => a.type === "shootout");
+    expect(alice).toHaveLength(1);
+    expect(alice[0].data?.points).toBe(63);
+    expect(alice[0].data?.setsCounted).toBe(3);
+  });
+
+  it("only a strictly higher score takes the record, with previousRecord recorded", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      // Establishes the record at 63.
+      ...scoredGame("g1", 100, "alice", "bob", [
+        { gameWinner: 12, gameLoser: 10 },
+        { gameWinner: 11, gameLoser: 10 },
+        { gameWinner: 11, gameLoser: 9 },
+      ]),
+      // Equal score — does not take the record.
+      ...scoredGame("g2", 200, "alice", "carol", [
+        { gameWinner: 12, gameLoser: 10 },
+        { gameWinner: 11, gameLoser: 10 },
+        { gameWinner: 11, gameLoser: 9 },
+      ]),
+      // 24 + 21 + 20 = 65 — takes the record.
+      ...scoredGame("g3", 300, "carol", "bob", [
+        { gameWinner: 13, gameLoser: 11 },
+        { gameWinner: 11, gameLoser: 10 },
+        { gameWinner: 11, gameLoser: 9 },
+      ]),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    // Alice: only the g1 record (g2 tied, g3 not her game).
+    expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "shootout")).toHaveLength(1);
+    // Carol: the g3 record only.
+    const carol = tt.achievements.getAchievements("carol").filter((a) => a.type === "shootout");
+    expect(carol).toHaveLength(1);
+    expect(carol[0].data).toMatchObject({ gameId: "g3", points: 65, previousRecord: 63 });
+    // Bob was in both record games.
+    expect(tt.achievements.getAchievements("bob").filter((a) => a.type === "shootout")).toHaveLength(2);
+    expect(tt.achievements.shootoutRecord).toStrictEqual({ points: 65, holders: ["carol", "bob"] });
+  });
+
+  it("tracks personal best and the record target in progression", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      // Alice/Bob set the record at 63.
+      ...scoredGame("g1", 100, "alice", "bob", [
+        { gameWinner: 12, gameLoser: 10 },
+        { gameWinner: 11, gameLoser: 10 },
+        { gameWinner: 11, gameLoser: 9 },
+      ]),
+      // Carol's best game is 18 + 18 + 16 = 52 — under the record.
+      ...scoredGame("g2", 200, "carol", "bob", [
+        { gameWinner: 11, gameLoser: 7 },
+        { gameWinner: 11, gameLoser: 7 },
+        { gameWinner: 11, gameLoser: 5 },
+      ]),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const carol = tt.achievements.getPlayerProgression("carol")["shootout"];
+    expect(carol.current).toBe(52);
+    expect(carol.target).toBe(64); // one beyond the record
+    expect(carol.recordHolders).toStrictEqual(["alice", "bob"]);
+    expect(carol.earned).toBe(0);
+
+    const alice = tt.achievements.getPlayerProgression("alice")["shootout"];
+    expect(alice.current).toBe(63);
+    expect(alice.earned).toBe(1);
+  });
+
+  it("progression has no target while nobody holds the record", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      ...scoredGame("g1", 100, "alice", "bob", [
+        { gameWinner: 11, gameLoser: 5 },
+        { gameWinner: 11, gameLoser: 7 },
+      ]),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const alice = tt.achievements.getPlayerProgression("alice")["shootout"];
+    expect(alice.current).toBe(34);
+    expect(alice.target).toBeUndefined();
+    expect(alice.recordHolders).toStrictEqual([]);
+  });
+});

--- a/frontend/src/client/client-db/__tests__/achievements/shootout.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/shootout.test.ts
@@ -6,6 +6,10 @@ import { EventType, EventTypeEnum } from "../../event-store/event-types";
 // best-of-5 finals compete on equal terms. A 60-point game establishes the
 // first record; after that only a strictly higher score takes it. Both
 // players of the record game are awarded — the points were scored together.
+//
+// Only games where every set has a valid score count: first to 11 (loser at
+// 9 or below) or a deuce set won by exactly 2. House-rule scores like 15–12
+// are silently ignored so inflated totals can't take the record.
 describe("Shootout Achievement", () => {
   const baseEvents: EventType[] = [
     { type: EventTypeEnum.PLAYER_CREATED, stream: "alice", time: 1, data: { name: "Alice" } },
@@ -31,12 +35,12 @@ describe("Shootout Achievement", () => {
   };
 
   it("awards BOTH players with undefined previousRecord when first establishing the record", () => {
-    // 22 + 21 + 20 = 63 points ≥ the 60-point floor.
+    // 22 + 24 + 20 = 66 points ≥ the 60-point floor.
     const events: EventType[] = [
       ...baseEvents,
       ...scoredGame("g1", 100, "alice", "bob", [
         { gameWinner: 12, gameLoser: 10 },
-        { gameWinner: 11, gameLoser: 10 },
+        { gameWinner: 13, gameLoser: 11 },
         { gameWinner: 11, gameLoser: 9 },
       ]),
     ];
@@ -51,11 +55,11 @@ describe("Shootout Achievement", () => {
     expect(alice[0].data).toStrictEqual({
       gameId: "g1",
       opponent: "bob",
-      points: 63,
+      points: 66,
       setsCounted: 3,
       sets: [
         { playerPoints: 12, opponentPoints: 10 },
-        { playerPoints: 11, opponentPoints: 10 },
+        { playerPoints: 13, opponentPoints: 11 },
         { playerPoints: 11, opponentPoints: 9 },
       ],
       previousRecord: undefined,
@@ -64,10 +68,10 @@ describe("Shootout Achievement", () => {
     // The loser's badge shows the same sets from their own perspective.
     expect(bob[0].data?.sets).toStrictEqual([
       { playerPoints: 10, opponentPoints: 12 },
-      { playerPoints: 10, opponentPoints: 11 },
+      { playerPoints: 11, opponentPoints: 13 },
       { playerPoints: 9, opponentPoints: 11 },
     ]);
-    expect(tt.achievements.shootoutRecord).toStrictEqual({ points: 63, holders: ["alice", "bob"] });
+    expect(tt.achievements.shootoutRecord).toStrictEqual({ points: 66, holders: ["alice", "bob"] });
   });
 
   it("does NOT award below the 60-point floor", () => {
@@ -87,13 +91,13 @@ describe("Shootout Achievement", () => {
   });
 
   it("counts only the 3 highest-scoring sets of a best-of-5 game", () => {
-    // Set sums: 22, 21, 20, 11, 11 — top 3 give 63, not the 85 total.
+    // Set sums: 22, 20, 24, 11, 11 — top 3 give 66, not the 88 total.
     const events: EventType[] = [
       ...baseEvents,
       ...scoredGame("g1", 100, "alice", "bob", [
         { gameWinner: 12, gameLoser: 10 },
-        { gameWinner: 10, gameLoser: 11 },
-        { gameWinner: 11, gameLoser: 9 },
+        { gameWinner: 9, gameLoser: 11 },
+        { gameWinner: 13, gameLoser: 11 },
         { gameWinner: 11, gameLoser: 0 },
         { gameWinner: 11, gameLoser: 0 },
       ]),
@@ -104,35 +108,35 @@ describe("Shootout Achievement", () => {
 
     const alice = tt.achievements.getAchievements("alice").filter((a) => a.type === "shootout");
     expect(alice).toHaveLength(1);
-    expect(alice[0].data?.points).toBe(63);
+    expect(alice[0].data?.points).toBe(66);
     expect(alice[0].data?.setsCounted).toBe(3);
     // Only the counted sets are stored, kept in game order.
     expect(alice[0].data?.sets).toStrictEqual([
       { playerPoints: 12, opponentPoints: 10 },
-      { playerPoints: 10, opponentPoints: 11 },
-      { playerPoints: 11, opponentPoints: 9 },
+      { playerPoints: 9, opponentPoints: 11 },
+      { playerPoints: 13, opponentPoints: 11 },
     ]);
   });
 
   it("only a strictly higher score takes the record, with previousRecord recorded", () => {
     const events: EventType[] = [
       ...baseEvents,
-      // Establishes the record at 63.
+      // Establishes the record at 66.
       ...scoredGame("g1", 100, "alice", "bob", [
         { gameWinner: 12, gameLoser: 10 },
-        { gameWinner: 11, gameLoser: 10 },
+        { gameWinner: 13, gameLoser: 11 },
         { gameWinner: 11, gameLoser: 9 },
       ]),
       // Equal score — does not take the record.
       ...scoredGame("g2", 200, "alice", "carol", [
         { gameWinner: 12, gameLoser: 10 },
-        { gameWinner: 11, gameLoser: 10 },
+        { gameWinner: 13, gameLoser: 11 },
         { gameWinner: 11, gameLoser: 9 },
       ]),
-      // 24 + 21 + 20 = 65 — takes the record.
+      // 26 + 24 + 20 = 70 — takes the record.
       ...scoredGame("g3", 300, "carol", "bob", [
+        { gameWinner: 14, gameLoser: 12 },
         { gameWinner: 13, gameLoser: 11 },
-        { gameWinner: 11, gameLoser: 10 },
         { gameWinner: 11, gameLoser: 9 },
       ]),
     ];
@@ -145,19 +149,57 @@ describe("Shootout Achievement", () => {
     // Carol: the g3 record only.
     const carol = tt.achievements.getAchievements("carol").filter((a) => a.type === "shootout");
     expect(carol).toHaveLength(1);
-    expect(carol[0].data).toMatchObject({ gameId: "g3", points: 65, previousRecord: 63 });
+    expect(carol[0].data).toMatchObject({ gameId: "g3", points: 70, previousRecord: 66 });
     // Bob was in both record games.
     expect(tt.achievements.getAchievements("bob").filter((a) => a.type === "shootout")).toHaveLength(2);
-    expect(tt.achievements.shootoutRecord).toStrictEqual({ points: 65, holders: ["carol", "bob"] });
+    expect(tt.achievements.shootoutRecord).toStrictEqual({ points: 70, holders: ["carol", "bob"] });
+  });
+
+  it("silently ignores games containing an invalid set score", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      // 27 + 24 + 22 = 73 points, but 15–12 is not a valid set score
+      // (above 11 the set must be won by exactly 2).
+      ...scoredGame("g1", 100, "alice", "bob", [
+        { gameWinner: 15, gameLoser: 12 },
+        { gameWinner: 13, gameLoser: 11 },
+        { gameWinner: 12, gameLoser: 10 },
+      ]),
+      // 11–10 is impossible too — at 10–10 the set continues to +2.
+      ...scoredGame("g2", 200, "alice", "carol", [
+        { gameWinner: 11, gameLoser: 10 },
+        { gameWinner: 11, gameLoser: 0 },
+        { gameWinner: 11, gameLoser: 0 },
+      ]),
+      // A legit game afterwards still establishes the FIRST record —
+      // the invalid games never became a record to beat.
+      ...scoredGame("g3", 300, "carol", "bob", [
+        { gameWinner: 12, gameLoser: 10 },
+        { gameWinner: 13, gameLoser: 11 },
+        { gameWinner: 11, gameLoser: 9 },
+      ]),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "shootout")).toHaveLength(0);
+    const carol = tt.achievements.getAchievements("carol").filter((a) => a.type === "shootout");
+    expect(carol).toHaveLength(1);
+    expect(carol[0].data).toMatchObject({ gameId: "g3", points: 66, previousRecord: undefined });
+    expect(tt.achievements.shootoutRecord).toStrictEqual({ points: 66, holders: ["carol", "bob"] });
+
+    // Invalid games do not feed the personal-best progression either.
+    expect(tt.achievements.getPlayerProgression("alice")["shootout"].current).toBe(0);
   });
 
   it("tracks personal best and the record target in progression", () => {
     const events: EventType[] = [
       ...baseEvents,
-      // Alice/Bob set the record at 63.
+      // Alice/Bob set the record at 66.
       ...scoredGame("g1", 100, "alice", "bob", [
         { gameWinner: 12, gameLoser: 10 },
-        { gameWinner: 11, gameLoser: 10 },
+        { gameWinner: 13, gameLoser: 11 },
         { gameWinner: 11, gameLoser: 9 },
       ]),
       // Carol's best game is 18 + 18 + 16 = 52 — under the record.
@@ -173,12 +215,12 @@ describe("Shootout Achievement", () => {
 
     const carol = tt.achievements.getPlayerProgression("carol")["shootout"];
     expect(carol.current).toBe(52);
-    expect(carol.target).toBe(64); // one beyond the record
+    expect(carol.target).toBe(67); // one beyond the record
     expect(carol.recordHolders).toStrictEqual(["alice", "bob"]);
     expect(carol.earned).toBe(0);
 
     const alice = tt.achievements.getPlayerProgression("alice")["shootout"];
-    expect(alice.current).toBe(63);
+    expect(alice.current).toBe(66);
     expect(alice.earned).toBe(1);
   });
 

--- a/frontend/src/client/client-db/__tests__/achievements/shootout.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/shootout.test.ts
@@ -53,9 +53,20 @@ describe("Shootout Achievement", () => {
       opponent: "bob",
       points: 63,
       setsCounted: 3,
+      sets: [
+        { playerPoints: 12, opponentPoints: 10 },
+        { playerPoints: 11, opponentPoints: 10 },
+        { playerPoints: 11, opponentPoints: 9 },
+      ],
       previousRecord: undefined,
     });
     expect(bob[0].data?.opponent).toBe("alice");
+    // The loser's badge shows the same sets from their own perspective.
+    expect(bob[0].data?.sets).toStrictEqual([
+      { playerPoints: 10, opponentPoints: 12 },
+      { playerPoints: 10, opponentPoints: 11 },
+      { playerPoints: 9, opponentPoints: 11 },
+    ]);
     expect(tt.achievements.shootoutRecord).toStrictEqual({ points: 63, holders: ["alice", "bob"] });
   });
 
@@ -95,6 +106,12 @@ describe("Shootout Achievement", () => {
     expect(alice).toHaveLength(1);
     expect(alice[0].data?.points).toBe(63);
     expect(alice[0].data?.setsCounted).toBe(3);
+    // Only the counted sets are stored, kept in game order.
+    expect(alice[0].data?.sets).toStrictEqual([
+      { playerPoints: 12, opponentPoints: 10 },
+      { playerPoints: 10, opponentPoints: 11 },
+      { playerPoints: 11, opponentPoints: 9 },
+    ]);
   });
 
   it("only a strictly higher score takes the record, with previousRecord recorded", () => {

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -18,11 +18,11 @@ export const GAMES_IN_PERIOD_RECORD_FLOOR = 3;
 
 // Smallest single-game Elo swing that can establish the very first David /
 // Goliath record (the same game sets both — Elo is zero-sum, so the winner's
-// gain is the loser's loss). 30 was the old fixed threshold for the
-// achievements, so history is preserved: the first upset that would have
-// earned the old badge is the one that seeds the record. After that only a
-// strictly bigger swing takes it.
-export const UPSET_RECORD_FLOOR = 30;
+// gain is the loser's loss). An evenly matched win moves 16 points, so 20
+// takes a real upset (the winner roughly 90+ Elo below the loser). The floor
+// only matters until the first record exists; after that only a strictly
+// bigger swing takes it.
+export const UPSET_RECORD_FLOOR = 20;
 
 // How many sets count toward a game's Shootout score. Most games are best of
 // 3, but one-set games and best-of-5 games (tournament finals) exist — summing
@@ -35,6 +35,21 @@ export const SHOOTOUT_SETS_COUNTED = 3;
 // first Shootout record. Three ordinary 11–7 sets are ~54 points; the first
 // record should take a genuinely point-heavy game, not just any full game.
 export const SHOOTOUT_RECORD_FLOOR = 60;
+
+// League game counts whose game awards "Milestone Game" to both players: the
+// 100th, 500th, 1,000th and every thousandth after. Deleted games do not
+// count — the numbering follows the games that still exist.
+export function isMilestoneGameNumber(gameNumber: number): boolean {
+  return gameNumber === 100 || gameNumber === 500 || (gameNumber > 0 && gameNumber % 1000 === 0);
+}
+
+// The next milestone strictly above `gameNumber` — what the league is
+// currently counting toward. Used by the progression view.
+export function nextMilestoneGameNumber(gameNumber: number): number {
+  if (gameNumber < 100) return 100;
+  if (gameNumber < 500) return 500;
+  return (Math.floor(gameNumber / 1000) + 1) * 1000;
+}
 
 export class Achievements {
   private parent: TennisTable;
@@ -205,7 +220,30 @@ export class Achievements {
 
     const gameLimitForRanked = this.parent.client.gameLimitForRanked;
 
-    this.parent.games.forEach((game) => {
+    this.parent.games.forEach((game, gameIndex) => {
+      // Check for "Milestone Game": awarded to both players of the league's
+      // 100th, 500th, 1,000th and every following thousandth game. Deleted
+      // games are already gone from parent.games, so they never count.
+      const leagueGameNumber = gameIndex + 1;
+      if (isMilestoneGameNumber(leagueGameNumber)) {
+        this.#addAchievement(
+          game.winner,
+          this.#createAchievement("milestone-game", game.winner, game.playedAt, {
+            gameId: game.id,
+            opponent: game.loser,
+            milestone: leagueGameNumber,
+          }),
+        );
+        this.#addAchievement(
+          game.loser,
+          this.#createAchievement("milestone-game", game.loser, game.playedAt, {
+            gameId: game.id,
+            opponent: game.winner,
+            milestone: leagueGameNumber,
+          }),
+        );
+      }
+
       // Initialize player trackers if they don't exist
       if (!playerTracker.has(game.winner)) {
         playerTracker.set(game.winner, {
@@ -2512,6 +2550,7 @@ export class Achievements {
       "group-stage-star": { earned: 0 },
       "season-winner": { current: 0, target: 1, earned: 0 },
       "season-opener": { earned: 0 },
+      "milestone-game": { current: 0, target: 100, earned: 0 },
     };
 
     let firstActiveAt: number | null = null;
@@ -3018,6 +3057,13 @@ export class Achievements {
     // record they must strictly exceed to earn the award.
     progression["shootout"].current = this.bestShootout.get(playerId) ?? 0;
 
+    // Milestone Game progression is league-wide: everyone shares the same
+    // count of existing games and the same next milestone to play toward.
+    // Deleted games are already gone from parent.games, so they don't count.
+    const totalLeagueGames = this.parent.games.length;
+    progression["milestone-game"].current = totalLeagueGames;
+    progression["milestone-game"].target = nextMilestoneGameNumber(totalLeagueGames);
+
     // Climber progression: current Elo - all-time low Elo since the
     // player first became ranked. Players who never became ranked have
     // no recorded low → progression stays at 0.
@@ -3186,6 +3232,9 @@ type AchievementDefinitions = {
   "shootout": { gameId: string; opponent: string; points: number; setsCounted: number; previousRecord?: number };
   // Awarded to both players of a season's very first game.
   "season-opener": { seasonStart: number; gameId: string; opponent: string };
+  // Awarded to both players of a league milestone game (the 100th, 500th,
+  // 1,000th and every thousandth after). `milestone` is that game number.
+  "milestone-game": { gameId: string; opponent: string; milestone: number };
 };
 
 type AchievementType = keyof AchievementDefinitions;
@@ -3381,6 +3430,7 @@ export type AchievementProgression = {
   "tournament-winner": BaseProgression;
   "season-winner": ProgressionWithTarget;
   "season-opener": BaseProgression;
+  "milestone-game": ProgressionWithTarget;
   "nice-game": BaseProgression;
   "less-is-more": BaseProgression;
   "close-calls": ProgressionWithTarget;

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -36,30 +36,19 @@ export const SHOOTOUT_SETS_COUNTED = 3;
 // record should take a genuinely point-heavy game, not just any full game.
 export const SHOOTOUT_RECORD_FLOOR = 60;
 
-// League game counts whose game awards "Milestone Game" to both players: the
-// 100th, 500th, 1,000th and every thousandth after. Deleted games do not
-// count — the numbering follows the games that still exist.
+// How often "Milestone Game" is awarded: every 500th league game (the 500th,
+// 1,000th, 1,500th, ...), to both players. Deleted games do not count — the
+// numbering follows the games that still exist.
+export const MILESTONE_GAME_INTERVAL = 500;
+
 export function isMilestoneGameNumber(gameNumber: number): boolean {
-  return gameNumber === 100 || gameNumber === 500 || (gameNumber > 0 && gameNumber % 1000 === 0);
+  return gameNumber > 0 && gameNumber % MILESTONE_GAME_INTERVAL === 0;
 }
 
 // The next milestone strictly above `gameNumber` — what the league is
 // currently counting toward. Used by the progression view.
 export function nextMilestoneGameNumber(gameNumber: number): number {
-  if (gameNumber < 100) return 100;
-  if (gameNumber < 500) return 500;
-  return (Math.floor(gameNumber / 1000) + 1) * 1000;
-}
-
-// The latest milestone at or below `gameNumber` (0 before the first one).
-// Together with nextMilestoneGameNumber it frames the current chase: the
-// progression bar restarts at each milestone and fills across the span to
-// the next.
-export function previousMilestoneGameNumber(gameNumber: number): number {
-  if (gameNumber < 100) return 0;
-  if (gameNumber < 500) return 100;
-  if (gameNumber < 1000) return 500;
-  return Math.floor(gameNumber / 1000) * 1000;
+  return (Math.floor(gameNumber / MILESTONE_GAME_INTERVAL) + 1) * MILESTONE_GAME_INTERVAL;
 }
 
 export class Achievements {
@@ -232,9 +221,9 @@ export class Achievements {
     const gameLimitForRanked = this.parent.client.gameLimitForRanked;
 
     this.parent.games.forEach((game, gameIndex) => {
-      // Check for "Milestone Game": awarded to both players of the league's
-      // 100th, 500th, 1,000th and every following thousandth game. Deleted
-      // games are already gone from parent.games, so they never count.
+      // Check for "Milestone Game": awarded to both players of every 500th
+      // league game. Deleted games are already gone from parent.games, so
+      // they never count.
       const leagueGameNumber = gameIndex + 1;
       if (isMilestoneGameNumber(leagueGameNumber)) {
         this.#addAchievement(
@@ -3080,14 +3069,12 @@ export class Achievements {
 
     // Milestone Game progression is league-wide (everyone shares it) and
     // restarts at every milestone: current is the games played since the
-    // previous milestone (0 right after one) and target is the span to the
-    // next, so the bar gauges how close the next milestone game is —
+    // previous milestone (0 right after one) and target is the 500-game
+    // interval, so the bar gauges how close the next milestone game is —
     // target - current games remain. Deleted games are already gone from
     // parent.games, so they don't count.
-    const totalLeagueGames = this.parent.games.length;
-    const previousMilestone = previousMilestoneGameNumber(totalLeagueGames);
-    progression["milestone-game"].current = totalLeagueGames - previousMilestone;
-    progression["milestone-game"].target = nextMilestoneGameNumber(totalLeagueGames) - previousMilestone;
+    progression["milestone-game"].current = this.parent.games.length % MILESTONE_GAME_INTERVAL;
+    progression["milestone-game"].target = MILESTONE_GAME_INTERVAL;
 
     // Climber progression: current Elo - all-time low Elo since the
     // player first became ranked. Players who never became ranked have
@@ -3266,8 +3253,8 @@ type AchievementDefinitions = {
   };
   // Awarded to both players of a season's very first game.
   "season-opener": { seasonStart: number; gameId: string; opponent: string };
-  // Awarded to both players of a league milestone game (the 100th, 500th,
-  // 1,000th and every thousandth after). `milestone` is that game number.
+  // Awarded to both players of every 500th league game. `milestone` is that
+  // game number.
   "milestone-game": { gameId: string; opponent: string; milestone: number };
 };
 

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -1651,6 +1651,17 @@ export class Achievements {
       .reduce((sum, points) => sum + points, 0);
   }
 
+  // A legitimately completed set: first to 11 with the loser at 9 or below,
+  // or a deuce set won by exactly 2 points. Anything else — e.g. 15–12 —
+  // comes from house rules that award bonus points (edge bounces and the
+  // like), which would inflate a game's point total past what legit games
+  // can reach.
+  #isValidSetScore(set: { gameWinner: number; gameLoser: number }): boolean {
+    const winnerScore = Math.max(set.gameWinner, set.gameLoser);
+    const loserScore = Math.min(set.gameWinner, set.gameLoser);
+    return (winnerScore === 11 && loserScore <= 9) || (winnerScore > 11 && winnerScore - loserScore === 2);
+  }
+
   // Awards "Shootout" to BOTH players of a game whose Shootout score beats
   // the league-wide record — the points were scored together, so the record
   // is held together. A score of SHOOTOUT_RECORD_FLOOR establishes the first
@@ -1662,6 +1673,11 @@ export class Achievements {
     setPoints: { gameWinner: number; gameLoser: number }[],
     playedAt: number,
   ) {
+    // Games containing any invalid set score are silently ignored — for the
+    // record AND the personal-best progression — so inflated house-rule
+    // totals can never take the record away from legit games.
+    if (!setPoints.every((set) => this.#isValidSetScore(set))) return;
+
     const points = this.#shootoutScore(setPoints);
 
     // Track personal bests for the progression view.

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -51,6 +51,17 @@ export function nextMilestoneGameNumber(gameNumber: number): number {
   return (Math.floor(gameNumber / 1000) + 1) * 1000;
 }
 
+// The latest milestone at or below `gameNumber` (0 before the first one).
+// Together with nextMilestoneGameNumber it frames the current chase: the
+// progression bar restarts at each milestone and fills across the span to
+// the next.
+export function previousMilestoneGameNumber(gameNumber: number): number {
+  if (gameNumber < 100) return 0;
+  if (gameNumber < 500) return 100;
+  if (gameNumber < 1000) return 500;
+  return Math.floor(gameNumber / 1000) * 1000;
+}
+
 export class Achievements {
   private parent: TennisTable;
   private hasCalculated = false;
@@ -3057,12 +3068,16 @@ export class Achievements {
     // record they must strictly exceed to earn the award.
     progression["shootout"].current = this.bestShootout.get(playerId) ?? 0;
 
-    // Milestone Game progression is league-wide: everyone shares the same
-    // count of existing games and the same next milestone to play toward.
-    // Deleted games are already gone from parent.games, so they don't count.
+    // Milestone Game progression is league-wide (everyone shares it) and
+    // restarts at every milestone: current is the games played since the
+    // previous milestone (0 right after one) and target is the span to the
+    // next, so the bar gauges how close the next milestone game is —
+    // target - current games remain. Deleted games are already gone from
+    // parent.games, so they don't count.
     const totalLeagueGames = this.parent.games.length;
-    progression["milestone-game"].current = totalLeagueGames;
-    progression["milestone-game"].target = nextMilestoneGameNumber(totalLeagueGames);
+    const previousMilestone = previousMilestoneGameNumber(totalLeagueGames);
+    progression["milestone-game"].current = totalLeagueGames - previousMilestone;
+    progression["milestone-game"].target = nextMilestoneGameNumber(totalLeagueGames) - previousMilestone;
 
     // Climber progression: current Elo - all-time low Elo since the
     // player first became ranked. Players who never became ranked have

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -16,6 +16,26 @@ export const STREAK_RECORD_FLOOR = 3;
 // naturally accumulate higher records on their own.
 export const GAMES_IN_PERIOD_RECORD_FLOOR = 3;
 
+// Smallest single-game Elo swing that can establish the very first David /
+// Goliath record (the same game sets both — Elo is zero-sum, so the winner's
+// gain is the loser's loss). 30 was the old fixed threshold for the
+// achievements, so history is preserved: the first upset that would have
+// earned the old badge is the one that seeds the record. After that only a
+// strictly bigger swing takes it.
+export const UPSET_RECORD_FLOOR = 30;
+
+// How many sets count toward a game's Shootout score. Most games are best of
+// 3, but one-set games and best-of-5 games (tournament finals) exist — summing
+// every set would hand the record to whoever plays the longest format. Only
+// the 3 highest-scoring sets count, so a best of 5 competes on equal terms
+// with a best of 3 (shorter games are naturally at a disadvantage).
+export const SHOOTOUT_SETS_COUNTED = 3;
+
+// Fewest combined points (across the counted sets) that can establish the very
+// first Shootout record. Three ordinary 11–7 sets are ~54 points; the first
+// record should take a genuinely point-heavy game, not just any full game.
+export const SHOOTOUT_RECORD_FLOOR = 60;
+
 export class Achievements {
   private parent: TennisTable;
   private hasCalculated = false;
@@ -27,6 +47,32 @@ export class Achievements {
   // Largest Elo loss each player has suffered from a loss where BOTH
   // players were ranked at the time. Used for Goliath progression.
   worstGoliathLoss: Map<string, number> = new Map();
+  // League-wide running records for the David / Goliath achievements: the
+  // largest single-game Elo swing between two ranked players to date. The
+  // same game always sets both (Elo is zero-sum) so the values are equal —
+  // only the holders differ (David's winner, Goliath's loser). Undefined
+  // until a swing reaches UPSET_RECORD_FLOOR and establishes the first
+  // record. Used by the progression view so players can see the mark to beat.
+  davidRecord: { eloGain: number | undefined; holder: string | undefined } = {
+    eloGain: undefined,
+    holder: undefined,
+  };
+  goliathRecord: { eloLoss: number | undefined; holder: string | undefined } = {
+    eloLoss: undefined,
+    holder: undefined,
+  };
+  // League-wide running record for the Shootout achievement: the most
+  // combined points in a single game, counting only the SHOOTOUT_SETS_COUNTED
+  // highest-scoring sets so different game formats compete fairly. Both
+  // players of the record game hold it together. Undefined until a game
+  // reaches SHOOTOUT_RECORD_FLOOR and establishes the first record.
+  shootoutRecord: { points: number | undefined; holders: string[] } = {
+    points: undefined,
+    holders: [],
+  };
+  // Each player's own highest Shootout score (top-3-sets combined points in
+  // one game). Used for Shootout progression.
+  bestShootout: Map<string, number> = new Map();
   // Lowest Elo each player has held while ranked, starting from the
   // moment they first crossed gameLimitForRanked games. Used for the
   // Climber achievement and progression. `time` is when that low was
@@ -103,6 +149,10 @@ export class Achievements {
     this.achievementMap.clear();
     this.bestDavidGain.clear();
     this.worstGoliathLoss.clear();
+    this.davidRecord = { eloGain: undefined, holder: undefined };
+    this.goliathRecord = { eloLoss: undefined, holder: undefined };
+    this.shootoutRecord = { points: undefined, holders: [] };
+    this.bestShootout.clear();
     this.climberAllTimeLow.clear();
     this.marathonSetRecord = { score: undefined, holder: undefined };
     this.leapFrogRecord = { ranksJumped: undefined, holder: undefined };
@@ -509,6 +559,12 @@ export class Achievements {
         );
       }
 
+      // Check for the Shootout record: most combined points in a single game,
+      // counting only the highest-scoring sets.
+      if (game.score?.setPoints) {
+        this.#checkShootoutAchievement(game.winner, game.loser, game.id, game.score.setPoints, game.playedAt);
+      }
+
       // Check for donut achievements (individual sets where loser scored 0)
       if (game.score?.setPoints) {
         const donutsEarned = this.#checkDonutAchievements(
@@ -694,12 +750,13 @@ export class Achievements {
   // undefeated day still in progress stays a pending attempt (tracked by
   // progression) until local midnight passes.
   //
-  // Perfect Week: for every working week (Monday–Friday, local time) in
-  // which a player won at least one game on each of the five weekdays.
-  // Wins on Saturday / Sunday do not count. Stamped at the game that
-  // completed the fifth distinct weekday. Unlike Perfect Day this is awarded
-  // immediately: losses never disqualify a week, so nothing later in the week
-  // can take it away.
+  // Perfect Week: for every week (Monday-start, local time) in which a
+  // player won at least one game on each of 5 consecutive calendar days,
+  // all within that same week — Mon–Fri, Tue–Sat or Wed–Sun. A run that
+  // crosses into the next week (e.g. Fri–Tue) does not count. Stamped at the
+  // game that completed the first such 5-day run; one award per week even if
+  // more days are won. Unlike Perfect Day this is awarded immediately:
+  // losses never disqualify a week, so nothing later can take it away.
   //
   // Both are earnable multiple times — once per qualifying day / week.
   // Games are already time-ordered, so the completing win's timestamp is
@@ -722,7 +779,10 @@ export class Achievements {
 
     type DayStats = { wins: number; losses: number; lastWinAt: number };
     const perDay = new Map<string, Map<number, DayStats>>();
-    type WeekStats = { weekdaysWon: Set<number>; completedAt: number | null };
+    // daysWon holds day offsets from the week's Monday (0=Mon..6=Sun).
+    // startOffset is the first day of the 5-day run that completed the week
+    // (only meaningful once completedAt is set).
+    type WeekStats = { daysWon: Set<number>; completedAt: number | null; startOffset: number };
     const perWeek = new Map<string, Map<number, WeekStats>>();
 
     const getDayStats = (playerId: string, day: number): DayStats => {
@@ -746,7 +806,7 @@ export class Achievements {
       }
       let stats = weeks.get(week);
       if (!stats) {
-        stats = { weekdaysWon: new Set(), completedAt: null };
+        stats = { daysWon: new Set(), completedAt: null, startOffset: 0 };
         weeks.set(week, stats);
       }
       return stats;
@@ -759,15 +819,28 @@ export class Achievements {
       winnerDay.lastWinAt = game.playedAt;
       getDayStats(game.loser, day).losses++;
 
-      // Perfect Week only counts wins on Monday–Friday.
-      const weekday = new Date(game.playedAt).getDay(); // 0=Sun..6=Sat
-      if (weekday >= 1 && weekday <= 5) {
-        const week = weekStartOf(game.playedAt);
-        const winnerWeek = getWeekStats(game.winner, week);
-        if (!winnerWeek.weekdaysWon.has(weekday)) {
-          winnerWeek.weekdaysWon.add(weekday);
-          if (winnerWeek.weekdaysWon.size === 5 && winnerWeek.completedAt === null) {
-            winnerWeek.completedAt = game.playedAt;
+      // Perfect Week counts wins on any day; what matters is completing a
+      // run of 5 consecutive won days inside the week (start offset 0, 1 or
+      // 2 — Mon–Fri, Tue–Sat or Wed–Sun).
+      const dayOffset = (new Date(game.playedAt).getDay() + 6) % 7; // 0=Mon..6=Sun
+      const week = weekStartOf(game.playedAt);
+      const winnerWeek = getWeekStats(game.winner, week);
+      if (!winnerWeek.daysWon.has(dayOffset)) {
+        winnerWeek.daysWon.add(dayOffset);
+        if (winnerWeek.completedAt === null) {
+          for (let start = 0; start <= 2; start++) {
+            let runComplete = true;
+            for (let offset = start; offset < start + 5; offset++) {
+              if (!winnerWeek.daysWon.has(offset)) {
+                runComplete = false;
+                break;
+              }
+            }
+            if (runComplete) {
+              winnerWeek.completedAt = game.playedAt;
+              winnerWeek.startOffset = start;
+              break;
+            }
           }
         }
       }
@@ -793,15 +866,20 @@ export class Achievements {
       }
     }
 
-    // Award Perfect Week for each week won on all five weekdays, in week order.
+    // Award Perfect Week for each week with a completed 5-day run, in week
+    // order. setDate keeps local midnight across DST, so the run's first day
+    // is derived from the week's Monday rather than by adding 24h multiples.
     for (const [playerId, weeks] of perWeek) {
       const sortedWeeks = Array.from(weeks.entries()).sort((a, b) => a[0] - b[0]);
       for (const [week, stats] of sortedWeeks) {
         if (stats.completedAt !== null) {
+          const startDate = new Date(week);
+          startDate.setDate(startDate.getDate() + stats.startOffset);
           this.#addAchievement(
             playerId,
             this.#createAchievement("perfect-week", playerId, stats.completedAt, {
               weekStart: week,
+              startDay: startDate.getTime(),
             }),
           );
         }
@@ -1401,12 +1479,14 @@ export class Achievements {
         }
       }
 
-      // David: ≥ 30 Elo gain from beating a much higher rated opponent.
-      // Goliath: mirror image — ≥ 30 Elo lost by the higher-rated loser.
-      // Elo is zero-sum, so the loser's loss magnitude equals the
-      // winner's gain. Both players must have been ranked at the time
-      // of playing the match (pre-match ranks non-null) for either to
-      // count.
+      // David: the league record for the biggest single-game Elo gain.
+      // Goliath: mirror image — the record for the biggest single-game Elo
+      // loss. Elo is zero-sum, so the loser's loss magnitude equals the
+      // winner's gain and one game always sets (or beats) both records at
+      // once. Both players must have been ranked at the time of playing the
+      // match (pre-match ranks non-null) for the game to count. A swing of
+      // UPSET_RECORD_FLOOR establishes the first record; after that only a
+      // strictly bigger swing takes the records over.
       if (winnerRankBefore !== null && loserRankBefore !== null) {
         const prevBest = this.bestDavidGain.get(game.winner) ?? 0;
         if (eloGain > prevBest) {
@@ -1416,13 +1496,17 @@ export class Achievements {
         if (eloGain > prevWorst) {
           this.worstGoliathLoss.set(game.loser, eloGain);
         }
-        if (eloGain >= 30) {
+        const currentUpsetRecord = this.davidRecord.eloGain;
+        const beatsUpsetRecord =
+          currentUpsetRecord === undefined ? eloGain >= UPSET_RECORD_FLOOR : eloGain > currentUpsetRecord;
+        if (beatsUpsetRecord) {
           this.#addAchievement(
             game.winner,
             this.#createAchievement("david", game.winner, game.playedAt, {
               opponent: game.loser,
               gameId: game.id,
               eloGain,
+              previousRecord: currentUpsetRecord,
             }),
           );
           this.#addAchievement(
@@ -1431,8 +1515,11 @@ export class Achievements {
               opponent: game.winner,
               gameId: game.id,
               eloLoss: eloGain,
+              previousRecord: this.goliathRecord.eloLoss,
             }),
           );
+          this.davidRecord = { eloGain, holder: game.winner };
+          this.goliathRecord = { eloLoss: eloGain, holder: game.loser };
         }
       }
 
@@ -1512,6 +1599,63 @@ export class Achievements {
 
       this.marathonSetRecord = { score: setWinnerScore, holder: setWinnerId };
     });
+  }
+
+  // The Shootout score of a game: combined points of its
+  // SHOOTOUT_SETS_COUNTED highest-scoring sets (all of them when the game
+  // has fewer). Shared by the awarding pass and the progression view so the
+  // two always agree.
+  #shootoutScore(setPoints: { gameWinner: number; gameLoser: number }[]): number {
+    return setPoints
+      .map((set) => set.gameWinner + set.gameLoser)
+      .sort((a, b) => b - a)
+      .slice(0, SHOOTOUT_SETS_COUNTED)
+      .reduce((sum, points) => sum + points, 0);
+  }
+
+  // Awards "Shootout" to BOTH players of a game whose Shootout score beats
+  // the league-wide record — the points were scored together, so the record
+  // is held together. A score of SHOOTOUT_RECORD_FLOOR establishes the first
+  // record; after that only a strictly higher score takes it over.
+  #checkShootoutAchievement(
+    winner: string,
+    loser: string,
+    gameId: string,
+    setPoints: { gameWinner: number; gameLoser: number }[],
+    playedAt: number,
+  ) {
+    const points = this.#shootoutScore(setPoints);
+
+    // Track personal bests for the progression view.
+    if (points > (this.bestShootout.get(winner) ?? 0)) this.bestShootout.set(winner, points);
+    if (points > (this.bestShootout.get(loser) ?? 0)) this.bestShootout.set(loser, points);
+
+    const currentRecord = this.shootoutRecord.points;
+    const beatsRecord = currentRecord === undefined ? points >= SHOOTOUT_RECORD_FLOOR : points > currentRecord;
+    if (!beatsRecord) return;
+
+    const setsCounted = Math.min(setPoints.length, SHOOTOUT_SETS_COUNTED);
+    this.#addAchievement(
+      winner,
+      this.#createAchievement("shootout", winner, playedAt, {
+        gameId,
+        opponent: loser,
+        points,
+        setsCounted,
+        previousRecord: currentRecord,
+      }),
+    );
+    this.#addAchievement(
+      loser,
+      this.#createAchievement("shootout", loser, playedAt, {
+        gameId,
+        opponent: winner,
+        points,
+        setsCounted,
+        previousRecord: currentRecord,
+      }),
+    );
+    this.shootoutRecord = { points, holders: [winner, loser] };
   }
 
   #checkDonutAchievements(
@@ -2086,6 +2230,30 @@ export class Achievements {
 
       // Check participation TODO
 
+      // Season Opener: both players of the season's very first game earned
+      // it the moment they opened the season — no need to wait for the
+      // season to end. Seasons only exist once they contain a game, and
+      // their games arrive in time order, so the first entry is the opener.
+      const openingGame = s.games[0];
+      if (openingGame) {
+        this.#addAchievement(
+          openingGame.winner,
+          this.#createAchievement("season-opener", openingGame.winner, openingGame.playedAt, {
+            seasonStart: s.start,
+            gameId: openingGame.id,
+            opponent: openingGame.loser,
+          }),
+        );
+        this.#addAchievement(
+          openingGame.loser,
+          this.#createAchievement("season-opener", openingGame.loser, openingGame.playedAt, {
+            seasonStart: s.start,
+            gameId: openingGame.id,
+            opponent: openingGame.winner,
+          }),
+        );
+      }
+
       // Check for season winners
       if (Date.now() > s.end && leaderboard.length > 0) {
         const winner = leaderboard[0].playerId;
@@ -2249,8 +2417,20 @@ export class Achievements {
         target: this.leapFrogRecord.ranksJumped === undefined ? undefined : this.leapFrogRecord.ranksJumped + 1,
         recordHolder: this.leapFrogRecord.holder,
       },
-      "david": { current: 0, target: 30, earned: 0 },
-      "goliath": { current: 0, target: 30, earned: 0 },
+      // David / Goliath chase a fractional Elo record, so unlike the integer
+      // records the target IS the record — it must be strictly exceeded.
+      "david": {
+        earned: 0,
+        current: 0,
+        target: this.davidRecord.eloGain,
+        recordHolder: this.davidRecord.holder,
+      },
+      "goliath": {
+        earned: 0,
+        current: 0,
+        target: this.goliathRecord.eloLoss,
+        recordHolder: this.goliathRecord.holder,
+      },
       "climber": { current: 0, target: 300, earned: 0 },
       "full-house": { current: 0, target: 1, missing: new Set(), earned: 0 },
       "humbled": { current: 0, target: 1, missing: new Set(), earned: 0 },
@@ -2269,6 +2449,12 @@ export class Achievements {
         current: 0,
         target: this.marathonSetRecord.score === undefined ? undefined : this.marathonSetRecord.score + 1,
         recordHolder: this.marathonSetRecord.holder,
+      },
+      "shootout": {
+        earned: 0,
+        current: 0,
+        target: this.shootoutRecord.points === undefined ? undefined : this.shootoutRecord.points + 1,
+        recordHolders: this.shootoutRecord.holders,
       },
       "hero-of-the-day": {
         earned: 0,
@@ -2325,6 +2511,7 @@ export class Achievements {
       "tournament-winner": { earned: 0 },
       "group-stage-star": { earned: 0 },
       "season-winner": { current: 0, target: 1, earned: 0 },
+      "season-opener": { earned: 0 },
     };
 
     let firstActiveAt: number | null = null;
@@ -2348,8 +2535,9 @@ export class Achievements {
     // calendar week / month, keyed by the period's start timestamp.
     const gamesPerWeek = new Map<number, number>();
     const gamesPerMonth = new Map<number, number>();
-    // Perfect Week progression: distinct weekdays (Mon–Fri) won per working week.
-    const perfectWeekWeekdays = new Map<number, Set<number>>();
+    // Perfect Week progression: distinct won days (offsets from Monday,
+    // 0=Mon..6=Sun) per week — any day can be part of a 5-day run.
+    const perfectWeekDaysWon = new Map<number, Set<number>>();
     const opponentsPlayed = new Set<string>();
     const gamesPerOpponent = new Map<string, { count: number; firstGame: number; lastGame: number }>();
     const firstOpponentForSet = new Set<string>();
@@ -2438,19 +2626,19 @@ export class Achievements {
       const heroMonthKey = this.#monthStartOf(game.playedAt);
       gamesPerMonth.set(heroMonthKey, (gamesPerMonth.get(heroMonthKey) ?? 0) + 1);
 
-      // Perfect Week progression: collect distinct Mon–Fri weekdays won.
-      const weekday = new Date(game.playedAt).getDay(); // 0=Sun..6=Sat
-      if (isWinner && weekday >= 1 && weekday <= 5) {
+      // Perfect Week progression: collect distinct won days per week.
+      if (isWinner) {
         const weekDate = new Date(game.playedAt);
         weekDate.setHours(0, 0, 0, 0);
-        weekDate.setDate(weekDate.getDate() - ((weekDate.getDay() + 6) % 7));
+        const wonDayOffset = (weekDate.getDay() + 6) % 7; // 0=Mon..6=Sun
+        weekDate.setDate(weekDate.getDate() - wonDayOffset);
         const weekKey = weekDate.getTime();
-        let weekdaysWon = perfectWeekWeekdays.get(weekKey);
-        if (!weekdaysWon) {
-          weekdaysWon = new Set();
-          perfectWeekWeekdays.set(weekKey, weekdaysWon);
+        let daysWon = perfectWeekDaysWon.get(weekKey);
+        if (!daysWon) {
+          daysWon = new Set();
+          perfectWeekDaysWon.set(weekKey, daysWon);
         }
-        weekdaysWon.add(weekday);
+        daysWon.add(wonDayOffset);
       }
 
       // Track opponents
@@ -2592,29 +2780,34 @@ export class Achievements {
     });
     progression["hero-of-the-month"].personalBest = busiestMonth;
 
-    // Perfect Week progression tracks THIS working week's live attempt: the
-    // run of consecutive weekdays from Monday, each with at least one win.
-    // A weekday that has fully elapsed without a win breaks the run to 0 (try
-    // again next Monday); the current weekday only counts once it has a win.
-    // E.g. a Monday win reads 1/5 all through Tuesday; if Tuesday then passes
-    // with no win, Wednesday starts the player at 0/5.
+    // Perfect Week progression tracks THIS week's live attempt: of the three
+    // possible 5-consecutive-day runs (Mon–Fri, Tue–Sat, Wed–Sun), the most
+    // won days in a run that can still be completed. A run is dead once any
+    // of its days has fully elapsed without a win; today and future days are
+    // still winnable and simply count 0 until won. E.g. a Monday win reads
+    // 1/5 all through Tuesday; if Tuesday then passes with no win, the
+    // Mon–Fri and Tue–Sat runs are dead and Wednesday starts the player on
+    // the Wed–Sun run at 0/5.
     const weekStartNow = new Date(nowMs);
     weekStartNow.setHours(0, 0, 0, 0);
     const daysSinceMonday = (weekStartNow.getDay() + 6) % 7; // 0=Mon..6=Sun
     weekStartNow.setDate(weekStartNow.getDate() - daysSinceMonday);
-    const weekdaysWonThisWeek = perfectWeekWeekdays.get(weekStartNow.getTime()) ?? new Set<number>();
-    // Weekdays (1=Mon..5=Fri) that have fully elapsed must each carry a win.
-    const passedWeekdays = Math.min(daysSinceMonday, 5);
-    let perfectWeekProgress = passedWeekdays;
-    for (let weekday = 1; weekday <= passedWeekdays; weekday++) {
-      if (!weekdaysWonThisWeek.has(weekday)) {
-        perfectWeekProgress = 0;
-        break;
+    const daysWonThisWeek = perfectWeekDaysWon.get(weekStartNow.getTime()) ?? new Set<number>();
+    let perfectWeekProgress = 0;
+    for (let start = 0; start <= 2; start++) {
+      let runIsDead = false;
+      let daysWonInRun = 0;
+      for (let offset = start; offset < start + 5; offset++) {
+        if (daysWonThisWeek.has(offset)) {
+          daysWonInRun++;
+        } else if (offset < daysSinceMonday) {
+          runIsDead = true;
+          break;
+        }
       }
-    }
-    // The current weekday (Mon–Fri) counts only once it has a win.
-    if (perfectWeekProgress !== 0 && daysSinceMonday <= 4 && weekdaysWonThisWeek.has(daysSinceMonday + 1)) {
-      perfectWeekProgress += 1;
+      if (!runIsDead) {
+        perfectWeekProgress = Math.max(perfectWeekProgress, daysWonInRun);
+      }
     }
     progression["perfect-week"].current = perfectWeekProgress;
 
@@ -2820,6 +3013,11 @@ export class Achievements {
     // progression here.
     progression["goliath"].current = this.worstGoliathLoss.get(playerId) ?? 0;
 
+    // Shootout progression: the player's own highest Shootout score (combined
+    // points of a game's highest-scoring sets), compared against the league
+    // record they must strictly exceed to earn the award.
+    progression["shootout"].current = this.bestShootout.get(playerId) ?? 0;
+
     // Climber progression: current Elo - all-time low Elo since the
     // player first became ranked. Players who never became ranked have
     // no recorded low → progression stays at 0.
@@ -2925,7 +3123,9 @@ type AchievementDefinitions = {
   "unbreakable-spirit": { opponent: string };
   "hat-trick": { firstWinAt: number; thirdWinAt: number };
   "perfect-day": { day: number; wins: number };
-  "perfect-week": { weekStart: number };
+  // `startDay` is the local midnight of the first day in the 5-consecutive-day
+  // run of won days; `weekStart` the Monday of the week containing the run.
+  "perfect-week": { weekStart: number; startDay: number };
   "kingslayer": { opponent: string; gameId: string };
   "king-maker": { newKing: string; netScoreGained: number };
   "touched-the-throne": { elo: number; firstGameAt: number; dethroned?: string };
@@ -2949,8 +3149,11 @@ type AchievementDefinitions = {
     // Undefined when this jump is the first to establish the league record.
     previousRecord?: number;
   };
-  "david": { opponent: string; gameId: string; eloGain: number };
-  "goliath": { opponent: string; gameId: string; eloLoss: number };
+  // Record-breaking upset achievements — one game always sets both records
+  // (Elo is zero-sum). Undefined previousRecord means the game established
+  // the very first league record.
+  "david": { opponent: string; gameId: string; eloGain: number; previousRecord?: number };
+  "goliath": { opponent: string; gameId: string; eloLoss: number; previousRecord?: number };
   "climber": { fromElo: number; toElo: number; fromDate: number; toDate: number };
   "marathon-set": {
     gameId: string;
@@ -2976,6 +3179,13 @@ type AchievementDefinitions = {
   // the minutes past local midnight — both in the browser's timezone.
   "earliest-game": { gameId: string; opponent: string; time: string; minutesIntoDay: number };
   "latest-game": { gameId: string; opponent: string; time: string; minutesIntoDay: number };
+  // Record-breaking most-points-in-one-game achievement, awarded to both
+  // players. `points` is the combined score of the game's `setsCounted`
+  // highest-scoring sets (at most SHOOTOUT_SETS_COUNTED). Undefined
+  // previousRecord means the game established the very first league record.
+  "shootout": { gameId: string; opponent: string; points: number; setsCounted: number; previousRecord?: number };
+  // Awarded to both players of a season's very first game.
+  "season-opener": { seasonStart: number; gameId: string; opponent: string };
 };
 
 type AchievementType = keyof AchievementDefinitions;
@@ -3069,6 +3279,31 @@ type LeapFrogProgression = BaseProgression & {
   recordHolder?: string;
 };
 
+// David / Goliath chase the league record for the biggest single-game Elo
+// swing. The record is fractional, so unlike the integer records the target
+// is the record itself and must be strictly exceeded.
+type UpsetRecordProgression = BaseProgression & {
+  // Player's own biggest qualifying single-game gain / loss (0 if none).
+  current: number;
+  // The league record to strictly exceed. Undefined when no one has set a
+  // record yet (a swing of UPSET_RECORD_FLOOR takes it outright).
+  target?: number;
+  // Player who currently holds the league record, if any.
+  recordHolder?: string;
+};
+
+type ShootoutProgression = BaseProgression & {
+  // Player's own highest Shootout score: combined points of one game's
+  // highest-scoring sets (at most SHOOTOUT_SETS_COUNTED of them). 0 if none.
+  current: number;
+  // One point beyond the league record — the score that takes it. Undefined
+  // when no one has set a record yet (a SHOOTOUT_RECORD_FLOOR-point game
+  // takes it outright).
+  target?: number;
+  // Both players of the record game hold the record together.
+  recordHolders?: string[];
+};
+
 type MarathonSetProgression = BaseProgression & {
   // Player's own highest winning set score from a true-deuce set
   // they won (winner ≥ 12, loser ≥ 10). 0 if they have none.
@@ -3145,6 +3380,7 @@ export type AchievementProgression = {
   "tournament-participated": BaseProgression;
   "tournament-winner": BaseProgression;
   "season-winner": ProgressionWithTarget;
+  "season-opener": BaseProgression;
   "nice-game": BaseProgression;
   "less-is-more": BaseProgression;
   "close-calls": ProgressionWithTarget;
@@ -3168,10 +3404,11 @@ export type AchievementProgression = {
   "on-the-podium": BaseProgression;
   "photo-finish": BaseProgression;
   "leap-frog": LeapFrogProgression;
-  "david": ProgressionWithTarget;
-  "goliath": ProgressionWithTarget;
+  "david": UpsetRecordProgression;
+  "goliath": UpsetRecordProgression;
   "climber": ProgressionWithTarget;
   "marathon-set": MarathonSetProgression;
+  "shootout": ShootoutProgression;
   "streak-ender": BaseProgression;
   "longest-win-streak": StreakRecordProgression;
   "longest-lose-streak": StreakRecordProgression;

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -45,12 +45,6 @@ export function isMilestoneGameNumber(gameNumber: number): boolean {
   return gameNumber > 0 && gameNumber % MILESTONE_GAME_INTERVAL === 0;
 }
 
-// The next milestone strictly above `gameNumber` — what the league is
-// currently counting toward. Used by the progression view.
-export function nextMilestoneGameNumber(gameNumber: number): number {
-  return (Math.floor(gameNumber / MILESTONE_GAME_INTERVAL) + 1) * MILESTONE_GAME_INTERVAL;
-}
-
 export class Achievements {
   private parent: TennisTable;
   private hasCalculated = false;
@@ -585,8 +579,9 @@ export class Achievements {
         );
       }
 
-      // Check for marathon-set achievements (each set evaluated in
-      // order against the running league-wide record).
+      // Check the set-score records: Marathon Set (each set evaluated in
+      // order against the running league-wide record) and Shootout (most
+      // combined points in one game, counting only its highest-scoring sets).
       if (game.score?.setPoints) {
         this.#checkMarathonSetAchievements(
           game.winner,
@@ -595,11 +590,6 @@ export class Achievements {
           game.score.setPoints,
           game.playedAt,
         );
-      }
-
-      // Check for the Shootout record: most combined points in a single game,
-      // counting only the highest-scoring sets.
-      if (game.score?.setPoints) {
         this.#checkShootoutAchievement(game.winner, game.loser, game.id, game.score.setPoints, game.playedAt);
       }
 
@@ -1639,16 +1629,19 @@ export class Achievements {
     });
   }
 
-  // The Shootout score of a game: combined points of its
-  // SHOOTOUT_SETS_COUNTED highest-scoring sets (all of them when the game
-  // has fewer). Shared by the awarding pass and the progression view so the
-  // two always agree.
-  #shootoutScore(setPoints: { gameWinner: number; gameLoser: number }[]): number {
+  // The sets that count toward a game's Shootout score: its
+  // SHOOTOUT_SETS_COUNTED highest-scoring ones (all of them when the game has
+  // fewer, earlier sets winning ties), returned in the order they were
+  // played so they can be displayed as the game unfolded.
+  #shootoutSets(
+    setPoints: { gameWinner: number; gameLoser: number }[],
+  ): { gameWinner: number; gameLoser: number }[] {
     return setPoints
-      .map((set) => set.gameWinner + set.gameLoser)
-      .sort((a, b) => b - a)
+      .map((set, index) => ({ set, index, sum: set.gameWinner + set.gameLoser }))
+      .sort((a, b) => b.sum - a.sum || a.index - b.index)
       .slice(0, SHOOTOUT_SETS_COUNTED)
-      .reduce((sum, points) => sum + points, 0);
+      .sort((a, b) => a.index - b.index)
+      .map(({ set }) => set);
   }
 
   // A legitimately completed set: first to 11 with the loser at 9 or below,
@@ -1678,7 +1671,8 @@ export class Achievements {
     // totals can never take the record away from legit games.
     if (!setPoints.every((set) => this.#isValidSetScore(set))) return;
 
-    const points = this.#shootoutScore(setPoints);
+    const countedSets = this.#shootoutSets(setPoints);
+    const points = countedSets.reduce((sum, set) => sum + set.gameWinner + set.gameLoser, 0);
 
     // Track personal bests for the progression view.
     if (points > (this.bestShootout.get(winner) ?? 0)) this.bestShootout.set(winner, points);
@@ -1688,22 +1682,12 @@ export class Achievements {
     const beatsRecord = currentRecord === undefined ? points >= SHOOTOUT_RECORD_FLOOR : points > currentRecord;
     if (!beatsRecord) return;
 
-    // The counted sets — the SHOOTOUT_SETS_COUNTED highest-scoring ones
-    // (earlier sets win ties), restored to game order for display.
-    const countedSets = setPoints
-      .map((set, index) => ({ set, index, sum: set.gameWinner + set.gameLoser }))
-      .sort((a, b) => b.sum - a.sum || a.index - b.index)
-      .slice(0, SHOOTOUT_SETS_COUNTED)
-      .sort((a, b) => a.index - b.index)
-      .map(({ set }) => set);
-
     this.#addAchievement(
       winner,
       this.#createAchievement("shootout", winner, playedAt, {
         gameId,
         opponent: loser,
         points,
-        setsCounted: countedSets.length,
         sets: countedSets.map((set) => ({ playerPoints: set.gameWinner, opponentPoints: set.gameLoser })),
         previousRecord: currentRecord,
       }),
@@ -1714,7 +1698,6 @@ export class Achievements {
         gameId,
         opponent: winner,
         points,
-        setsCounted: countedSets.length,
         sets: countedSets.map((set) => ({ playerPoints: set.gameLoser, opponentPoints: set.gameWinner })),
         previousRecord: currentRecord,
       }),
@@ -2576,7 +2559,7 @@ export class Achievements {
       "group-stage-star": { earned: 0 },
       "season-winner": { current: 0, target: 1, earned: 0 },
       "season-opener": { earned: 0 },
-      "milestone-game": { current: 0, target: 100, earned: 0 },
+      "milestone-game": { current: 0, target: MILESTONE_GAME_INTERVAL, earned: 0 },
     };
 
     let firstActiveAt: number | null = null;
@@ -3254,16 +3237,14 @@ type AchievementDefinitions = {
   "earliest-game": { gameId: string; opponent: string; time: string; minutesIntoDay: number };
   "latest-game": { gameId: string; opponent: string; time: string; minutesIntoDay: number };
   // Record-breaking most-points-in-one-game achievement, awarded to both
-  // players. `points` is the combined score of the game's `setsCounted`
-  // highest-scoring sets (at most SHOOTOUT_SETS_COUNTED); `sets` holds those
-  // counted sets' scores in game order, from the badge owner's perspective.
-  // Undefined previousRecord means the game established the very first
-  // league record.
+  // players. `sets` holds the counted sets — the game's SHOOTOUT_SETS_COUNTED
+  // highest-scoring ones, in the order played, from the badge owner's
+  // perspective — and `points` their combined score. Undefined previousRecord
+  // means the game established the very first league record.
   "shootout": {
     gameId: string;
     opponent: string;
     points: number;
-    setsCounted: number;
     sets: { playerPoints: number; opponentPoints: number }[];
     previousRecord?: number;
   };

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -1683,14 +1683,23 @@ export class Achievements {
     const beatsRecord = currentRecord === undefined ? points >= SHOOTOUT_RECORD_FLOOR : points > currentRecord;
     if (!beatsRecord) return;
 
-    const setsCounted = Math.min(setPoints.length, SHOOTOUT_SETS_COUNTED);
+    // The counted sets — the SHOOTOUT_SETS_COUNTED highest-scoring ones
+    // (earlier sets win ties), restored to game order for display.
+    const countedSets = setPoints
+      .map((set, index) => ({ set, index, sum: set.gameWinner + set.gameLoser }))
+      .sort((a, b) => b.sum - a.sum || a.index - b.index)
+      .slice(0, SHOOTOUT_SETS_COUNTED)
+      .sort((a, b) => a.index - b.index)
+      .map(({ set }) => set);
+
     this.#addAchievement(
       winner,
       this.#createAchievement("shootout", winner, playedAt, {
         gameId,
         opponent: loser,
         points,
-        setsCounted,
+        setsCounted: countedSets.length,
+        sets: countedSets.map((set) => ({ playerPoints: set.gameWinner, opponentPoints: set.gameLoser })),
         previousRecord: currentRecord,
       }),
     );
@@ -1700,7 +1709,8 @@ export class Achievements {
         gameId,
         opponent: winner,
         points,
-        setsCounted,
+        setsCounted: countedSets.length,
+        sets: countedSets.map((set) => ({ playerPoints: set.gameLoser, opponentPoints: set.gameWinner })),
         previousRecord: currentRecord,
       }),
     );
@@ -3242,9 +3252,18 @@ type AchievementDefinitions = {
   "latest-game": { gameId: string; opponent: string; time: string; minutesIntoDay: number };
   // Record-breaking most-points-in-one-game achievement, awarded to both
   // players. `points` is the combined score of the game's `setsCounted`
-  // highest-scoring sets (at most SHOOTOUT_SETS_COUNTED). Undefined
-  // previousRecord means the game established the very first league record.
-  "shootout": { gameId: string; opponent: string; points: number; setsCounted: number; previousRecord?: number };
+  // highest-scoring sets (at most SHOOTOUT_SETS_COUNTED); `sets` holds those
+  // counted sets' scores in game order, from the badge owner's perspective.
+  // Undefined previousRecord means the game established the very first
+  // league record.
+  "shootout": {
+    gameId: string;
+    opponent: string;
+    points: number;
+    setsCounted: number;
+    sets: { playerPoints: number; opponentPoints: number }[];
+    previousRecord?: number;
+  };
   // Awarded to both players of a season's very first game.
   "season-opener": { seasonStart: number; gameId: string; opponent: string };
   // Awarded to both players of a league milestone game (the 100th, 500th,

--- a/frontend/src/common/achievement-progress.ts
+++ b/frontend/src/common/achievement-progress.ts
@@ -6,8 +6,12 @@
 // set win, and the chase only begins at 12. A player whose best deuce set was
 // 13, needing 16 to beat the league record of 15, is 2 points into a 5-point
 // gap — 40%, not 13/16 = 81%. So the bar measures from 11 instead of 0.
+// Shootout sums the 3 highest-scoring sets of a game: three 11–0 sets (33
+// points) is the least any full-length game can score, so the chase toward a
+// point-heavy record only begins above that.
 const PROGRESS_BASELINES: Record<string, number> = {
   "marathon-set": 11,
+  "shootout": 33,
 };
 
 /**

--- a/frontend/src/pages/achievements/achievements-list.tsx
+++ b/frontend/src/pages/achievements/achievements-list.tsx
@@ -108,6 +108,11 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                       Season starting {dateString(achievement.data.seasonStart)}
                     </span>
                   )}
+                  {achievement.type === "milestone-game" && achievement.data && (
+                    <span className="text-[11px] opacity-80">
+                      League game #{fmtNum(achievement.data.milestone)}
+                    </span>
+                  )}
                   {achievement.data && "lastGameAt" in achievement.data && (
                     <span className="text-[11px] opacity-80">
                       {dateString(achievement.data.lastGameAt)} – {dateString(achievement.earnedAt)}

--- a/frontend/src/pages/achievements/achievements-list.tsx
+++ b/frontend/src/pages/achievements/achievements-list.tsx
@@ -218,7 +218,8 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                   {achievement.type === "shootout" && achievement.data && (
                     <span className="text-[11px] opacity-80">
                       {achievement.data.points} points in the top {achievement.data.setsCounted} set
-                      {achievement.data.setsCounted !== 1 ? "s" : ""}
+                      {achievement.data.setsCounted !== 1 ? "s" : ""}:{" "}
+                      {achievement.data.sets.map((set) => `${set.playerPoints}–${set.opponentPoints}`).join(", ")}
                       {achievement.data.previousRecord !== undefined
                         ? ` (prev record ${achievement.data.previousRecord})`
                         : " (first league record!)"}

--- a/frontend/src/pages/achievements/achievements-list.tsx
+++ b/frontend/src/pages/achievements/achievements-list.tsx
@@ -98,9 +98,14 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                       {dateString(achievement.data.startedAt)} – {dateString(achievement.earnedAt)}
                     </span>
                   )}
-                  {achievement.data && "seasonStart" in achievement.data && (
+                  {achievement.data && "seasonStart" in achievement.data && achievement.type !== "season-opener" && (
                     <span className="text-[11px] opacity-80">
                       Season: {dateString(achievement.data.seasonStart)} – {dateString(achievement.earnedAt)}
+                    </span>
+                  )}
+                  {achievement.type === "season-opener" && achievement.data && (
+                    <span className="text-[11px] opacity-80">
+                      Season starting {dateString(achievement.data.seasonStart)}
                     </span>
                   )}
                   {achievement.data && "lastGameAt" in achievement.data && (
@@ -118,11 +123,17 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                   {achievement.type === "david" && achievement.data && (
                     <span className="text-[11px] opacity-80">
                       {fmtNum(achievement.data.eloGain, { digits: 1, signedPositive: true })} Score
+                      {achievement.data.previousRecord !== undefined
+                        ? ` (prev record ${fmtNum(achievement.data.previousRecord, { digits: 1 })})`
+                        : " (first league record!)"}
                     </span>
                   )}
                   {achievement.type === "goliath" && achievement.data && (
                     <span className="text-[11px] opacity-80">
                       {fmtNum(-achievement.data.eloLoss, { digits: 1 })} Score
+                      {achievement.data.previousRecord !== undefined
+                        ? ` (prev record ${fmtNum(-achievement.data.previousRecord, { digits: 1 })})`
+                        : " (first league record!)"}
                     </span>
                   )}
                   {achievement.type === "best-friends" && achievement.data && (
@@ -199,6 +210,15 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                         : " (first league record!)"}
                     </span>
                   )}
+                  {achievement.type === "shootout" && achievement.data && (
+                    <span className="text-[11px] opacity-80">
+                      {achievement.data.points} points in the top {achievement.data.setsCounted} set
+                      {achievement.data.setsCounted !== 1 ? "s" : ""}
+                      {achievement.data.previousRecord !== undefined
+                        ? ` (prev record ${achievement.data.previousRecord})`
+                        : " (first league record!)"}
+                    </span>
+                  )}
                   {achievement.type === "hero-of-the-day" && achievement.data && (
                     <span className="text-[11px] opacity-80">
                       {achievement.data.gamesPlayed} games in one day
@@ -258,7 +278,7 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                   )}
                   {achievement.type === "perfect-week" && achievement.data && (
                     <span className="text-[11px] opacity-80">
-                      Week of {dateString(achievement.data.weekStart)}
+                      Won 5 days in a row from {dateString(achievement.data.startDay)}
                     </span>
                   )}
                   {achievement.type === "group-stage-star" && achievement.data && (

--- a/frontend/src/pages/achievements/achievements-list.tsx
+++ b/frontend/src/pages/achievements/achievements-list.tsx
@@ -217,8 +217,8 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                   )}
                   {achievement.type === "shootout" && achievement.data && (
                     <span className="text-[11px] opacity-80">
-                      {achievement.data.points} points in the top {achievement.data.setsCounted} set
-                      {achievement.data.setsCounted !== 1 ? "s" : ""}:{" "}
+                      {achievement.data.points} points in the top {achievement.data.sets.length} set
+                      {achievement.data.sets.length !== 1 ? "s" : ""}:{" "}
                       {achievement.data.sets.map((set) => `${set.playerPoints}–${set.opponentPoints}`).join(", ")}
                       {achievement.data.previousRecord !== undefined
                         ? ` (prev record ${achievement.data.previousRecord})`

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -816,11 +816,14 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                                 (Current leader's points)
                               </span>
                             )}
-                            {type === "milestone-game" && (
-                              <span className="text-xs text-secondary-text/70 font-normal ml-2">
-                                (The league's total games — everyone counts toward it together)
-                              </span>
-                            )}
+                            {type === "milestone-game" &&
+                              typeof data.target === "number" &&
+                              typeof data.current === "number" && (
+                                <span className="text-xs text-secondary-text/70 font-normal ml-2">
+                                  (League-wide — {fmtNum(data.target - data.current)} games until the next
+                                  milestone game)
+                                </span>
+                              )}
                           </span>
                         </div>
                       </div>

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -155,7 +155,7 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
   },
   "milestone-game": {
     title: "Milestone Game",
-    description: "Play in a league milestone game — the 100th, 500th, 1,000th and every thousandth after",
+    description: "Play in a league milestone game — every 500th game played",
     icon: "🏁",
   },
   "nice-game": {

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -567,7 +567,8 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
                 {achievement.type === "shootout" && achievement.data && (
                   <p className="text-xs text-secondary-text/70 mt-2">
                     {achievement.data.points} points across the {achievement.data.setsCounted} highest-scoring set
-                    {achievement.data.setsCounted !== 1 ? "s" : ""}
+                    {achievement.data.setsCounted !== 1 ? "s" : ""}:{" "}
+                    {achievement.data.sets.map((set) => `${set.playerPoints}–${set.opponentPoints}`).join(", ")}
                     {achievement.data.previousRecord !== undefined
                       ? ` (previous record: ${achievement.data.previousRecord})`
                       : " (first league record!)"}

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -6,7 +6,10 @@ import {
   Achievement,
   AchievementProgression,
   GAMES_IN_PERIOD_RECORD_FLOOR,
+  SHOOTOUT_RECORD_FLOOR,
+  SHOOTOUT_SETS_COUNTED,
   STREAK_RECORD_FLOOR,
+  UPSET_RECORD_FLOOR,
 } from "../../client/client-db/achievements";
 import { Link } from "react-router-dom";
 import { fmtNum } from "../../common/number-utils";
@@ -145,6 +148,11 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
     description: "Finished 1st in a season",
     icon: "🍁",
   },
+  "season-opener": {
+    title: "Season Opener",
+    description: "Play in the first game of a new season",
+    icon: "🌱",
+  },
   "nice-game": {
     title: "Nice Game",
     description: "Play a game where total points scored is 69",
@@ -207,7 +215,7 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
   },
   "perfect-week": {
     title: "Perfect Week",
-    description: "Win a game on every day of a working week (Mon–Fri)",
+    description: "Win a game on each of 5 consecutive days within one week (Mon–Sun)",
     icon: "🗓️",
   },
   "kingslayer": {
@@ -242,12 +250,12 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
   },
   "david": {
     title: "David",
-    description: "Take down a much higher rated opponent (gain 30+ Score from a single game)",
+    description: "Gain more Score from a single win than anyone in league history",
     icon: "🪨",
   },
   "goliath": {
     title: "Goliath",
-    description: "Got upset by a much lower rated opponent (lose 30+ Score from a single game)",
+    description: "Lose more Score from a single game than anyone in league history",
     icon: "🗿",
   },
   "climber": {
@@ -259,6 +267,11 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
     title: "Marathon Set",
     description: "Win a deuce set with the highest winning score in league history",
     icon: "🏓",
+  },
+  "shootout": {
+    title: "Shootout",
+    description: "Play the highest-scoring game in league history (the 3 highest-scoring sets count)",
+    icon: "💥",
   },
   "hero-of-the-day": {
     title: "Hero of the Day",
@@ -435,12 +448,18 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
                 {achievement.type === "david" && achievement.data && (
                   <p className="text-xs text-secondary-text/70 mt-2">
                     Gained {fmtNum(achievement.data.eloGain, { digits: 1, signedPositive: true })} Score
+                    {achievement.data.previousRecord !== undefined
+                      ? ` (previous record: ${fmtNum(achievement.data.previousRecord, { digits: 1 })})`
+                      : " (first league record!)"}
                   </p>
                 )}
 
                 {achievement.type === "goliath" && achievement.data && (
                   <p className="text-xs text-secondary-text/70 mt-2">
                     Lost {fmtNum(-achievement.data.eloLoss, { digits: 1 })} Score
+                    {achievement.data.previousRecord !== undefined
+                      ? ` (previous record: ${fmtNum(-achievement.data.previousRecord, { digits: 1 })})`
+                      : " (first league record!)"}
                   </p>
                 )}
 
@@ -476,9 +495,15 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
                   </p>
                 )}
 
-                {achievement.data && "seasonStart" in achievement.data && (
+                {achievement.data && "seasonStart" in achievement.data && achievement.type !== "season-opener" && (
                   <p className="text-xs text-secondary-text/70 mt-2">
                     Season from {dateString(achievement.data.seasonStart)} to {dateString(achievement.earnedAt)}
+                  </p>
+                )}
+
+                {achievement.type === "season-opener" && achievement.data && (
+                  <p className="text-xs text-secondary-text/70 mt-2">
+                    Opened the season starting {dateString(achievement.data.seasonStart)}
                   </p>
                 )}
 
@@ -522,6 +547,16 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
                 {achievement.type === "marathon-set" && achievement.data && (
                   <p className="text-xs text-secondary-text/70 mt-2">
                     Set score: {achievement.data.setWinnerScore}–{achievement.data.setLoserScore}
+                    {achievement.data.previousRecord !== undefined
+                      ? ` (previous record: ${achievement.data.previousRecord})`
+                      : " (first league record!)"}
+                  </p>
+                )}
+
+                {achievement.type === "shootout" && achievement.data && (
+                  <p className="text-xs text-secondary-text/70 mt-2">
+                    {achievement.data.points} points across the {achievement.data.setsCounted} highest-scoring set
+                    {achievement.data.setsCounted !== 1 ? "s" : ""}
                     {achievement.data.previousRecord !== undefined
                       ? ` (previous record: ${achievement.data.previousRecord})`
                       : " (first league record!)"}
@@ -613,7 +648,7 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
 
                 {achievement.type === "perfect-week" && achievement.data && (
                   <p className="text-xs text-secondary-text/70 mt-2">
-                    Working week of {dateString(achievement.data.weekStart)}
+                    Won on 5 consecutive days from {dateString(achievement.data.startDay)}
                   </p>
                 )}
 
@@ -934,6 +969,51 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                         </div>
                       )}
 
+                      {/* Record holder for david / goliath. The record is a
+                          fractional Elo swing, so the target must be strictly
+                          exceeded rather than reached. */}
+                      {(type === "david" || type === "goliath") && "recordHolder" in data && data.recordHolder && (
+                        <div className="mt-2 text-xs text-secondary-text/70">
+                          League record held by{" "}
+                          <Link to={{ pathname: "/player/" + data.recordHolder, search }}>
+                            <span className="text-secondary-text underline">
+                              {context.playerName(data.recordHolder)}
+                            </span>
+                          </Link>
+                          . {type === "david" ? "Gain" : "Lose"} more than{" "}
+                          {fmtNum(data.target, { digits: 1 })} Score in one game to take it.
+                        </div>
+                      )}
+
+                      {/* Record holders for shootout — both players of the
+                          record game hold it together. */}
+                      {type === "shootout" && "recordHolders" in data && (
+                        <div className="mt-2 text-xs text-secondary-text/70">
+                          {data.recordHolders && data.recordHolders.length > 0 ? (
+                            <>
+                              League record held by{" "}
+                              {data.recordHolders.map((holder, i) => (
+                                <span key={holder}>
+                                  {i > 0 && " and "}
+                                  <Link to={{ pathname: "/player/" + holder, search }}>
+                                    <span className="text-secondary-text underline">
+                                      {context.playerName(holder)}
+                                    </span>
+                                  </Link>
+                                </span>
+                              ))}
+                              . Play a {data.target}+ point game (your {SHOOTOUT_SETS_COUNTED} highest-scoring
+                              sets count) to take it.
+                            </>
+                          ) : (
+                            <>
+                              No record set yet — play a {SHOOTOUT_RECORD_FLOOR}+ point game to start the
+                              record.
+                            </>
+                          )}
+                        </div>
+                      )}
+
                       {/* Record holder for leap-frog */}
                       {type === "leap-frog" && "recordHolder" in data && (
                         <div className="mt-2 text-xs text-secondary-text/70">
@@ -1024,6 +1104,16 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                   ) : type === "marathon-set" ? (
                     <div className="mt-2 text-xs text-secondary-text/70">
                       No league record yet — win a deuce set with the winning score at 12 or above to set the first record.
+                    </div>
+                  ) : type === "david" || type === "goliath" ? (
+                    <div className="mt-2 text-xs text-secondary-text/70">
+                      No league record yet — {type === "david" ? "gain" : "lose"} {UPSET_RECORD_FLOOR}+ Score in a
+                      single game (both players ranked) to set the first record.
+                    </div>
+                  ) : type === "shootout" ? (
+                    <div className="mt-2 text-xs text-secondary-text/70">
+                      No league record yet — play a {SHOOTOUT_RECORD_FLOOR}+ point game (the{" "}
+                      {SHOOTOUT_SETS_COUNTED} highest-scoring sets count) to set the first record.
                     </div>
                   ) : type === "leap-frog" ? (
                     <div className="mt-2 text-xs text-secondary-text/70">

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -153,6 +153,11 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
     description: "Play in the first game of a new season",
     icon: "🌱",
   },
+  "milestone-game": {
+    title: "Milestone Game",
+    description: "Play in a league milestone game — the 100th, 500th, 1,000th and every thousandth after",
+    icon: "🏁",
+  },
   "nice-game": {
     title: "Nice Game",
     description: "Play a game where total points scored is 69",
@@ -507,6 +512,12 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
                   </p>
                 )}
 
+                {achievement.type === "milestone-game" && achievement.data && (
+                  <p className="text-xs text-secondary-text/70 mt-2">
+                    Played in league game #{fmtNum(achievement.data.milestone)}
+                  </p>
+                )}
+
                 {achievement.data && "firstWinAt" in achievement.data && "thirdWinAt" in achievement.data && (
                   <p className="text-xs text-secondary-text/70 mt-2">
                     From {dateString(achievement.data.firstWinAt)} to {dateString(achievement.data.thirdWinAt)}
@@ -803,6 +814,11 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                             {type === "season-winner" && (
                               <span className="text-xs text-secondary-text/70 font-normal ml-2">
                                 (Current leader's points)
+                              </span>
+                            )}
+                            {type === "milestone-game" && (
+                              <span className="text-xs text-secondary-text/70 font-normal ml-2">
+                                (The league's total games — everyone counts toward it together)
                               </span>
                             )}
                           </span>

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -275,7 +275,7 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
   },
   "shootout": {
     title: "Shootout",
-    description: "Play the highest-scoring game in league history (the 3 highest-scoring sets count)",
+    description: "Play the highest-scoring game in league history (the 3 highest-scoring legal sets count)",
     icon: "💥",
   },
   "hero-of-the-day": {
@@ -566,8 +566,8 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
 
                 {achievement.type === "shootout" && achievement.data && (
                   <p className="text-xs text-secondary-text/70 mt-2">
-                    {achievement.data.points} points across the {achievement.data.setsCounted} highest-scoring set
-                    {achievement.data.setsCounted !== 1 ? "s" : ""}:{" "}
+                    {achievement.data.points} points across the {achievement.data.sets.length} highest-scoring set
+                    {achievement.data.sets.length !== 1 ? "s" : ""}:{" "}
                     {achievement.data.sets.map((set) => `${set.playerPoints}–${set.opponentPoints}`).join(", ")}
                     {achievement.data.previousRecord !== undefined
                       ? ` (previous record: ${achievement.data.previousRecord})`
@@ -1023,7 +1023,7 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                                 </span>
                               ))}
                               . Play a {data.target}+ point game (your {SHOOTOUT_SETS_COUNTED} highest-scoring
-                              sets count) to take it.
+                              legal sets count) to take it.
                             </>
                           ) : (
                             <>
@@ -1133,7 +1133,7 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                   ) : type === "shootout" ? (
                     <div className="mt-2 text-xs text-secondary-text/70">
                       No league record yet — play a {SHOOTOUT_RECORD_FLOOR}+ point game (the{" "}
-                      {SHOOTOUT_SETS_COUNTED} highest-scoring sets count) to set the first record.
+                      {SHOOTOUT_SETS_COUNTED} highest-scoring legal sets count) to set the first record.
                     </div>
                   ) : type === "leap-frog" ? (
                     <div className="mt-2 text-xs text-secondary-text/70">


### PR DESCRIPTION
## Summary
Adds three new achievements and refactors David/Goliath to track league-wide records instead of fixed thresholds. Perfect Week is also updated to accept any 5 consecutive calendar days within a week, rather than only Monday–Friday.

## Key Changes

**New Achievements:**
- **Shootout** 💥: Awarded to both players of the game with the most combined points (counting only the 3 highest-scoring sets). A 60-point game establishes the first record; only strictly higher scores take it over.
- **Season Opener** 🌱: Awarded to both players of a season's first game.
- **Milestone Game** 🏁: Awarded to both players of the league's 100th, 500th, 1,000th and every thousandth game thereafter. Deleted games do not count toward numbering.

**David & Goliath Refactor:**
- Changed from fixed 30-point threshold to league-wide records tracking the biggest single-game Elo swing.
- A 20-point swing (UPSET_RECORD_FLOOR) establishes the first record; after that only strictly bigger swings award again.
- Both achievements now include `previousRecord` in their data to show what was beaten.
- Added `davidRecord` and `goliathRecord` properties to track current league records and holders.

**Perfect Week Update:**
- Now accepts any 5 consecutive calendar days within a Monday-start week (Mon–Fri, Tue–Sat, or Wed–Sun).
- Previously only counted Monday–Friday wins.
- Added `startDay` to achievement data to indicate which day the 5-day run began.
- Runs crossing week boundaries no longer count.

**Implementation Details:**
- Added helper functions `isMilestoneGameNumber()` and `nextMilestoneGameNumber()` for milestone logic.
- Added `#shootoutScore()` method to calculate game points consistently between awarding and progression views.
- Updated achievement calculation loop to track game index for milestone numbering.
- Perfect Week logic now checks for any valid 5-day run within the week rather than hardcoding weekdays.
- All new achievements include progression tracking (personal bests and record targets).

**Tests:**
- Added comprehensive test suites for Shootout, Season Opener, and Milestone Game.
- Updated David and Goliath tests to reflect record-based behavior.
- Updated Perfect Week tests to cover new 5-consecutive-day logic and week-boundary cases.

**UI Updates:**
- Added achievement labels and descriptions for all three new achievements.
- Updated David/Goliath descriptions to reflect record-based nature.
- Updated Perfect Week description to clarify 5 consecutive days within a week.
- Added display of `previousRecord` in achievement details for David, Goliath, and Shootout.
- Added changelog post documenting the changes.

https://claude.ai/code/session_014Lx3ewNSsnf4GcroRXrV4B