### PR TITLE
Track shared progress towards the next Season Opener

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -51,7 +51,7 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
     body: [
       list(
         "Shootout 💥 - the league record for the most points in one game. Only the 3 legal sets with the most points count, so a best-of-5 game competes on equal terms with a best-of-3. A game with 60 points or more sets the first record. A game with an illegal set score does not compete at all. A score of 15-12 is illegal, because above 11 a player must win a set by exactly 2 points. Bonus points from house rules therefore cannot increase a total.",
-        "Season Opener 🌱 - both players of the first game of a season earn this. It returns every quarter.",
+        "Season Opener 🌱 - both players of the first game of a season earn this. It returns every quarter. All players see the same progress view, which counts down to the start of the next season. The view stays at 100% from the start of a season until the first game of it.",
         "Milestone Game 🏁 - both players of every 500th game in the league earn this. Deleted games do not count. All players see the same progress view, and it restarts at each milestone.",
       ),
       text(

--- a/frontend/src/client/client-db/__tests__/achievements/season-opener.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/season-opener.test.ts
@@ -1,6 +1,7 @@
 import { TennisTable } from "../../tennis-table";
 import { EventType, EventTypeEnum } from "../../event-store/event-types";
-import { determineSeason } from "../../seasons/seasons";
+import { determineNextSeason, determineSeason } from "../../seasons/seasons";
+import { achievementProgressPercentage } from "../../../../common/achievement-progress";
 
 // Season Opener is awarded to BOTH players of a season's very first game,
 // stamped at the game itself. Games in the grace period between seasons
@@ -97,5 +98,123 @@ describe("Season Opener Achievement", () => {
     expect(carol).toHaveLength(1);
     expect(carol[0].data?.gameId).toBe("g3");
     expect(tt.achievements.getAchievements("dave").filter((a) => a.type === "season-opener")).toHaveLength(0);
+  });
+
+  // The progress is a league-wide countdown to the next season start: the same
+  // values for every player, whether or not they ever opened a season.
+  describe("progress towards the next Season Opener", () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    const q1 = determineSeason(q1Game1);
+    const q2Start = determineNextSeason(q1Game1).start;
+    // A game in the Q4 2023 season, so a season exists before Q1 2024 starts.
+    const q4Game = new Date(2023, 9, 10, 12).getTime();
+
+    function progressionFor(events: EventType[], playerId: string) {
+      const tt = new TennisTable({ events });
+      tt.achievements.calculateAchievements();
+      return tt.achievements.getPlayerProgression(playerId)["season-opener"];
+    }
+
+    function percentageOf(progress: { current: number; target: number }) {
+      return achievementProgressPercentage("season-opener", progress.current, progress.target);
+    }
+
+    it("counts from the season start towards the next season start, the same for everyone", () => {
+      const now = new Date(2024, 1, 1, 12).getTime(); // 1 February 2024, inside the Q1 season
+      jest.useFakeTimers();
+      jest.setSystemTime(now);
+
+      const events: EventType[] = [...baseEvents, game("g1", q1Game1, "alice", "bob")];
+
+      // Alice opened the season and Carol has never played, but the countdown
+      // is the same for both.
+      for (const player of ["alice", "carol"]) {
+        const progress = progressionFor(events, player);
+        expect(progress.target).toBe(q2Start - q1.start);
+        expect(progress.current).toBe(now - q1.start);
+        expect(progress.nextSeasonStart).toBe(q2Start);
+      }
+      expect(progressionFor(events, "alice").earned).toBe(1);
+      expect(progressionFor(events, "carol").earned).toBe(0);
+    });
+
+    it("starts at 0 at the season start", () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(q1.start);
+
+      const events: EventType[] = [...baseEvents, game("g1", q1.start, "alice", "bob")];
+
+      expect(progressionFor(events, "alice").current).toBe(0);
+    });
+
+    it("holds at 100% while the season is open and has no games", () => {
+      const now = new Date(2024, 0, 2, 12).getTime(); // the day after the Q1 season started
+      jest.useFakeTimers();
+      jest.setSystemTime(now);
+
+      // The last game is in the Q4 2023 season, so the Q1 season is open and
+      // its opener is still there to take.
+      const events: EventType[] = [...baseEvents, game("g1", q4Game, "alice", "bob")];
+
+      const progress = progressionFor(events, "carol");
+      expect(progress.current).toBe(progress.target);
+      expect(percentageOf(progress)).toBe(100);
+    });
+
+    it("falls back to the countdown once the opening game is played", () => {
+      const now = new Date(2024, 0, 2, 12).getTime();
+      jest.useFakeTimers();
+      jest.setSystemTime(now);
+
+      const openingGame = new Date(2024, 0, 2, 10).getTime(); // two hours before now
+      const events: EventType[] = [
+        ...baseEvents,
+        game("g1", q4Game, "alice", "bob"),
+        game("g2", openingGame, "alice", "carol"),
+      ];
+
+      // The player who earned it and a player who did not are both back at the
+      // same small part of the way towards the next season start.
+      for (const player of ["alice", "dave"]) {
+        const progress = progressionFor(events, player);
+        expect(progress.target).toBe(q2Start - q1.start);
+        expect(progress.current).toBe(now - q1.start);
+        expect(percentageOf(progress)).toBeLessThan(5);
+      }
+    });
+
+    it("keeps counting through the grace period between seasons", () => {
+      const now = new Date(2024, 2, 25, 12).getTime(); // 25 March 2024, after the Q1 season ended
+      jest.useFakeTimers();
+      jest.setSystemTime(now);
+      expect(now).toBeGreaterThan(q1.end);
+      expect(now).toBeLessThan(q2Start);
+
+      const events: EventType[] = [...baseEvents, game("g1", q1Game1, "alice", "bob")];
+
+      // The countdown still measures from the Q1 season start, so the bar is
+      // close to full but not yet at 100%.
+      const progress = progressionFor(events, "carol");
+      expect(progress.target).toBe(q2Start - q1.start);
+      expect(progress.current).toBe(now - q1.start);
+      expect(percentageOf(progress)).toBeGreaterThan(90);
+      expect(percentageOf(progress)).toBeLessThan(100);
+    });
+
+    it("does not hold at 100% in the grace period after a season with no games", () => {
+      const now = new Date(2024, 2, 25, 12).getTime();
+      jest.useFakeTimers();
+      jest.setSystemTime(now);
+
+      // The Q1 season is over and nobody opened it, so its opener is gone.
+      const events: EventType[] = [...baseEvents, game("g1", q4Game, "alice", "bob")];
+
+      const progress = progressionFor(events, "carol");
+      expect(progress.current).toBe(now - q1.start);
+      expect(progress.current).toBeLessThan(progress.target);
+    });
   });
 });

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -1,6 +1,7 @@
 import { Elo } from "./elo";
 import { EventTypeEnum } from "./event-store/event-types";
 import { Game } from "./event-store/projectors/games-projector";
