### PR TITLE
Broadcast WebSocket updates across all server instances

### DIFF
--- a/DenoServer/.env.example
+++ b/DenoServer/.env.example
@@ -5,5 +5,6 @@ ENVIRONMENT=local
 CLIENT=local
 GAMEBOT_TOKEN=""
 GAMEBOT_CHANNEL_ID=""
+# Leave both empty to use the local SQLite database instead of Supabase
 SUPABASE_URL=""
-SUPABASE_SERVICE_ROLE_KEY=""
+SUPABASE_SECRET_KEY=""

--- a/DenoServer/AGENTS.md
+++ b/DenoServer/AGENTS.md
@@ -4,7 +4,7 @@
 The backend is the "Vault". It is a **Thin Server** designed to be simple, fast, and stateless regarding business rules. It does **not** calculate match winners, Elo ratings, or statistics.
 
 ## Responsibilities
-1.  **Event Storage:** Appends events to the database (Deno KV).
+1.  **Event Storage:** Appends events to the database (SQL).
 2.  **Authentication:** Handles user login and session security.
 3.  **Broadcasting:** Pushes new events to connected clients via WebSockets.
 4.  **Image Handling:** Proxies/manages image uploads (ImageKit).
@@ -12,14 +12,30 @@ The backend is the "Vault". It is a **Thin Server** designed to be simple, fast,
 ## Architecture
 - **Runtime:** Deno.
 - **Framework:** Oak (Middleware framework).
-- **Database:** Deno KV (Key-Value store).
+- **Database:** SQL behind the `Database` interface in `db/database.ts`. Supabase
+  Postgres in deployed environments, SQLite (`./data/local.db`) locally.
 - **Routes:** Organized in folders (e.g., `user/`, `event-store/`, `web-socket/`).
+
+## Database
+- **Interface:** `db/database.ts` defines every operation the server can perform.
+  `db.ts` picks the implementation: Supabase when `SUPABASE_URL` and
+  `SUPABASE_SECRET_KEY` are set, otherwise local SQLite. On Deno Deploy the
+  Supabase variables are required and the server refuses to start without them.
+- **Implementations:** `db/supabase.ts` and `db/sqlite.ts`. Add a method to both
+  when you extend the interface.
+- **Schema:** `db/schema.sql`. Tables: `events`, `users`, `live_game`,
+  `key_value`.
+- **Multi-tenancy:** One database serves every deployment. Every table has a
+  `client_id` column from the `CLIENT` env var, and every query filters on it.
+  A query without that filter reads another office's data.
 
 ## Workflows
 
 ### 1. Running the Server
 - **Command:** `deno task dev`
-- **Flags:** Note the usage of `--unstable-kv` and `--unstable-cron`.
+- **Flags:** Note the usage of `--unstable-cron` and
+  `--unstable-broadcast-channel`.
+- **Database:** Uses local SQLite unless the Supabase env vars are set.
 
 ### 2. Type Checking
 - **Command:** `deno task check`
@@ -32,9 +48,20 @@ The backend is the "Vault". It is a **Thin Server** designed to be simple, fast,
 ## Tech Stack
 - **Deno** (TypeScript).
 - **Oak** (HTTP Server).
-- **Deno KV** (Persistence).
+- **Supabase Postgres** (Persistence), **SQLite** locally.
 
 ## Key Files
 - `server.ts`: Entry point and middleware setup.
 - `deno.json`: Task and import definitions.
 - `event-store/event-store.ts`: Logic for persisting events.
+- `db.ts`: Chooses the database implementation.
+- `db/database.ts`: The database interface both implementations satisfy.
+- `db/schema.sql`: The Postgres schema.
+- `web-socket/web-socket-client-manager.ts`: Connected clients and broadcasts.
+
+## Broadcasting
+The connected WebSocket clients live in the memory of one server instance, and
+the deployment runs several. A broadcast therefore goes out over a
+`BroadcastChannel` first, so every instance sends it to its own clients. A write
+can land on an instance that holds no clients at all. Never assume the instance
+that handles a request is the instance a client is connected to.

--- a/DenoServer/README.md
+++ b/DenoServer/README.md
@@ -4,10 +4,14 @@
 
 `cp .env.example .env`
 
+The server uses a local SQLite database at `./data/local.db` unless `SUPABASE_URL`
+and `SUPABASE_SECRET_KEY` are set. With those set it uses Supabase Postgres, and
+`CLIENT` selects which deployment's data to read and write.
+
 # Start server in dev mode
 
 `deno task dev`
 
 # Other: Start REPL if you wan to try out db stuff with repl
 
