### PR TITLE
Serve 2 each all set, and save vertical space on tracking pages

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -281,7 +281,7 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
         "The player who must serve appears in the game tracker, the live game pages, the TV overlay and the live game card on the leaderboard.",
       ),
       text(
-        "The serve changes after every 2 points, and after every point at deuce. The app calculates it from the score.",
+        "The serve changes after every 2 points. The house rule keeps 2 serves each for the whole set, also at 10-10. The app calculates the server from the score.",
       ),
     ],
   },

--- a/frontend/src/common/serve-tracker-display.tsx
+++ b/frontend/src/common/serve-tracker-display.tsx
@@ -12,9 +12,9 @@ type ServeTrackerProps = {
   player1Color: string;
   player2Color: string;
   /**
-   * When provided, a "Starts serving" selector is shown while the current set
-   * is still 0-0, letting the operator pick who serves first. Omit for
-   * read-only displays (e.g. the public scoreboard / TV overlay).
+   * When provided, a "Serves first" selector replaces the tracker while the
+   * current set is still 0-0, letting the operator pick who serves first. Omit
+   * for read-only displays (e.g. the public scoreboard / TV overlay).
    */
   onSelectFirstServer?: (player: Server) => void;
 };
@@ -28,50 +28,50 @@ export const ServeTrackerDisplay: React.FC<ServeTrackerProps> = ({
   player2Color,
   onSelectFirstServer,
 }) => {
-  const { server, servesRemaining, isDeuce } = getServeInfo(currentSet, firstServer);
+  const { server, servesRemaining } = getServeInfo(currentSet, firstServer);
   const serverName = server === 1 ? player1Name : player2Name;
   const isSetEmpty = currentSet.player1 === 0 && currentSet.player2 === 0;
   const serverColor = server === 1 ? player1Color : player2Color;
 
+  // At 0-0 the selector says who serves first, so the tracker pill would only
+  // repeat it. Show one or the other to keep the tracker a single row.
+  if (onSelectFirstServer && isSetEmpty) {
+    return (
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <span className="text-xs text-gray-400">🏓 Serves first:</span>
+        <button
+          onClick={() => onSelectFirstServer(1)}
+          className={classNames(
+            "text-xs px-2.5 py-1 rounded-full font-semibold transition",
+            firstServer === 1 ? "hover:brightness-95" : "bg-gray-100 text-gray-500 hover:bg-gray-200",
+          )}
+          style={firstServer === 1 ? fill(player1Color) : undefined}
+        >
+          {player1Name}
+        </button>
+        <button
+          onClick={() => onSelectFirstServer(2)}
+          className={classNames(
+            "text-xs px-2.5 py-1 rounded-full font-semibold transition",
+            firstServer === 2 ? "hover:brightness-95" : "bg-gray-100 text-gray-500 hover:bg-gray-200",
+          )}
+          style={firstServer === 2 ? fill(player2Color) : undefined}
+        >
+          {player2Name}
+        </button>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex flex-col items-center gap-1">
+    <div className="flex items-center justify-center">
       <div className="flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-semibold" style={fill(serverColor)}>
         <span>🏓</span>
         <span>{serverName} to serve</span>
-        {isDeuce ? (
-          <span className="text-xs font-normal opacity-80">(deuce)</span>
-        ) : (
-          <span className="text-xs font-normal opacity-80">
-            ({servesRemaining} serve{servesRemaining === 1 ? "" : "s"} left)
-          </span>
-        )}
+        <span className="text-xs font-normal opacity-80">
+          ({servesRemaining} serve{servesRemaining === 1 ? "" : "s"} left)
+        </span>
       </div>
-
-      {onSelectFirstServer && isSetEmpty && (
-        <div className="flex items-center gap-2 mt-1">
-          <span className="text-xs text-gray-400">Starts serving:</span>
-          <button
-            onClick={() => onSelectFirstServer(1)}
-            className={classNames(
-              "text-xs px-2 py-0.5 rounded-full font-semibold transition",
-              firstServer === 1 ? "hover:brightness-95" : "bg-gray-100 text-gray-500 hover:bg-gray-200",
-            )}
-            style={firstServer === 1 ? fill(player1Color) : undefined}
-          >
-            {player1Name}
-          </button>
-          <button
-            onClick={() => onSelectFirstServer(2)}
-            className={classNames(
-              "text-xs px-2 py-0.5 rounded-full font-semibold transition",
-              firstServer === 2 ? "hover:brightness-95" : "bg-gray-100 text-gray-500 hover:bg-gray-200",
-            )}
-            style={firstServer === 2 ? fill(player2Color) : undefined}
-          >
-            {player2Name}
-          </button>
-        </div>
-      )}
     </div>
   );
 };

--- a/frontend/src/common/serve-tracker.test.ts
+++ b/frontend/src/common/serve-tracker.test.ts
@@ -5,27 +5,26 @@ describe("getServeInfo", () => {
     expect(getServeInfo({ player1: 0, player2: 0 }, 1)).toEqual({
       server: 1,
       servesRemaining: 2,
-      isDeuce: false,
     });
-    expect(getServeInfo({ player1: 1, player2: 0 }, 1)).toMatchObject({
+    expect(getServeInfo({ player1: 1, player2: 0 }, 1)).toEqual({
       server: 1,
       servesRemaining: 1,
     });
   });
 
   it("switches to the other player after two points", () => {
-    expect(getServeInfo({ player1: 1, player2: 1 }, 1)).toMatchObject({
+    expect(getServeInfo({ player1: 1, player2: 1 }, 1)).toEqual({
       server: 2,
       servesRemaining: 2,
     });
-    expect(getServeInfo({ player1: 2, player2: 1 }, 1)).toMatchObject({
+    expect(getServeInfo({ player1: 2, player2: 1 }, 1)).toEqual({
       server: 2,
       servesRemaining: 1,
     });
   });
 
   it("switches back after four points", () => {
-    expect(getServeInfo({ player1: 2, player2: 2 }, 1)).toMatchObject({
+    expect(getServeInfo({ player1: 2, player2: 2 }, 1)).toEqual({
       server: 1,
       servesRemaining: 2,
     });
@@ -36,19 +35,22 @@ describe("getServeInfo", () => {
     expect(getServeInfo({ player1: 1, player2: 1 }, 2)).toMatchObject({ server: 1 });
   });
 
-  it("alternates every point at deuce", () => {
-    expect(getServeInfo({ player1: 10, player2: 10 }, 1)).toMatchObject({
+  it("stays 2 serves each when both players reach 10 points", () => {
+    expect(getServeInfo({ player1: 10, player2: 10 }, 1)).toEqual({
+      server: 1,
+      servesRemaining: 2,
+    });
+    expect(getServeInfo({ player1: 11, player2: 10 }, 1)).toEqual({
       server: 1,
       servesRemaining: 1,
-      isDeuce: true,
     });
-    expect(getServeInfo({ player1: 11, player2: 10 }, 1)).toMatchObject({
+    expect(getServeInfo({ player1: 11, player2: 11 }, 1)).toEqual({
       server: 2,
-      isDeuce: true,
+      servesRemaining: 2,
     });
-    expect(getServeInfo({ player1: 11, player2: 11 }, 1)).toMatchObject({
-      server: 1,
-      isDeuce: true,
+    expect(getServeInfo({ player1: 12, player2: 11 }, 1)).toEqual({
+      server: 2,
+      servesRemaining: 1,
     });
   });
 });

--- a/frontend/src/common/serve-tracker.ts
+++ b/frontend/src/common/serve-tracker.ts
@@ -3,15 +3,14 @@ export type Server = 1 | 2;
 export type ServeInfo = {
   /** Which player is currently serving. */
   server: Server;
-  /** Serves left in the current server's turn (1 during deuce, otherwise 1 or 2). */
+  /** Serves left in the current server's turn (1 or 2). */
   servesRemaining: number;
-  /** True once both players have reached 10 points, when serve alternates every point. */
-  isDeuce: boolean;
 };
 
 /**
- * Table tennis serve rules: each player serves 2 points in a row, then it
- * switches. Once both players reach 10 (deuce), the serve switches every point.
+ * House rule: each player serves 2 points in a row, then it switches. The serve
+ * stays 2 each for the whole set — unlike the official rules it does not change
+ * to 1 serve each when both players reach 10 points.
  *
  * `firstServer` is whoever served the first point of the current set; the
  * server for any later point is derived from the points played so far.
@@ -21,10 +20,9 @@ export function getServeInfo(
   firstServer: Server,
 ): ServeInfo {
   const totalPoints = setScore.player1 + setScore.player2;
-  const isDeuce = setScore.player1 >= 10 && setScore.player2 >= 10;
-  const serveTurn = isDeuce ? totalPoints : Math.floor(totalPoints / 2);
+  const serveTurn = Math.floor(totalPoints / 2);
   const otherServer: Server = firstServer === 1 ? 2 : 1;
   const server: Server = serveTurn % 2 === 0 ? firstServer : otherServer;
-  const servesRemaining = isDeuce ? 1 : 2 - (totalPoints % 2);
-  return { server, servesRemaining, isDeuce };
+  const servesRemaining = 2 - (totalPoints % 2);
+  return { server, servesRemaining };
 }

--- a/frontend/src/pages/add-game/track-game.tsx
+++ b/frontend/src/pages/add-game/track-game.tsx
@@ -274,8 +274,15 @@ export const TrackGamePage: React.FC = () => {
 
   // Scoring Screen
   if (stage === "scoring") {
-    const player1Leading = currentSetScore.player1 > currentSetScore.player2;
-    const player2Leading = currentSetScore.player2 > currentSetScore.player1;
+    // Whoever leads the current set is the only possible set winner, so a single
+    // button covers both players.
+    const setLeader: Server | null =
+      currentSetScore.player1 > currentSetScore.player2
+        ? 1
+        : currentSetScore.player2 > currentSetScore.player1
+          ? 2
+          : null;
+    const setLeaderColor = setLeader === 1 ? player1Color : player2Color;
     const isSetEmpty = currentSetScore.player1 === 0 && currentSetScore.player2 === 0;
     const canEndMatch =
       (matchData.setPoints?.length || 0) > 0 && isSetEmpty && matchData.setsWon.player1 !== matchData.setsWon.player2;
@@ -313,12 +320,11 @@ export const TrackGamePage: React.FC = () => {
                   </span>
                 </div>
               </div>
-              <h2 className="text-gray-400 text-xs uppercase tracking-widest font-bold mt-4">
-                Set {(matchData.setPoints?.length || 0) + 1}
-              </h2>
-
-              {/* Serve Tracker */}
-              <div className="mt-3">
+              {/* Set number and serve tracker share one row to save height */}
+              <div className="mt-3 flex flex-wrap items-center justify-center gap-x-3 gap-y-1">
+                <h2 className="text-gray-400 text-xs uppercase tracking-widest font-bold">
+                  Set {(matchData.setPoints?.length || 0) + 1}
+                </h2>
                 <ServeTrackerDisplay
                   currentSet={currentSetScore}
                   firstServer={firstServer}
@@ -332,8 +338,7 @@ export const TrackGamePage: React.FC = () => {
             </div>
 
             {/* Score Display */}
-            {/* Score Display */}
-            <div className="grid grid-cols-2 gap-2 mb-4">
+            <div className="grid grid-cols-2 gap-2 mb-3">
               {/* Player 1 */}
               <div className="rounded-lg p-2" style={{ backgroundColor: panel1Tint }}>
                 <h3 className="text-sm font-semibold text-gray-700 mb-1 text-center truncate">
@@ -405,31 +410,20 @@ export const TrackGamePage: React.FC = () => {
               </div>
             </div>
 
-            {/* Set Won Buttons */}
-            <div className="space-y-2 mb-3">
-              <button
-                onClick={() => setWon(1)}
-                disabled={!player1Leading}
-                className={classNames(
-                  "w-full py-3 rounded-lg font-semibold transition text-base",
-                  player1Leading ? "hover:brightness-95" : "bg-gray-300 text-gray-500 cursor-not-allowed",
-                )}
-                style={player1Leading ? fill(player1Color) : undefined}
-              >
-                Set Won by {context.playerName(player1)}
-              </button>
-              <button
-                onClick={() => setWon(2)}
-                disabled={!player2Leading}
-                className={classNames(
-                  "w-full py-3 rounded-lg font-semibold transition text-base",
-                  player2Leading ? "hover:brightness-95" : "bg-gray-300 text-gray-500 cursor-not-allowed",
-                )}
-                style={player2Leading ? fill(player2Color) : undefined}
-              >
-                Set Won by {context.playerName(player2)}
-              </button>
-            </div>
+            {/* Set Won Button */}
+            <button
+              onClick={() => setLeader && setWon(setLeader)}
+              disabled={setLeader === null}
+              className={classNames(
+                "w-full py-3 mb-2 rounded-lg font-semibold transition text-base",
+                setLeader === null ? "bg-gray-300 text-gray-500 cursor-not-allowed" : "hover:brightness-95",
+              )}
+              style={setLeader === null ? undefined : fill(setLeaderColor)}
+            >
+              {setLeader === null
+                ? "Set Won by leading player"
+                : `Set Won by ${context.playerName(setLeader === 1 ? player1 : player2)}`}
+            </button>
 
             {/* End Match Button */}
             <button

--- a/frontend/src/pages/add-game/track-game.tsx
+++ b/frontend/src/pages/add-game/track-game.tsx
@@ -307,10 +307,17 @@ export const TrackGamePage: React.FC = () => {
                   </span>
                 </div>
 
-                <div className="flex items-center gap-2 bg-gray-50 px-4 py-1 rounded-xl shadow-inner">
-                  <span className="text-3xl font-black">{matchData.setsWon.player1}</span>
-                  <span className="font-bold text-xl">-</span>
-                  <span className="text-3xl font-black">{matchData.setsWon.player2}</span>
+                {/* Big numbers are sets, the small ones under them are the points
+                    of the set being played. */}
+                <div className="flex flex-col items-center bg-gray-50 px-4 py-1 rounded-xl shadow-inner">
+                  <div className="flex items-center gap-2">
+                    <span className="text-3xl font-black">{matchData.setsWon.player1}</span>
+                    <span className="font-bold text-xl">-</span>
+                    <span className="text-3xl font-black">{matchData.setsWon.player2}</span>
+                  </div>
+                  <div className="text-xs font-bold text-gray-500 leading-none pb-0.5">
+                    ({currentSetScore.player1}-{currentSetScore.player2})
+                  </div>
                 </div>
 
                 <div className="flex flex-col items-center gap-1">

--- a/frontend/src/pages/live-game/live-game-admin-page.tsx
+++ b/frontend/src/pages/live-game/live-game-admin-page.tsx
@@ -69,6 +69,13 @@ export const LiveGameAdminPage: React.FC = () => {
   const player1Color = stringToColor(localState.player1Id || "");
   const player2Color = stringToColor(localState.player2Id || "");
 
+  const setLeader: Server | null =
+    localState.currentSet.player1 > localState.currentSet.player2
+      ? 1
+      : localState.currentSet.player2 > localState.currentSet.player1
+        ? 2
+        : null;
+
   function pushState(next: LiveGameState) {
     setLocalState(next);
     updateLiveGame.mutate(next);
@@ -291,11 +298,11 @@ export const LiveGameAdminPage: React.FC = () => {
                 </span>
               </div>
             </div>
-            <h2 className="text-gray-400 text-xs uppercase tracking-widest font-bold mt-4 text-center">
-              Set {localState.completedSets.length + 1}
-            </h2>
-
-            <div className="mt-3">
+            {/* Set number and serve tracker share one row to save height */}
+            <div className="mt-3 flex flex-wrap items-center justify-center gap-x-3 gap-y-1">
+              <h2 className="text-gray-400 text-xs uppercase tracking-widest font-bold">
+                Set {localState.completedSets.length + 1}
+              </h2>
               <ServeTrackerDisplay
                 currentSet={localState.currentSet}
                 firstServer={localState.firstServer}
@@ -306,10 +313,8 @@ export const LiveGameAdminPage: React.FC = () => {
                 onSelectFirstServer={setFirstServer}
               />
             </div>
-          </div>
 
-          <div className="bg-white rounded-xl shadow-lg p-4 text-black">
-            <div className="grid grid-cols-2 gap-2">
+            <div className="grid grid-cols-2 gap-2 mt-3">
               <PlayerScoreControls
                 name={context.playerName(localState.player1Id)}
                 score={localState.currentSet.player1}
@@ -326,42 +331,23 @@ export const LiveGameAdminPage: React.FC = () => {
               />
             </div>
 
-            <div className="space-y-2 mt-4">
-              <button
-                onClick={() => setWon(1)}
-                disabled={localState.currentSet.player1 <= localState.currentSet.player2}
-                className={classNames(
-                  "w-full py-3 rounded-lg font-semibold text-base",
-                  localState.currentSet.player1 > localState.currentSet.player2
-                    ? "hover:brightness-95"
-                    : "bg-gray-300 text-gray-500 cursor-not-allowed",
-                )}
-                style={
-                  localState.currentSet.player1 > localState.currentSet.player2
-                    ? fill(player1Color)
-                    : undefined
-                }
-              >
-                Set won by {context.playerName(localState.player1Id)}
-              </button>
-              <button
-                onClick={() => setWon(2)}
-                disabled={localState.currentSet.player2 <= localState.currentSet.player1}
-                className={classNames(
-                  "w-full py-3 rounded-lg font-semibold text-base",
-                  localState.currentSet.player2 > localState.currentSet.player1
-                    ? "hover:brightness-95"
-                    : "bg-gray-300 text-gray-500 cursor-not-allowed",
-                )}
-                style={
-                  localState.currentSet.player2 > localState.currentSet.player1
-                    ? fill(player2Color)
-                    : undefined
-                }
-              >
-                Set won by {context.playerName(localState.player2Id)}
-              </button>
-            </div>
+            {/* Whoever leads the current set is the only possible set winner, so a
+                single button covers both players. */}
+            <button
+              onClick={() => setLeader && setWon(setLeader)}
+              disabled={setLeader === null}
+              className={classNames(
+                "w-full py-3 mt-3 rounded-lg font-semibold text-base",
+                setLeader === null ? "bg-gray-300 text-gray-500 cursor-not-allowed" : "hover:brightness-95",
+              )}
+              style={setLeader === null ? undefined : fill(setLeader === 1 ? player1Color : player2Color)}
+            >
+              {setLeader === null
+                ? "Set won by leading player"
+                : `Set won by ${context.playerName(
+                    setLeader === 1 ? localState.player1Id : localState.player2Id,
+                  )}`}
+            </button>
           </div>
 
           <LiveGamePredictionCard
@@ -399,20 +385,23 @@ export const LiveGameAdminPage: React.FC = () => {
             >
               End Match & Review
             </button>
-            <button
-              onClick={resetMatch}
-              disabled={isSubmitting}
-              className="w-full py-3 rounded-lg font-semibold bg-gray-200 text-gray-700 hover:bg-gray-300 disabled:opacity-50"
-            >
-              Reset score
-            </button>
-            <button
-              onClick={endLiveGame}
-              disabled={isSubmitting}
-              className="w-full py-3 rounded-lg font-semibold bg-red-100 text-red-700 hover:bg-red-200 disabled:opacity-50"
-            >
-              ❌ End live game (discard)
-            </button>
+            {/* The two secondary actions share a row to save height */}
+            <div className="grid grid-cols-2 gap-2">
+              <button
+                onClick={resetMatch}
+                disabled={isSubmitting}
+                className="py-3 rounded-lg font-semibold bg-gray-200 text-gray-700 hover:bg-gray-300 disabled:opacity-50"
+              >
+                Reset score
+              </button>
+              <button
+                onClick={endLiveGame}
+                disabled={isSubmitting}
+                className="py-3 rounded-lg font-semibold bg-red-100 text-red-700 hover:bg-red-200 disabled:opacity-50"
+              >
+                ❌ End live game
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/frontend/src/pages/live-game/live-game-admin-page.tsx
+++ b/frontend/src/pages/live-game/live-game-admin-page.tsx
@@ -283,10 +283,17 @@ export const LiveGameAdminPage: React.FC = () => {
                   {context.playerName(localState.player1Id)}
                 </span>
               </div>
-              <div className="flex items-center gap-2 bg-gray-50 px-4 py-1 rounded-xl shadow-inner">
-                <span className="text-3xl font-black">{localState.setsWon.player1}</span>
-                <span className="font-bold text-xl">-</span>
-                <span className="text-3xl font-black">{localState.setsWon.player2}</span>
+              {/* Big numbers are sets, the small ones under them are the points of
+                  the set being played. */}
+              <div className="flex flex-col items-center bg-gray-50 px-4 py-1 rounded-xl shadow-inner">
+                <div className="flex items-center gap-2">
+                  <span className="text-3xl font-black">{localState.setsWon.player1}</span>
+                  <span className="font-bold text-xl">-</span>
+                  <span className="text-3xl font-black">{localState.setsWon.player2}</span>
+                </div>
+                <div className="text-xs font-bold text-gray-500 leading-none pb-0.5">
+                  ({localState.currentSet.player1}-{localState.currentSet.player2})
+                </div>
               </div>
               <div className="flex flex-col items-center gap-1">
                 <ProfilePicture playerId={localState.player2Id} size={50} border={2} />

--- a/frontend/src/pages/live-game/live-game-prediction-card.tsx
+++ b/frontend/src/pages/live-game/live-game-prediction-card.tsx
@@ -120,49 +120,43 @@ export const LiveGamePredictionCard: React.FC<Props> = ({
 
   return (
     <div className="bg-white rounded-xl shadow-lg p-4 text-black">
-      <h2 className="text-gray-400 text-xs uppercase tracking-widest font-bold mb-3 text-center">
+      <h2 className="text-gray-400 text-xs uppercase tracking-widest font-bold mb-2 text-center">
         Live Win Prediction
       </h2>
 
-      {hasUnranked && (
-        <div className="mb-3 flex items-center gap-2 rounded-lg border border-yellow-500/60 bg-yellow-50 px-3 py-2 text-xs text-yellow-800">
-          <span className="text-base leading-none">⚠️</span>
-          <span>{unrankedLabel} — the prediction is based on insufficient data and may be unreliable.</span>
-        </div>
-      )}
-
       {hasPrediction ? (
         <>
-          <div className="flex items-baseline justify-between text-sm font-semibold mb-1">
-            <span className="truncate max-w-[45%]" style={textOn(player1Color, CARD_SURFACE)}>
-              {player1Name}
+          {/* Each player's win chance sits in the label row, so the bar itself
+              needs no text and can stay short. */}
+          <div className="flex items-baseline justify-between gap-2 text-sm font-semibold mb-1">
+            <span className="truncate" style={textOn(player1Color, CARD_SURFACE)}>
+              {player1Name} {fmtNum(player1WinChance * 100)}%
             </span>
-            <span className="truncate max-w-[45%] text-right" style={textOn(player2Color, CARD_SURFACE)}>
-              {player2Name}
+            <span className="truncate text-right" style={textOn(player2Color, CARD_SURFACE)}>
+              {fmtNum(player2WinChance * 100)}% {player2Name}
             </span>
           </div>
-          <div className="flex h-8 w-full overflow-hidden rounded-full bg-gray-100">
+          <div className="flex h-6 w-full overflow-hidden rounded-full bg-gray-100">
             <div
-              className="flex items-center justify-start px-2 text-xs font-bold transition-all duration-500"
+              className="transition-all duration-500"
               style={{ width: `${player1WinChance * 100}%`, ...fill(player1Color) }}
-            >
-              {player1WinChance >= 0.12 && `${fmtNum(player1WinChance * 100)}%`}
-            </div>
+            />
             <div
-              className="flex items-center justify-end px-2 text-xs font-bold transition-all duration-500"
+              className="transition-all duration-500"
               style={{ width: `${player2WinChance * 100}%`, ...fill(player2Color) }}
-            >
-              {player2WinChance >= 0.12 && `${fmtNum(player2WinChance * 100)}%`}
-            </div>
+            />
           </div>
-          <div className="mt-1 flex justify-between text-xs font-semibold">
-            <span style={textOn(player1Color, CARD_SURFACE)}>{fmtNum(player1WinChance * 100)}% win chance</span>
-            <span style={textOn(player2Color, CARD_SURFACE)}>{fmtNum(player2WinChance * 100)}% win chance</span>
-          </div>
-          <div className="mt-3 text-center text-xs text-gray-500">{fmtNum(confidence * 100)}% confidence</div>
+          <div className="mt-1 text-center text-xs text-gray-500">{fmtNum(confidence * 100)}% confidence</div>
         </>
       ) : (
         <p className="text-center text-sm text-gray-500 py-2">Not enough data to predict a winner yet.</p>
+      )}
+
+      {hasUnranked && (
+        <div className="mt-2 flex items-center gap-2 rounded-lg border border-yellow-500/60 bg-yellow-50 px-3 py-2 text-xs text-yellow-800">
+          <span className="text-base leading-none">⚠️</span>
+          <span>{unrankedLabel} — the prediction is based on insufficient data and may be unreliable.</span>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
House rule: the serve stays 2 points each for the whole set. The serve
tracker no longer switches to 1 serve each when both players reach 10.

Vertical space on the game tracker and the live game admin page:
- One "Set won by <leader>" button instead of one button per player.
- The set number and the serve tracker share a row, and the "Serves first"
  selector replaces the serve pill at 0-0 instead of stacking under it.
- The live game admin score header and the point controls are one card, and
  the reset/end actions share a row.
- The prediction card puts each win chance in the label row above a shorter
  bar, and moves the unranked warning under the bar.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015T2ckr5DSq4ykVvFwdGufv