+import { determineNextSeason, determineSeason } from "./seasons/seasons";
 import { TennisTable } from "./tennis-table";
 
 // Shortest streak that can establish the very first Longest Win / Lose Streak
@@ -2558,7 +2559,8 @@ export class Achievements {
       "tournament-winner": { earned: 0 },
       "group-stage-star": { earned: 0 },
       "season-winner": { current: 0, target: 1, earned: 0 },
-      "season-opener": { earned: 0 },
+      // League-wide countdown to the next season start, filled in below.
+      "season-opener": { current: 0, target: 0, earned: 0 },
       "milestone-game": { current: 0, target: MILESTONE_GAME_INTERVAL, earned: 0 },
     };
 
@@ -3043,6 +3045,25 @@ export class Achievements {
       }
     }
 
+    // Season Opener progression is league-wide (everyone shares the same
+    // values) and counts down to the next season start, because that is when
+    // the next opener becomes available. Target is the span from the start of
+    // the current season — in the grace period between seasons that is the
+    // season which just ended — to the start of the next season. Current is
+    // the part of that span which has passed, so the bar shows how close the
+    // next season start is. While a season is open and still has no games the
+    // opener is there to take, so the bar holds at 100% until the first game
+    // earns it and the countdown to the next season start begins again.
+    const currentSeason = determineSeason(now);
+    const nextSeasonStart = determineNextSeason(now).start;
+    const seasonOpenerTarget = nextSeasonStart - currentSeason.start;
+    const inGracePeriod = now >= currentSeason.end;
+    const currentSeasonHasGames = seasons.some((season) => season.start === currentSeason.start);
+    progression["season-opener"].target = seasonOpenerTarget;
+    progression["season-opener"].current =
+      !inGracePeriod && !currentSeasonHasGames ? seasonOpenerTarget : now - currentSeason.start;
+    progression["season-opener"].nextSeasonStart = nextSeasonStart;
+
     // David progression: highest Elo gained from a win where both
     // players were ranked at the time of the match. Players who never
     // crossed the ranked threshold will naturally have no entries in