-`deno repl -A --unstable-kv`
+`deno repl -A`

--- a/DenoServer/deno.json
+++ b/DenoServer/deno.json
@@ -1,8 +1,8 @@
 {
   "nodeModulesDir": "auto",
-  "unstable": ["cron"],
+  "unstable": ["cron", "broadcast-channel"],
   "tasks": {
-    "dev": "deno run --allow-net --allow-env --allow-read --allow-write --allow-ffi --env --watch --unstable-cron --unstable-ffi server.ts",
+    "dev": "deno run --allow-net --allow-env --allow-read --allow-write --allow-ffi --env --watch --unstable-cron --unstable-ffi --unstable-broadcast-channel server.ts",
     "check": "deno check ."
   },
   "compilerOptions": {

--- a/DenoServer/web-socket/web-socket-client-manager.ts
+++ b/DenoServer/web-socket/web-socket-client-manager.ts
@@ -12,12 +12,53 @@ enum WS_MESSAGE {
   CLEAR_CACHE = "clear-cache",
 }
 
+/**
+ * Name of the cross-instance channel. All server instances of a deployment
+ * join the same channel, so a broadcast reaches every connected client and not
+ * only the clients that share an instance with the writer.
+ */
+const FANOUT_CHANNEL_NAME = "ws-updates-fanout";
+
 export class WebSocketClientManager {
   private readonly instanciatedAt = Date.now();
   private clients: Map<string, { client: WebSocket; createdAt: number }>;
+  /**
+   * The web socket clients live in the memory of one server instance, but the
+   * deployment runs several instances. A write can land on an instance that
+   * holds no web sockets, so the broadcast must travel between the instances
+   * before it goes to the clients.
+   *
+   * `BroadcastChannel` does this on Deno Deploy. It is undefined on a local
+   * server without the unstable flag, and then the fanout is a no-op. One
+   * local instance holds all the clients, so the local behaviour stays correct.
+   */
+  private fanout: BroadcastChannel | undefined;
 
   constructor() {
     this.clients = new Map();
+    this.fanout = this.openFanoutChannel();
+  }
+
+  private openFanoutChannel(): BroadcastChannel | undefined {
+    if (typeof BroadcastChannel === "undefined") {
+      console.log("BroadcastChannel is not available. Web socket broadcasts stay local to this instance.");
+      return undefined;
+    }
+
+    try {
+      const channel = new BroadcastChannel(FANOUT_CHANNEL_NAME);
+      // A message from another instance goes to this instance's clients only.
+      // Sending it back to the channel would loop between the instances.
+      channel.onmessage = (event: MessageEvent<unknown>) => {
+        if (typeof event.data === "string") {
+          this.sendToLocalClients(event.data);
+        }
+      };
+      return channel;
+    } catch (error) {
+      console.error("Failed to open the web socket fanout channel:", error);
+      return undefined;
+    }
   }
 
   private addClient(client: WebSocket): string {
@@ -79,20 +120,41 @@ export class WebSocketClientManager {
   }
 
   private async sendLatestEvent(client: WebSocket) {
-    const lastEvent = await getLatestEventTimestamp();
-    if (!lastEvent) return;
+    // A database read can fail. It runs outside of a request, so a rejection
+    // here is unhandled and stops the process with all of its web sockets.
+    try {
+      const lastEvent = await getLatestEventTimestamp();
+      if (!lastEvent) return;
 
-    client.send(WS_MESSAGE.LATEST_EVENT + ":" + lastEvent);
+      if (client.readyState === WebSocket.OPEN) {
+        client.send(WS_MESSAGE.LATEST_EVENT + ":" + lastEvent);
+      }
+    } catch (error) {
+      console.error("Failed to send the latest event to a client:", error);
+    }
   }
 
   /**
-   * Send message to all open web sockets on the server managed by the manager
+   * Send message to all open web sockets of this server instance
    */
-  private broadcastMessage(message: string) {
+  private sendToLocalClients(message: string) {
     for (const [_id, client] of this.clients) {
       if (client.client.readyState === WebSocket.OPEN) {
         client.client.send(message);
       }
+    }
+  }
+
+  /**
+   * Send message to all open web sockets of all server instances
+   */
+  private broadcastMessage(message: string) {
+    this.sendToLocalClients(message);
+
+    try {
+      this.fanout?.postMessage(message);
+    } catch (error) {
+      console.error("Failed to send a web socket broadcast to the other instances:", error);
     }
   }
 
@@ -137,9 +199,14 @@ export class WebSocketClientManager {
    * Used for when new events are added.
    */
   async broadcastLatestEvent() {
-    const lastEvent = await getLatestEventTimestamp();
-    if (!lastEvent) return;
-    this.broadcastMessage(WS_MESSAGE.LATEST_EVENT + ":" + lastEvent);
+    // Callers do not await this, so a rejection would be unhandled.
+    try {
+      const lastEvent = await getLatestEventTimestamp();
+      if (!lastEvent) return;
+      this.broadcastMessage(WS_MESSAGE.LATEST_EVENT + ":" + lastEvent);
+    } catch (error) {
+      console.error("Failed to broadcast the latest event:", error);
+    }
   }
 
   /**
@@ -164,10 +231,14 @@ export class WebSocketClientManager {
    */
   listAllClients(): {
     instanciatedAt: string;
+    crossInstanceFanout: boolean;
     clients: { id: string; createdAt: number }[];
   } {
     return {
       instanciatedAt: new Date(this.instanciatedAt).toLocaleString("no-NO", { hourCycle: "h23" }),
+      // The list covers one server instance. A deployment runs several, so two
+      // calls can report different instances and different client lists.
+      crossInstanceFanout: this.fanout !== undefined,
       clients: Array.from(this.clients.keys()).map((id) => ({
         id,
         createdAt: this.clients.get(id)!.createdAt,

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -10,7 +10,7 @@ The system follows a strict **Event Sourcing** architecture with a clear separat
 
 ## Directory Structure
 - `/frontend`: The React application. Contains all business logic and UI.
-- `/DenoServer`: The Deno backend. Handles API, WebSockets, and DB (Deno KV).
+- `/DenoServer`: The Deno backend. Handles API, WebSockets, and DB (Supabase Postgres, SQLite locally).
 
 ## General Philosophies
 1.  **Event Driven:** The state is a derivative of events. To change state, you emit an event.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-Purpose: To test out deno, kv db and deno deploy
+Purpose: To test out deno, deno deploy and event sourcing with a thick client
 App: Track table tennis matches in the office
+
+The store started as Deno KV and is now SQL: Supabase Postgres when deployed,
+SQLite when run locally.
 
 See server readme for local run server command

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -422,10 +422,10 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
       "A public page and an admin page for a game in progress, and an overlay without app chrome for a screen next to the table.",
     body: [
       text(
-        "One page is for the person who records the score. The other page is for everyone who watches. The state is on the server, and the server pushes it to viewers over the WebSocket connection, so the public page does not poll.",
+        "One page is for the person who records the score. The other page is for everyone who watches. The state is on the server, and the server pushes it to viewers over the WebSocket connection. Each viewer also polls every few seconds, so the score follows the game if the connection stops.",
       ),
       text(
-        "The overlay is a separate route with no menu, header or padding, so you can capture it and show it on a TV. It has a zoom option for different screen sizes, and it refetches the state if the connection stops.",
+        "The overlay is a separate route with no menu, header or padding, so you can capture it and show it on a TV. It has a zoom option for different screen sizes. The poll continues while the tab is in the background, which a capture on a TV is.",
       ),
     ],
   },
@@ -874,6 +874,9 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
     summary: "A game you enter on one phone appears on every other screen immediately, with no refresh.",
     body: [
       text("The server broadcasts a new event to every connected client, so the leaderboard updates itself."),
+      text(
+        "The deployment runs the server in several instances, and each instance holds its own connections. A broadcast now travels between the instances first, so it reaches every client and not only the clients of the instance that took the write.",
+      ),
       text(
         "The same channel now carries the cache invalidation when an admin edits an event. It also lets the live game page and the TV overlay work with no poll.",
       ),

--- a/frontend/src/hooks/use-web-socket.tsx
+++ b/frontend/src/hooks/use-web-socket.tsx
@@ -10,6 +10,23 @@ export enum WS_MESSAGE {
   CLEAR_CACHE = "clear-cache",
 }
 
+const RECONNECT_DELAY_MS = 5_000;
+
+/**
+ * The WebSocket constructor takes a `ws:` or a `wss:` url. Most browsers accept
+ * an `http:` or an `https:` url and map it, but some throw instead. The api
+ * base url is an http url, so map it here.
+ */
+function toWebSocketUrl(url: string): string {
+  if (url.startsWith("https://")) {
+    return "wss://" + url.slice("https://".length);
+  }
+  if (url.startsWith("http://")) {
+    return "ws://" + url.slice("http://".length);
+  }
+  return url;
+}
+
 export const useWebSocket = (
   url: string,
   { onMessage, onClose }: { onMessage?: (message: string) => void; onClose?: () => void },
@@ -17,6 +34,8 @@ export const useWebSocket = (
   const [webSocket, setWebSocket] = useState<WebSocket>();
   const onMessageRef = useRef(onMessage);
   const onCloseRef = useRef(onClose);
+  const socketRef = useRef<WebSocket>();
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
 
   // Keep refs up to date so reconnections use the latest callbacks
   useEffect(() => { onMessageRef.current = onMessage; }, [onMessage]);
@@ -26,27 +45,65 @@ export const useWebSocket = (
     webSocket?.send(message);
   }
 
-  function openWebSocket() {
-    const socket = new WebSocket(url);
-    socket.onmessage = (messageEvent) => {
-      onMessageRef.current && typeof messageEvent.data === "string" && onMessageRef.current(messageEvent.data);
-    };
-    socket.onclose = () => {
-      // Retry connection every 5 seconds
-      onCloseRef.current && onCloseRef.current();
-      setTimeout(() => {
-        openWebSocket();
-      }, 5_000);
-    };
-    setWebSocket(socket);
-  }
-
   useEffect(() => {
+    const socketUrl = toWebSocketUrl(url);
+    let isMounted = true;
+
+    function scheduleReconnect() {
+      if (isMounted === false) return;
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = setTimeout(openWebSocket, RECONNECT_DELAY_MS);
+    }
+
+    function openWebSocket() {
+      if (isMounted === false) return;
+
+      let socket: WebSocket;
+      try {
+        socket = new WebSocket(socketUrl);
+      } catch (error) {
+        console.error("Failed to open the web socket:", error);
+        scheduleReconnect();
+        return;
+      }
+
+      socketRef.current = socket;
+      socket.onmessage = (messageEvent) => {
+        onMessageRef.current && typeof messageEvent.data === "string" && onMessageRef.current(messageEvent.data);
+      };
+      socket.onclose = () => {
+        onCloseRef.current && onCloseRef.current();
+        // A socket the hook has already replaced must not open another one.
+        if (socketRef.current !== socket) return;
+        scheduleReconnect();
+      };
+      setWebSocket(socket);
+    }
+
+    /**
+     * A device that sleeps or a tab that goes to the background can lose the
+     * connection with no close event. Reconnect as soon as the page is visible
+     * again, so the screen does not wait for the next heartbeat to time out.
+     */
+    function onVisibilityChange() {
+      if (document.visibilityState !== "visible") return;
+
+      const state = socketRef.current?.readyState;
+      if (state === WebSocket.OPEN || state === WebSocket.CONNECTING) return;
+
+      clearTimeout(reconnectTimeoutRef.current);
+      openWebSocket();
+    }
+
     openWebSocket();
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
     return () => {
-      webSocket?.close();
+      isMounted = false;
+      clearTimeout(reconnectTimeoutRef.current);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      socketRef.current?.close();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [url]);
 
   return { send, webSocket };

--- a/frontend/src/pages/leaderboard/leader-board.tsx
+++ b/frontend/src/pages/leaderboard/leader-board.tsx
@@ -21,6 +21,8 @@ import { RelativeTime } from "../../common/date-utils";
 
 type LeaderboardView = "overall" | "season";
 
+const LIVE_GAME_CARD_POLL_MS = 10_000;
+
 const LeaderboardToggle = ({
   className,
   view,
@@ -59,7 +61,9 @@ const LeaderboardToggle = ({
 export const LeaderBoard: React.FC = () => {
   const context = useEventDbContext();
   const navigate = useNavigate();
-  const liveGameQuery = useLiveGameQuery();
+  // The card shows the score of a game in progress. A slow fallback poll keeps
+  // it current if the WebSocket broadcast does not arrive.
+  const liveGameQuery = useLiveGameQuery({ refetchIntervalMs: LIVE_GAME_CARD_POLL_MS });
   const leaderboard = context.leaderboard.getLeaderboard();
   const [viewString, setViewString] = useLocalStorage("leaderboard_view", "overall");
   

--- a/frontend/src/pages/live-game/live-game-overlay.tsx
+++ b/frontend/src/pages/live-game/live-game-overlay.tsx
@@ -17,7 +17,9 @@ export const LiveGameOverlay: React.FC = () => {
   const [searchParams] = useSearchParams();
   const zoom = parseFloat(searchParams.get("zoom") || "1") || 1;
   const context = useEventDbContext();
-  const liveGameQuery = useLiveGameQuery({ refetchIntervalMs: POLL_FALLBACK_MS });
+  // The overlay is captured on a screen next to the table, where the tab counts
+  // as a background tab. It must keep the poll running.
+  const liveGameQuery = useLiveGameQuery({ refetchIntervalMs: POLL_FALLBACK_MS, refetchInBackground: true });
 
   const state = liveGameQuery.data;
   const isActive = !!state && !!state.player1Id && !!state.player2Id && state.startedAt !== null && !state.finishedAt;

--- a/frontend/src/pages/live-game/live-game-page.tsx
+++ b/frontend/src/pages/live-game/live-game-page.tsx
@@ -13,14 +13,15 @@ import { Server } from "../../common/serve-tracker";
 import { ServeTrackerDisplay } from "../../common/serve-tracker-display";
 
 // Fallback poll in case the WebSocket drops — primary updates come from
-// the LIVE_GAME broadcast handled in WebSocketRefetcher.
+// the LIVE_GAME broadcast handled in WebSocketRefetcher. The poll also runs
+// while the tab is in the background, for a phone that lies on the table.
 const POLL_FALLBACK_MS = 3_000;
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
 
 export const LiveGamePage: React.FC = () => {
   const context = useEventDbContext();
-  const liveGameQuery = useLiveGameQuery({ refetchIntervalMs: POLL_FALLBACK_MS });
+  const liveGameQuery = useLiveGameQuery({ refetchIntervalMs: POLL_FALLBACK_MS, refetchInBackground: true });
 
   const isAdmin = session.sessionData?.role === "admin";
   const state = liveGameQuery.data;

--- a/frontend/src/pages/live-game/use-live-game.ts
+++ b/frontend/src/pages/live-game/use-live-game.ts
@@ -5,7 +5,16 @@ import { queryClient } from "../../common/query-client";
 
 const LIVE_GAME_QUERY_KEY = ["live-game"];
 
-export function useLiveGameQuery(options?: { refetchIntervalMs?: number | false; enabled?: boolean }) {
+export function useLiveGameQuery(options?: {
+  refetchIntervalMs?: number | false;
+  enabled?: boolean;
+  /**
+   * React Query stops an interval refetch while the tab is in the background. A
+   * screen that shows the score is often in the background: a TV capture, or a
+   * phone that lies on the table. Set this to keep the poll running.
+   */
+  refetchInBackground?: boolean;
+}) {
   return useQuery<LiveGameState | null>({
     enabled: options?.enabled ?? true,
     queryKey: LIVE_GAME_QUERY_KEY,
@@ -19,6 +28,7 @@ export function useLiveGameQuery(options?: { refetchIntervalMs?: number | false;
       return JSON.parse(text) as LiveGameState;
     },
     refetchInterval: options?.refetchIntervalMs ?? false,
+    refetchIntervalInBackground: options?.refetchInBackground ?? false,
     refetchOnWindowFocus: true,
     refetchOnReconnect: true,
   });


### PR DESCRIPTION
The WebSocket client registry lives in the memory of one server instance,
but the deployment runs several. A write that lands on an instance holding
no sockets broadcast to nobody, so other devices only saw a new score when
they reloaded and read the state over HTTP.

Broadcasts now go through a BroadcastChannel, which Deno Deploy uses for
messages between instances. Each instance sends to its own clients and
forwards the message to the others, which send to theirs. The channel is
undefined on a local server without the unstable flag, and then the fanout
is a no-op with one instance holding all the clients.

Also harden the paths around it:

- The database read behind the latest-event message can fail. It runs
  outside a request, so a rejection was unhandled and could stop the
  process with all of its sockets. Both call sites now catch.
- Map the api base url to ws:/wss: before opening the socket. Not every
  browser accepts an http: url in the WebSocket constructor.
- Close the socket on unmount, stop a replaced socket from opening
  another one, and reconnect as soon as the page is visible again instead
  of waiting for the heartbeat to time out.
- Keep the viewer poll running while the tab is in the background, which
  is what a TV capture and a phone on the table are, and give the live
  game card on the leaderboard a slow poll of its own.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ABLLAWEWma6QuGn9Y6JNZd