### PR TITLE
Reorganize navigation: add Compare and Other hub pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,9 +127,8 @@ fast and accurate comprehension by a human reader. Follow the STE writing rules:
   verb works.
 - Keep the emoji in an achievement name, and keep numbers as digits.
 
-The page is at `/changelog`. Until the navigation structure is reworked it is
-only in the nav menu for logged-in admins - everyone else reaches it by direct
-url.
+The page is at `/changelog`. Everyone reaches it from the "Other" item in the
+nav menu.
 
 ## Context Files
 - Root Instructions: `./GEMINI.md`

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -53,6 +53,8 @@ import { LiveGameAdminPage } from "./pages/live-game/live-game-admin-page";
 import { LiveGameOverlay } from "./pages/live-game/live-game-overlay";
 import { ChangelogPage } from "./pages/changelog/changelog-page";
 import { ChangelogPostPage } from "./pages/changelog/changelog-post-page";
+import { ComparePage } from "./pages/compare/compare-page";
+import { OtherPage } from "./pages/other/other-page";
 import { NotFoundPage } from "./pages/not-found-page";
 
 const RequireAuth: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -86,6 +88,7 @@ function App() {
                         <Route path="/tennis-table" element={<Navigate to="/leader-board" />} />
                         <Route path="/leader-board" element={<LeaderBoard />} />
                         <Route path="/player/:name" element={<PlayerPage />} />
+                        <Route path="/compare" element={<ComparePage />} />
                         <Route path="/1v1" element={<PvPPage />} />
                         <Route path="/compare-players" element={<ComparePlayersPage />} />
                         <Route path="/player-network" element={<PlayerNetwork />} />
@@ -136,6 +139,7 @@ function App() {
                         <Route path="/add-game-track" element={<TrackGamePage />} />
                         <Route path="/game/edit/score" element={<EditGameSore />} />
                         <Route path="/camera" element={<CameraPage />} />
+                        <Route path="/other" element={<OtherPage />} />
                         <Route path="/settings" element={<SettingsPage />} />
                         <Route path="/log-in" element={<LoginPage />} />
                         <Route path="/sign-up" element={<SignupPage />} />

--- a/frontend/src/pages/compare/compare-page.tsx
+++ b/frontend/src/pages/compare/compare-page.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+export const ComparePage: React.FC = () => {
+  const compareOptions: { name: string; url: string }[] = [
+    { name: "Compare 1v1 👥🥊", url: "/1v1" },
+    { name: "Compare all 📈", url: "/compare-players" },
+  ];
+
+  return (
+    <div className="flex flex-col items-center bg-primary-background rounded-lg p-4 w-fit m-auto">
+      <h1 className="mb-6 text-2xl text-primary-text">Compare</h1>
+      <div className="flex flex-col gap-4 w-96">
+        {compareOptions.map(({ name, url }) => (
+          <Link
+            key={url}
+            className="bg-secondary-background hover:bg-secondary-background/50 rounded-md py-4 text-center text-lg text-secondary-text"
+            to={url}
+          >
+            {name}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/other/other-page.tsx
+++ b/frontend/src/pages/other/other-page.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+export const OtherPage: React.FC = () => {
+  const otherOptions: { name: string; url: string }[] = [
+    { name: "Settings 🔧", url: "/settings" },
+    { name: "Changelog 📜", url: "/changelog" },
+  ];
+
+  return (
+    <div className="flex flex-col items-center bg-primary-background rounded-lg p-4 w-fit m-auto">
+      <h1 className="mb-6 text-2xl text-primary-text">Other</h1>
+      <div className="flex flex-col gap-4 w-96">
+        {otherOptions.map(({ name, url }) => (
+          <Link
+            key={url}
+            className="bg-secondary-background hover:bg-secondary-background/50 rounded-md py-4 text-center text-lg text-secondary-text"
+            to={url}
+          >
+            {name}
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/wrappers/nav-menu.tsx
+++ b/frontend/src/wrappers/nav-menu.tsx
@@ -27,19 +27,15 @@ export const NavMenu: React.FC = () => {
       { name: "🍁 Seasons", to: "/season/list" },
       { name: "🏓  Add game", to: "/add-game" },
       { name: "👤  New player", to: "/add-player" },
-      { name: "👥🥊 Compare 1v1", to: "/1v1" },
-      { name: "📈 Compare all", to: "/compare-players" },
+      { name: "👥🥊 Compare", to: "/compare" },
 
       { name: "🏆 Tournaments", to: "/tournament/list" },
       { name: "🎖️ Achievements", to: "/achievements" },
       { name: "🏛️ Hall of Fame", to: "/hall-of-fame" },
       { name: "🤖 Simulations", to: "/simulations" },
-      { name: "🔧 Settings", to: "/settings" },
+      { name: "🗂️ Other", to: "/other" },
     ];
     if (session.isAuthenticated && session.sessionData?.role === "admin") {
-      // Changelog (/changelog) is deliberately admin-only until the navigation
-      // structure is reworked. Reachable by direct url for everyone else.
-      items.push({ name: "📜 Changelog", to: "/changelog" });
       items.push({ name: "📺 Live Game", to: "/live-game" });
       items.push({ name: "🔐 Admin Page", to: "/admin" });
     }


### PR DESCRIPTION
## Summary
Restructures the main navigation menu by introducing two new hub pages that group related features, reducing clutter in the nav menu and improving information architecture.

## Changes
- **New Compare hub page** (`/compare`): Groups "Compare 1v1" and "Compare all" options, replacing two separate nav items with a single entry
- **New Other hub page** (`/other`): Groups "Settings" and "Changelog", making Changelog accessible to all users (previously admin-only in nav)
- **Updated nav menu**: Replaces 4 items with 2 hub links, simplifying the main navigation
- **Updated documentation**: CLAUDE.md now reflects that Changelog is accessible to everyone via the Other menu

## Implementation Details
- Both hub pages follow the same component pattern: a centered card with a title and a list of navigation links
- Uses consistent styling with Tailwind classes matching the existing design system
- Routes added to App.tsx for `/compare` and `/other` paths
- Changelog is no longer restricted to admin-only nav visibility, though admin-only features remain in the admin section

https://claude.ai/code/session_01DY36CwrwDkHt7w6UJJjv9G