@@ -3329,6 +3350,16 @@ type WelcomeCommitteeProgression = ProgressionWithTarget & {
   newPlayers?: Set<string>; // List of new players this person was first opponent for
 };
 
+// Season Opener is league-wide: every player waits for the same next season
+// to start, so the progress is the same for everyone. Current and target are
+// milliseconds — how much of the span between the current season start and the
+// next season start has passed, and the whole span.
+type SeasonOpenerProgression = ProgressionWithTarget & {
+  // The moment the next season starts, which is when the next opener is there
+  // to take.
+  nextSeasonStart?: number;
+};
+
 type MissingPlayersProgression = ProgressionWithTarget & {
   // Currently ranked players the player has not yet beaten (Full House) /
   // not yet lost to (Humbled) — i.e. what's left to complete the set.
@@ -3447,7 +3478,7 @@ export type AchievementProgression = {
   "tournament-participated": BaseProgression;
   "tournament-winner": BaseProgression;
   "season-winner": ProgressionWithTarget;
-  "season-opener": BaseProgression;
+  "season-opener": SeasonOpenerProgression;
   "milestone-game": ProgressionWithTarget;
   "nice-game": BaseProgression;
   "less-is-more": BaseProgression;

--- a/frontend/src/pages/achievements/progress-list.tsx
+++ b/frontend/src/pages/achievements/progress-list.tsx
@@ -17,7 +17,10 @@ export const ProgressList: React.FC<ProgressListProps> = ({ selectedType }) => {
   // Time-based achievements store current/target as raw milliseconds, which
   // would render as enormous numbers. Show them as whole days instead.
   const isTimePeriod =
-    selectedType.startsWith("active-") || selectedType.startsWith("back-after-") || selectedType === "anniversary";
+    selectedType.startsWith("active-") ||
+    selectedType.startsWith("back-after-") ||
+    selectedType === "anniversary" ||
+    selectedType === "season-opener";
 
   // Calculate progress for all players when a specific type is selected.
   // Retired players are included — their progress history is as real as

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -758,7 +758,10 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
         const percentage = hasTarget && hasCurrent ? achievementProgressPercentage(type, data.current, data.target) : 0;
         const hasEarned = data.earned > 0;
         const isTimePeriod =
-          type.startsWith("active-") || type.startsWith("back-after-") || type === "anniversary";
+          type.startsWith("active-") ||
+          type.startsWith("back-after-") ||
+          type === "anniversary" ||
+          type === "season-opener";
 
         return (
           <div
@@ -825,6 +828,17 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                                   milestone game)
                                 </span>
                               )}
+                            {type === "season-opener" &&
+                              typeof data.target === "number" &&
+                              typeof data.current === "number" && (
+                                <span className="text-xs text-secondary-text/70 font-normal ml-2">
+                                  (League-wide —{" "}
+                                  {data.current >= data.target
+                                    ? "the season is open, and the first game of it earns this"
+                                    : `${formatTimePeriod(data.target - data.current)} until the next season starts`}
+                                  )
+                                </span>
+                              )}
                           </span>
                         </div>
                       </div>
@@ -848,6 +862,14 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                       {type === "anniversary" && "firstGameAt" in data && !!data.firstGameAt && (
                         <div className="mt-2 text-xs text-secondary-text/70">
                           Anniversary date: {dateString(data.firstGameAt)}
+                        </div>
+                      )}
+
+                      {/* Show when the next season starts — the moment the
+                          next Season Opener is there to take. */}
+                      {type === "season-opener" && "nextSeasonStart" in data && !!data.nextSeasonStart && (
+                        <div className="mt-2 text-xs text-secondary-text/70">
+                          Next season starts: {dateString(data.nextSeasonStart)}
                         </div>
                       )}
 


### PR DESCRIPTION
Season Opener had no progress bar: it was earned-only, so the Progress
tab showed nothing about when the next one could be taken.

It is now a league-wide countdown, identical for every player. Target is
the span from the start of the current season to the start of the next
one — during the grace period between seasons the current season is the
one that just ended — and current is the part of that span which has
passed. While a season is open and still has no games the opener is
there to take, so the bar holds at 100% until the first game earns it
and the countdown starts over.

Values are milliseconds, so both progress views render them as whole
days, and the player view names the date the next season starts.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019HEFZM1NeWGVv6Nu3v2xCv