### PR TITLE
Add best-ever values to achievement progression tracking

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -54,9 +54,10 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
       ),
       list(
         "Counts: Unstoppable 🔥, Punching Bag 🥊, Never Give Up 🫠, Domination Streak 🎯, Humiliation Streak 👹, Hat Trick 🎩, Perfect Day ☀️, Perfect Week 🗓️, Best Friends 💙 and Group Play Star ⭐ show your best count.",
-        "Ranks: On the Podium 🥉 and Touched the Throne 👑 show the best rank you have held. Kingslayer ⚔️ shows the best rank of a player you have beaten.",
+        "Best Friends, Domination Streak and Humiliation Streak also name the opponent. Group Play Star shows the size of the group play, for example 3 of 4.",
+        "Ranks: On the Podium 🥉 and Touched the Throne 👑 show the best rank you have held. Kingslayer ⚔️ shows the best rank of a player you have beaten, and names the player. Season's Champion 🍁 shows your best rank in a finished season.",
         "Days: Regular 📅, Dedicated 🌟 and Veteran 🎖️ show your longest activity streak. Welcome Back 👋, Long Time No See 🙈 and A Cinderella Story 👸 show your longest absence.",
-        "Score: Climber 🧗 shows the largest climb you have made above your low point.",
+        "Score: Climber 🧗 shows the largest climb you have made above your low point, with the start and end Score.",
       ),
       text(
         "The streak records and the Hero records showed a personal best before. They now use the same Best display.",

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -42,6 +42,29 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "achievement-progress-best-values",
+    title: "Best values on achievement progress",
+    date: "2026-08-05",
+    tags: ["feature-update"],
+    summary:
+      "The Progress tab on the player page shows a Best value for achievements with progress that resets. The value is your closest attempt.",
+    body: [
+      text(
+        "Many achievements measure progress that resets. A loss ends a win streak, and a new day resets Perfect Day. The progress bar then shows 0 again. The new Best value keeps your closest attempt, next to the current progress.",
+      ),
+      list(
+        "Counts: Unstoppable 🔥, Punching Bag 🥊, Never Give Up 🫠, Domination Streak 🎯, Humiliation Streak 👹, Hat Trick 🎩, Perfect Day ☀️, Perfect Week 🗓️, Best Friends 💙 and Group Play Star ⭐ show your best count.",
+        "Ranks: On the Podium 🥉 and Touched the Throne 👑 show the best rank you have held. Kingslayer ⚔️ shows the best rank of a player you have beaten.",
+        "Days: Regular 📅, Dedicated 🌟 and Veteran 🎖️ show your longest activity streak. Welcome Back 👋, Long Time No See 🙈 and A Cinderella Story 👸 show your longest absence.",
+        "Score: Climber 🧗 shows the largest climb you have made above your low point.",
+      ),
+      text(
+        "The streak records and the Hero records showed a personal best before. They now use the same Best display.",
+      ),
+      text("Group Stage Star has the new name Group Play Star ⭐. It matches the group play name in tournaments."),
+    ],
+  },
+  {
     slug: "shootout-season-opener-and-record-david-goliath",
     title: "3 new achievements, and David & Goliath become league records",
     date: "2026-08-04",
@@ -383,7 +406,7 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
     date: "2026-05-17",
     tags: ["feature-update"],
     summary:
-      "David, Goliath, Marathon Set, Streak Ender, Group Stage Star, and 5 achievements from Elo and leaderboard rank.",
+      "David, Goliath, Marathon Set, Streak Ender, Group Play Star, and 5 achievements from Elo and leaderboard rank.",
     body: [
       text(
         "Some achievements are for a result against the odds. David is for a win that gains a large amount of Score, which happens when you beat a much higher-rated player. Goliath is for the loss in the same game. Streak Ender is for the end of a run of wins by another player.",

--- a/frontend/src/client/client-db/__tests__/achievements/group-stage-star.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/group-stage-star.test.ts
@@ -301,7 +301,15 @@ describe("Group Stage Star Achievement", () => {
     const tt = new TennisTable({ events });
     tt.achievements.calculateAchievements();
 
-    expect(tt.achievements.getPlayerProgression("alice")["group-stage-star"]).toStrictEqual({ earned: 1, best: 3 });
-    expect(tt.achievements.getPlayerProgression("bob")["group-stage-star"]).toStrictEqual({ earned: 0, best: 2 });
+    expect(tt.achievements.getPlayerProgression("alice")["group-stage-star"]).toStrictEqual({
+      earned: 1,
+      best: 3,
+      bestOutOf: 3,
+    });
+    expect(tt.achievements.getPlayerProgression("bob")["group-stage-star"]).toStrictEqual({
+      earned: 0,
+      best: 2,
+      bestOutOf: 3,
+    });
   });
 });

--- a/frontend/src/client/client-db/__tests__/achievements/group-stage-star.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/group-stage-star.test.ts
@@ -63,6 +63,12 @@ describe("Group Stage Star Achievement", () => {
     expect(tt.achievements.getAchievements("bob").filter((a) => a.type === "group-stage-star")).toHaveLength(0);
     expect(tt.achievements.getAchievements("carol").filter((a) => a.type === "group-stage-star")).toHaveLength(0);
     expect(tt.achievements.getAchievements("dave").filter((a) => a.type === "group-stage-star")).toHaveLength(0);
+
+    // Progression best: the most wins in one group stage. Alice went 3-0,
+    // Bob 2-1 — Bob's best shows how close he came without earning it.
+    expect(tt.achievements.getPlayerProgression("alice")["group-stage-star"].best).toBe(3);
+    expect(tt.achievements.getPlayerProgression("bob")["group-stage-star"].best).toBe(2);
+    expect(tt.achievements.getPlayerProgression("bob")["group-stage-star"].earned).toBe(0);
   });
 
   it("does NOT award while the group stage is still in progress (some games pending)", () => {
@@ -295,7 +301,7 @@ describe("Group Stage Star Achievement", () => {
     const tt = new TennisTable({ events });
     tt.achievements.calculateAchievements();
 
-    expect(tt.achievements.getPlayerProgression("alice")["group-stage-star"]).toStrictEqual({ earned: 1 });
-    expect(tt.achievements.getPlayerProgression("bob")["group-stage-star"]).toStrictEqual({ earned: 0 });
+    expect(tt.achievements.getPlayerProgression("alice")["group-stage-star"]).toStrictEqual({ earned: 1, best: 3 });
+    expect(tt.achievements.getPlayerProgression("bob")["group-stage-star"]).toStrictEqual({ earned: 0, best: 2 });
   });
 });

--- a/frontend/src/client/client-db/__tests__/achievements/hat-trick.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/hat-trick.test.ts
@@ -506,6 +506,42 @@ describe("Hat-trick Achievement Tests", () => {
       expect(progression["hat-trick"].current).toBe(2);
       expect(progression["hat-trick"].target).toBe(3);
       expect(progression["hat-trick"].earned).toBe(0);
+      expect(progression["hat-trick"].best).toBe(2);
+    });
+
+    it("should track the best-ever number of wins inside a single 90-minute window", () => {
+      const baseTime = Date.now();
+      const events: EventType[] = [
+        ...baseEvents,
+        // Two wins 50 minutes apart, then a third 100 minutes after the
+        // first — no 90-minute window ever contains all three.
+        {
+          time: baseTime,
+          stream: "game-1",
+          type: EventTypeEnum.GAME_CREATED,
+          data: { playedAt: baseTime, winner: "player-1", loser: "player-2" },
+        },
+        {
+          time: baseTime + 50 * 60 * 1000,
+          stream: "game-2",
+          type: EventTypeEnum.GAME_CREATED,
+          data: { playedAt: baseTime + 50 * 60 * 1000, winner: "player-1", loser: "player-3" },
+        },
+        {
+          time: baseTime + 100 * 60 * 1000,
+          stream: "game-3",
+          type: EventTypeEnum.GAME_CREATED,
+          data: { playedAt: baseTime + 100 * 60 * 1000, winner: "player-1", loser: "player-2" },
+        },
+      ];
+
+      const tennisTable = new TennisTable({ events });
+      tennisTable.achievements.calculateAchievements();
+
+      const progression = tennisTable.achievements.getPlayerProgression("player-1");
+
+      expect(progression["hat-trick"].best).toBe(2);
+      expect(progression["hat-trick"].earned).toBe(0);
     });
 
     it("should show earned count after completing hat-trick", () => {

--- a/frontend/src/client/client-db/__tests__/achievements/hero-of-the-day.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/hero-of-the-day.test.ts
@@ -158,13 +158,13 @@ describe("Hero of the Day achievement", () => {
 
     const alice = tt.achievements.getPlayerProgression("alice")["hero-of-the-day"];
     expect(alice.current).toBe(0); // no games today
-    expect(alice.personalBest).toBe(13);
+    expect(alice.best).toBe(13);
     expect(alice.target).toBe(14); // one beyond the record of 13
     expect(alice.recordHolder).toBe("alice");
     expect(alice.earned).toBe(2);
 
     const bob = tt.achievements.getPlayerProgression("bob")["hero-of-the-day"];
-    expect(bob.personalBest).toBe(13);
+    expect(bob.best).toBe(13);
     expect(bob.target).toBe(14);
     expect(bob.recordHolder).toBe("alice");
     expect(bob.earned).toBe(0);
@@ -176,7 +176,7 @@ describe("Hero of the Day achievement", () => {
     const progression = tt.achievements.getPlayerProgression("alice")["hero-of-the-day"];
     expect(progression.target).toBeUndefined();
     expect(progression.recordHolder).toBeUndefined();
-    expect(progression.personalBest).toBe(GAMES_IN_PERIOD_RECORD_FLOOR - 1);
+    expect(progression.best).toBe(GAMES_IN_PERIOD_RECORD_FLOOR - 1);
     expect(progression.earned).toBe(0);
   });
 });

--- a/frontend/src/client/client-db/__tests__/achievements/hero-of-the-week-and-month.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/hero-of-the-week-and-month.test.ts
@@ -138,13 +138,13 @@ describe("Hero of the Week achievement", () => {
 
     const alice = tt.achievements.getPlayerProgression("alice")["hero-of-the-week"];
     expect(alice.current).toBe(0); // no games this week
-    expect(alice.personalBest).toBe(13);
+    expect(alice.best).toBe(13);
     expect(alice.target).toBe(14); // one beyond the record of 13
     expect(alice.recordHolder).toBe("alice");
     expect(alice.earned).toBe(2);
 
     const bob = tt.achievements.getPlayerProgression("bob")["hero-of-the-week"];
-    expect(bob.personalBest).toBe(13);
+    expect(bob.best).toBe(13);
     expect(bob.target).toBe(14);
     expect(bob.recordHolder).toBe("alice");
     expect(bob.earned).toBe(0);
@@ -156,7 +156,7 @@ describe("Hero of the Week achievement", () => {
     const progression = tt.achievements.getPlayerProgression("alice")["hero-of-the-week"];
     expect(progression.target).toBeUndefined();
     expect(progression.recordHolder).toBeUndefined();
-    expect(progression.personalBest).toBe(GAMES_IN_PERIOD_RECORD_FLOOR - 1);
+    expect(progression.best).toBe(GAMES_IN_PERIOD_RECORD_FLOOR - 1);
     expect(progression.earned).toBe(0);
   });
 });
@@ -239,13 +239,13 @@ describe("Hero of the Month achievement", () => {
 
     const alice = tt.achievements.getPlayerProgression("alice")["hero-of-the-month"];
     expect(alice.current).toBe(0); // no games this month
-    expect(alice.personalBest).toBe(25);
+    expect(alice.best).toBe(25);
     expect(alice.target).toBe(26); // one beyond the record of 25
     expect(alice.recordHolder).toBe("alice");
     expect(alice.earned).toBe(2);
 
     const bob = tt.achievements.getPlayerProgression("bob")["hero-of-the-month"];
-    expect(bob.personalBest).toBe(25);
+    expect(bob.best).toBe(25);
     expect(bob.target).toBe(26);
     expect(bob.recordHolder).toBe("alice");
     expect(bob.earned).toBe(0);
@@ -257,7 +257,7 @@ describe("Hero of the Month achievement", () => {
     const progression = tt.achievements.getPlayerProgression("alice")["hero-of-the-month"];
     expect(progression.target).toBeUndefined();
     expect(progression.recordHolder).toBeUndefined();
-    expect(progression.personalBest).toBe(GAMES_IN_PERIOD_RECORD_FLOOR - 1);
+    expect(progression.best).toBe(GAMES_IN_PERIOD_RECORD_FLOOR - 1);
     expect(progression.earned).toBe(0);
   });
 });

--- a/frontend/src/client/client-db/__tests__/achievements/kingslayer.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/kingslayer.test.ts
@@ -143,6 +143,7 @@ describe("Kingslayer Achievement", () => {
     tt.achievements.calculateAchievements();
 
     expect(tt.achievements.getPlayerProgression("c")["kingslayer"].best).toBe(2);
+    expect(tt.achievements.getPlayerProgression("c")["kingslayer"].bestOpponent).toBe("b");
     expect(tt.achievements.getPlayerProgression("c")["kingslayer"].earned).toBe(0);
     // E never won a game — no beaten rank to report.
     expect(tt.achievements.getPlayerProgression("e")["kingslayer"].best).toBeUndefined();

--- a/frontend/src/client/client-db/__tests__/achievements/kingslayer.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/kingslayer.test.ts
@@ -132,4 +132,19 @@ describe("Kingslayer Achievement", () => {
     expect(kingslayers).toHaveLength(1);
     expect(kingslayers[0].data?.gameId).toBe("ks-1");
   });
+
+  it("reports the best-ranked beaten opponent in the progression", () => {
+    // After the setup C's best win is over D (rank 4). C then beats B
+    // (rank 2 going into the match) — the best beaten rank becomes #2,
+    // one short of a kingslay.
+    const events = [...fivePlayerSetup(), game("upset", 1000, "c", "b")];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getPlayerProgression("c")["kingslayer"].best).toBe(2);
+    expect(tt.achievements.getPlayerProgression("c")["kingslayer"].earned).toBe(0);
+    // E never won a game — no beaten rank to report.
+    expect(tt.achievements.getPlayerProgression("e")["kingslayer"].best).toBeUndefined();
+  });
 });

--- a/frontend/src/client/client-db/__tests__/achievements/longest-streak.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/longest-streak.test.ts
@@ -244,7 +244,7 @@ describe("Longest Win Streak / Longest Lose Streak achievements", () => {
 
     const aliceProgression = tt.achievements.getPlayerProgression("alice")["longest-win-streak"];
     expect(aliceProgression.current).toBe(2);
-    expect(aliceProgression.personalBest).toBe(5);
+    expect(aliceProgression.best).toBe(5);
     // The record is 5, so a streak of 6 is what takes it.
     expect(aliceProgression.target).toBe(6);
     expect(aliceProgression.recordHolder).toBe("alice");
@@ -252,7 +252,7 @@ describe("Longest Win Streak / Longest Lose Streak achievements", () => {
 
     const bobProgression = tt.achievements.getPlayerProgression("bob")["longest-win-streak"];
     expect(bobProgression.current).toBe(0);
-    expect(bobProgression.personalBest).toBe(1);
+    expect(bobProgression.best).toBe(1);
     expect(bobProgression.target).toBe(6);
     expect(bobProgression.recordHolder).toBe("alice");
     expect(bobProgression.earned).toBe(0);
@@ -268,9 +268,9 @@ describe("Longest Win Streak / Longest Lose Streak achievements", () => {
     expect(progression["longest-win-streak"].target).toBeUndefined();
     expect(progression["longest-win-streak"].recordHolder).toBeUndefined();
     expect(progression["longest-win-streak"].current).toBe(2);
-    expect(progression["longest-win-streak"].personalBest).toBe(2);
+    expect(progression["longest-win-streak"].best).toBe(2);
     expect(progression["longest-lose-streak"].target).toBeUndefined();
     expect(progression["longest-lose-streak"].current).toBe(0);
-    expect(progression["longest-lose-streak"].personalBest).toBe(0);
+    expect(progression["longest-lose-streak"].best).toBe(0);
   });
 });

--- a/frontend/src/client/client-db/__tests__/achievements/on-the-podium.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/on-the-podium.test.ts
@@ -50,6 +50,45 @@ describe("On the Podium Achievement", () => {
     expect(tt.achievements.getAchievements("e").filter((x) => x.type === "on-the-podium")).toHaveLength(0);
   });
 
+  it("reports the best rank ever held in the podium and throne progression", () => {
+    const tt = new TennisTable({ events: fivePlayerSetup() });
+    tt.achievements.calculateAchievements();
+
+    // A holds rank #1 and E rank #5 throughout the ≥5-ranked stretch.
+    expect(tt.achievements.getPlayerProgression("a")["on-the-podium"].best).toBe(1);
+    expect(tt.achievements.getPlayerProgression("a")["touched-the-throne"].best).toBe(1);
+    expect(tt.achievements.getPlayerProgression("e")["on-the-podium"].best).toBe(5);
+    expect(tt.achievements.getPlayerProgression("e")["touched-the-throne"].best).toBe(5);
+  });
+
+  it("does NOT record a best rank while fewer than 5 players are ranked", () => {
+    // 4-player double round-robin: everyone is ranked but the cohort never
+    // reaches 5, matching the gate on the award itself.
+    const events: EventType[] = [
+      { time: 1, stream: "a", type: EventTypeEnum.PLAYER_CREATED, data: { name: "A" } },
+      { time: 2, stream: "b", type: EventTypeEnum.PLAYER_CREATED, data: { name: "B" } },
+      { time: 3, stream: "c", type: EventTypeEnum.PLAYER_CREATED, data: { name: "C" } },
+      { time: 4, stream: "d", type: EventTypeEnum.PLAYER_CREATED, data: { name: "D" } },
+    ];
+    const pairs: [string, string][] = [
+      ["a", "b"], ["a", "c"], ["a", "d"],
+      ["b", "c"], ["b", "d"],
+      ["c", "d"],
+    ];
+    let t = 100;
+    for (let round = 0; round < 2; round++) {
+      for (const [winner, loser] of pairs) {
+        events.push(game(`g-${round}-${winner}-${loser}`, t++, winner, loser));
+      }
+    }
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getPlayerProgression("a")["on-the-podium"].best).toBeUndefined();
+    expect(tt.achievements.getPlayerProgression("a")["touched-the-throne"].best).toBeUndefined();
+  });
+
   it("does NOT award when fewer than 5 players are ranked", () => {
     // 4-player double round-robin (12 games). All 4 ranked but
     // rankedCount = 4 < 5, so no badge is awarded.

--- a/frontend/src/client/client-db/__tests__/achievements/perfect-day.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/perfect-day.test.ts
@@ -256,5 +256,32 @@ describe("Perfect Day Achievement Tests", () => {
       const progression = tennisTable.achievements.getPlayerProgression("player-1");
       expect(progression["perfect-day"].current).toBe(0);
     });
+
+    it("keeps the best undefeated-day attempt after the day has passed", () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2024, 0, 20, 8));
+
+      // 3 undefeated wins on the 15th — the closest attempt. 4 wins on the
+      // 16th, but a loss the same day nullifies that day entirely.
+      const lossAt = new Date(2024, 0, 16, 17).getTime();
+      const events: EventType[] = [
+        ...baseEvents,
+        ...winsOnDay(2024, 0, 15, "player-1", ["player-2", "player-3", "player-2"], "g"),
+        ...winsOnDay(2024, 0, 16, "player-1", ["player-2", "player-3", "player-2", "player-3"], "h"),
+        {
+          time: lossAt,
+          stream: "loss",
+          type: EventTypeEnum.GAME_CREATED,
+          data: { playedAt: lossAt, winner: "player-2", loser: "player-1" },
+        },
+      ];
+
+      const tennisTable = new TennisTable({ events });
+      tennisTable.achievements.calculateAchievements();
+
+      const progression = tennisTable.achievements.getPlayerProgression("player-1");
+      expect(progression["perfect-day"].current).toBe(0);
+      expect(progression["perfect-day"].best).toBe(3);
+    });
   });
 });

--- a/frontend/src/client/client-db/__tests__/achievements/perfect-week.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/perfect-week.test.ts
@@ -341,5 +341,27 @@ describe("Perfect Week Achievement Tests", () => {
       const progression = tennisTable.achievements.getPlayerProgression("player-1");
       expect(progression["perfect-week"].current).toBe(0);
     });
+
+    it("keeps the best run from past weeks as the best value", () => {
+      // "now" is the Monday after a Mon–Thu near-miss (4 of the 5 days of
+      // the Mon–Fri run). Current resets, the best keeps the attempt.
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2024, 0, 22, 8));
+
+      const events: EventType[] = [
+        ...baseEvents,
+        win(2024, 0, 15, "player-1", "player-2", "mon"),
+        win(2024, 0, 16, "player-1", "player-2", "tue"),
+        win(2024, 0, 17, "player-1", "player-2", "wed"),
+        win(2024, 0, 18, "player-1", "player-2", "thu"),
+      ];
+
+      const tennisTable = new TennisTable({ events });
+      tennisTable.achievements.calculateAchievements();
+
+      const progression = tennisTable.achievements.getPlayerProgression("player-1");
+      expect(progression["perfect-week"].current).toBe(0);
+      expect(progression["perfect-week"].best).toBe(4);
+    });
   });
 });

--- a/frontend/src/client/client-db/__tests__/achievements/season-winner.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/season-winner.test.ts
@@ -1,0 +1,29 @@
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { TennisTable } from "../../tennis-table";
+
+describe("Season's Champion progression", () => {
+  it("reports the best final rank from finished seasons as the best value", () => {
+    // A game inside the Q1 2024 season (starts the first Monday of January
+    // 2024, ends in late March) — long finished, so its final ranks count.
+    const playedAt = new Date(2024, 1, 15, 12).getTime();
+    const events: EventType[] = [
+      { type: EventTypeEnum.PLAYER_CREATED, stream: "alice", time: 1, data: { name: "Alice" } },
+      { type: EventTypeEnum.PLAYER_CREATED, stream: "bob", time: 2, data: { name: "Bob" } },
+      { type: EventTypeEnum.PLAYER_CREATED, stream: "carol", time: 3, data: { name: "Carol" } },
+      {
+        type: EventTypeEnum.GAME_CREATED,
+        stream: "g1",
+        time: playedAt,
+        data: { winner: "alice", loser: "bob", playedAt },
+      },
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getPlayerProgression("alice")["season-winner"].best).toBe(1);
+    expect(tt.achievements.getPlayerProgression("bob")["season-winner"].best).toBe(2);
+    // Carol never played in a season — no best rank to report.
+    expect(tt.achievements.getPlayerProgression("carol")["season-winner"].best).toBeUndefined();
+  });
+});

--- a/frontend/src/client/client-db/__tests__/achievements/streak-all-10.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/streak-all-10.ts
@@ -61,7 +61,7 @@ describe("TennisTable", () => {
       expect(streakAchievements).toHaveLength(0);
 
       const progression = tennisTable.achievements.getPlayerProgression("alice");
-      expect(progression["streak-all-10"]).toStrictEqual({ current: 9, target: 10, earned: 0 });
+      expect(progression["streak-all-10"]).toStrictEqual({ current: 9, best: 9, target: 10, earned: 0 });
     });
 
     it("should earn achievement at exactly 10 consecutive wins", () => {
@@ -93,7 +93,7 @@ describe("TennisTable", () => {
       });
 
       const progression = tennisTable.achievements.getPlayerProgression("alice");
-      expect(progression["streak-all-10"]).toStrictEqual({ current: 10, target: 10, earned: 1 });
+      expect(progression["streak-all-10"]).toStrictEqual({ current: 10, best: 10, target: 10, earned: 1 });
     });
 
     it("should only earn achievement once even with 11 consecutive wins", () => {
@@ -137,7 +137,7 @@ describe("TennisTable", () => {
       });
 
       const progression = tennisTable.achievements.getPlayerProgression("alice");
-      expect(progression["streak-all-10"]).toStrictEqual({ current: 11, target: 10, earned: 1 });
+      expect(progression["streak-all-10"]).toStrictEqual({ current: 11, best: 11, target: 10, earned: 1 });
     });
 
     it("should reset progress after a loss", () => {
@@ -182,7 +182,7 @@ describe("TennisTable", () => {
       expect(streakAchievements).toHaveLength(0);
 
       const progression = tennisTable.achievements.getPlayerProgression("alice");
-      expect(progression["streak-all-10"]).toStrictEqual({ current: 6, target: 10, earned: 0 });
+      expect(progression["streak-all-10"]).toStrictEqual({ current: 6, best: 6, target: 10, earned: 0 });
     });
 
     it("should earn achievement multiple times with losses in between", () => {
@@ -243,7 +243,7 @@ describe("TennisTable", () => {
       });
 
       const progression = tennisTable.achievements.getPlayerProgression("alice");
-      expect(progression["streak-all-10"]).toStrictEqual({ current: 10, target: 10, earned: 2 });
+      expect(progression["streak-all-10"]).toStrictEqual({ current: 10, best: 10, target: 10, earned: 2 });
     });
   });
 });

--- a/frontend/src/client/client-db/__tests__/achievements/streak-player-10.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/streak-player-10.ts
@@ -62,6 +62,7 @@ describe("TennisTable", () => {
       const progression = tennisTable.achievements.getPlayerProgression("alice");
       expect(progression["streak-player-10"]).toStrictEqual({
         current: 9,
+        best: 9,
         target: 10,
         earned: 0,
         perOpponent: new Map([["bob", 9]]),
@@ -99,6 +100,7 @@ describe("TennisTable", () => {
       const progression = tennisTable.achievements.getPlayerProgression("alice");
       expect(progression["streak-player-10"]).toStrictEqual({
         current: 0, // No other streaks below 10
+        best: 10,
         target: 10,
         earned: 1,
         perOpponent: new Map([["bob", 10]]),
@@ -136,6 +138,7 @@ describe("TennisTable", () => {
       const progression = tennisTable.achievements.getPlayerProgression("alice");
       expect(progression["streak-player-10"]).toStrictEqual({
         current: 0, // No other streaks below 10
+        best: 11,
         target: 10,
         earned: 1,
         perOpponent: new Map([["bob", 11]]),
@@ -193,6 +196,7 @@ describe("TennisTable", () => {
       const progression = tennisTable.achievements.getPlayerProgression("alice");
       expect(progression["streak-player-10"]).toStrictEqual({
         current: 5, // Charlie's streak of 5 becomes the current (highest below 10)
+        best: 10,
         target: 10,
         earned: 1,
         perOpponent: new Map([
@@ -252,6 +256,7 @@ describe("TennisTable", () => {
       const progression = tennisTable.achievements.getPlayerProgression("alice");
       expect(progression["streak-player-10"]).toStrictEqual({
         current: 6, // Bob's new streak of 6 is highest (Charlie has 5)
+        best: 6,
         target: 10,
         earned: 0,
         perOpponent: new Map([
@@ -311,6 +316,7 @@ describe("TennisTable", () => {
       const progression = tennisTable.achievements.getPlayerProgression("alice");
       expect(progression["streak-player-10"]).toStrictEqual({
         current: 0, // Both opponents at 10, no streaks below 10
+        best: 10,
         target: 10,
         earned: 2,
         perOpponent: new Map([

--- a/frontend/src/client/client-db/__tests__/achievements/streak-player-10.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/streak-player-10.ts
@@ -63,6 +63,7 @@ describe("TennisTable", () => {
       expect(progression["streak-player-10"]).toStrictEqual({
         current: 9,
         best: 9,
+        bestOpponent: "bob",
         target: 10,
         earned: 0,
         perOpponent: new Map([["bob", 9]]),
@@ -101,6 +102,7 @@ describe("TennisTable", () => {
       expect(progression["streak-player-10"]).toStrictEqual({
         current: 0, // No other streaks below 10
         best: 10,
+        bestOpponent: "bob",
         target: 10,
         earned: 1,
         perOpponent: new Map([["bob", 10]]),
@@ -139,6 +141,7 @@ describe("TennisTable", () => {
       expect(progression["streak-player-10"]).toStrictEqual({
         current: 0, // No other streaks below 10
         best: 11,
+        bestOpponent: "bob",
         target: 10,
         earned: 1,
         perOpponent: new Map([["bob", 11]]),
@@ -197,6 +200,7 @@ describe("TennisTable", () => {
       expect(progression["streak-player-10"]).toStrictEqual({
         current: 5, // Charlie's streak of 5 becomes the current (highest below 10)
         best: 10,
+        bestOpponent: "bob",
         target: 10,
         earned: 1,
         perOpponent: new Map([
@@ -257,6 +261,7 @@ describe("TennisTable", () => {
       expect(progression["streak-player-10"]).toStrictEqual({
         current: 6, // Bob's new streak of 6 is highest (Charlie has 5)
         best: 6,
+        bestOpponent: "bob",
         target: 10,
         earned: 0,
         perOpponent: new Map([
@@ -317,6 +322,7 @@ describe("TennisTable", () => {
       expect(progression["streak-player-10"]).toStrictEqual({
         current: 0, // Both opponents at 10, no streaks below 10
         best: 10,
+        bestOpponent: "bob",
         target: 10,
         earned: 2,
         perOpponent: new Map([

--- a/frontend/src/client/client-db/__tests__/achievements/streak-player-20.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/streak-player-20.ts
@@ -62,6 +62,7 @@ describe("TennisTable", () => {
       const progression = tennisTable.achievements.getPlayerProgression("alice");
       expect(progression["streak-player-20"]).toStrictEqual({
         current: 19,
+        best: 19,
         target: 20,
         earned: 0,
         perOpponent: new Map([["bob", 19]]),
@@ -99,6 +100,7 @@ describe("TennisTable", () => {
       const progression = tennisTable.achievements.getPlayerProgression("alice");
       expect(progression["streak-player-20"]).toStrictEqual({
         current: 0, // No other streaks below 20
+        best: 20,
         target: 20,
         earned: 1,
         perOpponent: new Map([["bob", 20]]),
@@ -136,6 +138,7 @@ describe("TennisTable", () => {
       const progression = tennisTable.achievements.getPlayerProgression("alice");
       expect(progression["streak-player-20"]).toStrictEqual({
         current: 0, // No other streaks below 20
+        best: 21,
         target: 20,
         earned: 1,
         perOpponent: new Map([["bob", 21]]),
@@ -193,6 +196,7 @@ describe("TennisTable", () => {
       const progression = tennisTable.achievements.getPlayerProgression("alice");
       expect(progression["streak-player-20"]).toStrictEqual({
         current: 10, // Charlie's streak of 10 becomes the current (highest below 20)
+        best: 20,
         target: 20,
         earned: 1,
         perOpponent: new Map([
@@ -252,6 +256,7 @@ describe("TennisTable", () => {
       const progression = tennisTable.achievements.getPlayerProgression("alice");
       expect(progression["streak-player-20"]).toStrictEqual({
         current: 12, // Bob's new streak of 12 is highest (Charlie has 10)
+        best: 12,
         target: 20,
         earned: 0,
         perOpponent: new Map([
@@ -311,6 +316,7 @@ describe("TennisTable", () => {
       const progression = tennisTable.achievements.getPlayerProgression("alice");
       expect(progression["streak-player-20"]).toStrictEqual({
         current: 0, // Both opponents at 20, no streaks below 20
+        best: 20,
         target: 20,
         earned: 2,
         perOpponent: new Map([

--- a/frontend/src/client/client-db/__tests__/achievements/streak-player-20.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/streak-player-20.ts
@@ -63,6 +63,7 @@ describe("TennisTable", () => {
       expect(progression["streak-player-20"]).toStrictEqual({
         current: 19,
         best: 19,
+        bestOpponent: "bob",
         target: 20,
         earned: 0,
         perOpponent: new Map([["bob", 19]]),
@@ -101,6 +102,7 @@ describe("TennisTable", () => {
       expect(progression["streak-player-20"]).toStrictEqual({
         current: 0, // No other streaks below 20
         best: 20,
+        bestOpponent: "bob",
         target: 20,
         earned: 1,
         perOpponent: new Map([["bob", 20]]),
@@ -139,6 +141,7 @@ describe("TennisTable", () => {
       expect(progression["streak-player-20"]).toStrictEqual({
         current: 0, // No other streaks below 20
         best: 21,
+        bestOpponent: "bob",
         target: 20,
         earned: 1,
         perOpponent: new Map([["bob", 21]]),
@@ -197,6 +200,7 @@ describe("TennisTable", () => {
       expect(progression["streak-player-20"]).toStrictEqual({
         current: 10, // Charlie's streak of 10 becomes the current (highest below 20)
         best: 20,
+        bestOpponent: "bob",
         target: 20,
         earned: 1,
         perOpponent: new Map([
@@ -257,6 +261,7 @@ describe("TennisTable", () => {
       expect(progression["streak-player-20"]).toStrictEqual({
         current: 12, // Bob's new streak of 12 is highest (Charlie has 10)
         best: 12,
+        bestOpponent: "bob",
         target: 20,
         earned: 0,
         perOpponent: new Map([
@@ -317,6 +322,7 @@ describe("TennisTable", () => {
       expect(progression["streak-player-20"]).toStrictEqual({
         current: 0, // Both opponents at 20, no streaks below 20
         best: 20,
+        bestOpponent: "bob",
         target: 20,
         earned: 2,
         perOpponent: new Map([

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -114,14 +114,16 @@ export class Achievements {
   // Podium / Touched the Throne awards use, so a "best" here always means a
   // rank those achievements would count. Used for their progression.
   bestRankEver: Map<string, number> = new Map();
-  // Best (lowest) pre-match rank of any opponent each player has beaten,
-  // with the same ≥5 ranked cohort gate as Kingslayer. Used for Kingslayer
-  // progression — how close the player has come to beating a #1.
-  bestBeatenRank: Map<string, number> = new Map();
+  // Best (lowest) pre-match rank of any opponent each player has beaten —
+  // and who that opponent was — with the same ≥5 ranked cohort gate as
+  // Kingslayer. Used for Kingslayer progression: how close the player has
+  // come to beating a #1.
+  bestBeatenRank: Map<string, { rank: number; opponent: string }> = new Map();
   // Each player's largest climb ever reached: the most Elo they have been
-  // above their ranked-era all-time low at any point. Used for Climber
-  // progression — the chase regresses when Elo drops, so the best is kept.
-  bestClimb: Map<string, number> = new Map();
+  // above their ranked-era all-time low at any point, with the low and the
+  // peak behind it. Used for Climber progression — the chase regresses when
+  // Elo drops, so the best is kept.
+  bestClimb: Map<string, { climb: number; fromElo: number; toElo: number }> = new Map();
   // League-wide running records for the Earliest / Latest Game achievements:
   // the earliest and latest time-of-day (minutes past local midnight, in the
   // browser's timezone) any game has been played to date. Undefined until the
@@ -1252,8 +1254,9 @@ export class Achievements {
       }
       const low = this.climberAllTimeLow.get(playerId)!;
       const climb = currentElo - low.elo;
-      if (climb > (this.bestClimb.get(playerId) ?? 0)) {
-        this.bestClimb.set(playerId, climb);
+      const prevBestClimb = this.bestClimb.get(playerId);
+      if (climb > 0 && (prevBestClimb === undefined || climb > prevBestClimb.climb)) {
+        this.bestClimb.set(playerId, { climb, fromElo: low.elo, toElo: currentElo });
       }
       if (currentElo - low.elo >= 300 && !climber.has(playerId)) {
         climber.add(playerId);
@@ -1370,8 +1373,8 @@ export class Achievements {
       // beaten, for Kingslayer progression. Same ≥5 cohort gate as the award.
       if (loserRankBefore !== null && rankedCountBefore >= 5) {
         const bestBeaten = this.bestBeatenRank.get(game.winner);
-        if (bestBeaten === undefined || loserRankBefore < bestBeaten) {
-          this.bestBeatenRank.set(game.winner, loserRankBefore);
+        if (bestBeaten === undefined || loserRankBefore < bestBeaten.rank) {
+          this.bestBeatenRank.set(game.winner, { rank: loserRankBefore, opponent: game.loser });
         }
       }
 
@@ -2628,8 +2631,10 @@ export class Achievements {
     const streaksPerOpponent = new Map<string, number>();
     // Highest win streak the player has EVER held against a single opponent —
     // streaksPerOpponent only carries live streaks, which reset when that
-    // opponent wins one back. Used as the Domination / Humiliation best.
+    // opponent wins one back. Used as the Domination / Humiliation best,
+    // together with who the streak was against.
     let bestStreakPerOpponentEver = 0;
+    let bestStreakOpponentEver: string | undefined = undefined;
     // Every game timestamp of this player, in play order. Used for the
     // best-ever values of the window-based chases: Hat Trick (90-minute win
     // window), the activity streaks and the longest absence.
@@ -2776,7 +2781,10 @@ export class Achievements {
         // Track win streak against specific opponent
         const opponentStreak = (streaksPerOpponent.get(opponent) || 0) + 1;
         streaksPerOpponent.set(opponent, opponentStreak);
-        bestStreakPerOpponentEver = Math.max(bestStreakPerOpponentEver, opponentStreak);
+        if (opponentStreak > bestStreakPerOpponentEver) {
+          bestStreakPerOpponentEver = opponentStreak;
+          bestStreakOpponentEver = opponent;
+        }
 
         // Count donuts (only for winners)
         if (game.score?.setPoints) {
@@ -3001,8 +3009,10 @@ export class Achievements {
 
     // Best Friends best: the most games ever played with one opponent inside
     // any 1-year window — the current count decays as games age out of the
-    // rolling window, so the closest attempt is kept separately.
+    // rolling window, so the closest attempt is kept separately, together
+    // with who it was played with.
     let bestFriendsBest = 0;
+    let bestFriendsOpponent: string | undefined = undefined;
 
     gamesPerOpponent.forEach((_, opponent) => {
       // Count games with this opponent in the last year
@@ -3033,7 +3043,11 @@ export class Achievements {
         while (time - sharedGameTimes[windowStart] > ONE_YEAR) {
           windowStart++;
         }
-        bestFriendsBest = Math.max(bestFriendsBest, index - windowStart + 1);
+        const gamesInWindow = index - windowStart + 1;
+        if (gamesInWindow > bestFriendsBest) {
+          bestFriendsBest = gamesInWindow;
+          bestFriendsOpponent = opponent;
+        }
       });
 
       if (gamesInLastYear > 0 && firstGameInWindow !== null) {
@@ -3055,6 +3069,7 @@ export class Achievements {
     // (which would be 50+ if all opponents are over the threshold)
     progression["best-friends"].current = maxGamesUnderTarget > 0 ? maxGamesUnderTarget : maxGamesInLastYear;
     progression["best-friends"].best = bestFriendsBest;
+    progression["best-friends"].bestOpponent = bestFriendsOpponent;
     progression["best-friends"].perOpponent = opponentGamesInLastYear;
 
     // Track max streaks under target for streak-player achievements
@@ -3082,8 +3097,10 @@ export class Achievements {
     // Set current to max under target, or 0 if all are at/over the target
     progression["streak-player-10"].current = maxStreakUnder10;
     progression["streak-player-10"].best = bestStreakPerOpponentEver;
+    progression["streak-player-10"].bestOpponent = bestStreakOpponentEver;
     progression["streak-player-20"].current = maxStreakUnder20;
     progression["streak-player-20"].best = bestStreakPerOpponentEver;
+    progression["streak-player-20"].bestOpponent = bestStreakOpponentEver;
 
     // Calculate active period with 30-day reset logic
     const activityPeriod = this.#calculateActivityPeriod(playerId);
@@ -3202,6 +3219,20 @@ export class Achievements {
       }
     }
 
+    // Season's Champion best: the best final rank in a finished season the
+    // player took part in. The season leaderboard is sorted best-first, so
+    // the rank is the index + 1. Undefined when they never finished a season.
+    let bestSeasonRank: number | undefined = undefined;
+    for (const season of seasons) {
+      if (now <= season.end) continue;
+      const rankIndex = season.getLeaderboard().findIndex((entry) => entry.playerId === playerId);
+      if (rankIndex === -1) continue;
+      if (bestSeasonRank === undefined || rankIndex + 1 < bestSeasonRank) {
+        bestSeasonRank = rankIndex + 1;
+      }
+    }
+    progression["season-winner"].best = bestSeasonRank;
+
     // Season Opener progression is league-wide (everyone shares the same
     // values) and counts down to the next season start, because that is when
     // the next opener becomes available. Target is the span from the start of
@@ -3262,27 +3293,47 @@ export class Achievements {
       progression["climber"].current = Math.max(0, currentElo - climberLow.elo);
     }
     // Climber best: the highest the player has ever climbed above their low —
-    // the chase regresses when Elo drops, so the closest attempt is kept.
-    progression["climber"].best = this.bestClimb.get(playerId);
+    // the chase regresses when Elo drops, so the closest attempt is kept,
+    // with the low and the peak behind it.
+    const bestClimbEntry = this.bestClimb.get(playerId);
+    progression["climber"].best = bestClimbEntry?.climb;
+    progression["climber"].bestFromElo = bestClimbEntry?.fromElo;
+    progression["climber"].bestToElo = bestClimbEntry?.toElo;
 
     // On the Podium / Touched the Throne best: the best (lowest) rank the
     // player has ever held. Kingslayer best: the best (lowest) pre-match rank
-    // of an opponent they have beaten. All recorded only while the ranked
-    // cohort had ≥5 players, matching the gates on the awards themselves.
+    // of an opponent they have beaten, and who it was. All recorded only
+    // while the ranked cohort had ≥5 players, matching the awards' gates.
     progression["on-the-podium"].best = this.bestRankEver.get(playerId);
     progression["touched-the-throne"].best = this.bestRankEver.get(playerId);
-    progression["kingslayer"].best = this.bestBeatenRank.get(playerId);
+    const bestBeatenEntry = this.bestBeatenRank.get(playerId);
+    progression["kingslayer"].best = bestBeatenEntry?.rank;
+    progression["kingslayer"].bestOpponent = bestBeatenEntry?.opponent;
 
-    // Group Play Star best: the most wins the player has had in one
-    // tournament's group play — their strongest group play so far.
-    let bestGroupStageWins = 0;
+    // Group Play Star best: the player's group play that came closest to
+    // perfect — the highest share of games won, ties broken by more wins, so
+    // 3 of 4 beats 3 of 6 and a perfect 3 of 3 beats both. Both numbers are
+    // kept so the view can show "Best: 3 of 4". The share comparison uses
+    // cross-multiplication to stay in integers.
+    let bestGroupPlay: { wins: number; games: number } | undefined = undefined;
     this.parent.tournaments.getTournaments().forEach((tournament) => {
       const score = tournament.groupPlay?.groupScores.get(playerId);
-      if (score) {
-        bestGroupStageWins = Math.max(bestGroupStageWins, score.wins);
+      if (!score) return;
+      const games = score.wins + score.loss + score.skips;
+      if (games === 0) return;
+      const beatsBest =
+        bestGroupPlay === undefined ||
+        score.wins * bestGroupPlay.games > bestGroupPlay.wins * games ||
+        (score.wins * bestGroupPlay.games === bestGroupPlay.wins * games && score.wins > bestGroupPlay.wins);
+      if (beatsBest) {
+        bestGroupPlay = { wins: score.wins, games };
       }
     });
-    progression["group-stage-star"].best = bestGroupStageWins;
+    if (bestGroupPlay !== undefined) {
+      const { wins, games } = bestGroupPlay;
+      progression["group-stage-star"].best = wins;
+      progression["group-stage-star"].bestOutOf = games;
+    }
 
     // Full House / Humbled progression: how many of the currently ranked
     // players (excluding the player themselves) this player has beaten /
@@ -3523,6 +3574,8 @@ type AnniversaryProgression = ProgressionWithTarget & {
 
 type StreakPlayerProgression = ProgressionWithTarget & {
   perOpponent?: Map<string, number>; // Breakdown of current streaks per opponent
+  // Who the best-ever streak was against, shown next to the best value.
+  bestOpponent?: string;
 };
 
 type VarietyPlayerProgression = ProgressionWithTarget & {
@@ -3531,6 +3584,8 @@ type VarietyPlayerProgression = ProgressionWithTarget & {
 
 type BestFriendsProgression = ProgressionWithTarget & {
   perOpponent?: Map<string, { count: number; timespan: number }>;
+  // Who the best 1-year window was played with, shown next to the best value.
+  bestOpponent?: string;
 };
 
 type WelcomeCommitteeProgression = ProgressionWithTarget & {
@@ -3633,6 +3688,23 @@ type StreakRecordProgression = BaseProgression & {
   best: number;
 };
 
+type GroupPlayStarProgression = BaseProgression & {
+  // Games in the group play behind `best`, so the view can show "3 of 4" —
+  // the win count alone says nothing without the size of the group.
+  bestOutOf?: number;
+};
+
+type KingslayerProgression = BaseProgression & {
+  // Who the best-ranked beaten opponent was, shown next to the best rank.
+  bestOpponent?: string;
+};
+
+type ClimberProgression = ProgressionWithTarget & {
+  // The low and the peak behind the best climb, shown as "(912 → 1162)".
+  bestFromElo?: number;
+  bestToElo?: number;
+};
+
 // Earliest / Latest Game are record-breaking achievements with no numeric
 // progress bar — you either hold the record or you don't. Instead of a
 // percentage, the progress view shows the current league record and the
@@ -3684,7 +3756,7 @@ export type AchievementProgression = {
   "hat-trick": ProgressionWithTarget;
   "perfect-day": ProgressionWithTarget;
   "perfect-week": ProgressionWithTarget;
-  "kingslayer": BaseProgression;
+  "kingslayer": KingslayerProgression;
   "king-maker": BaseProgression;
   "touched-the-throne": BaseProgression;
   "on-the-podium": BaseProgression;
@@ -3692,7 +3764,7 @@ export type AchievementProgression = {
   "leap-frog": LeapFrogProgression;
   "david": UpsetRecordProgression;
   "goliath": UpsetRecordProgression;
-  "climber": ProgressionWithTarget;
+  "climber": ClimberProgression;
   "marathon-set": MarathonSetProgression;
   "shootout": ShootoutProgression;
   "streak-ender": BaseProgression;
@@ -3701,7 +3773,7 @@ export type AchievementProgression = {
   "hero-of-the-day": HeroRecordProgression;
   "hero-of-the-week": HeroRecordProgression;
   "hero-of-the-month": HeroRecordProgression;
-  "group-stage-star": BaseProgression;
+  "group-stage-star": GroupPlayStarProgression;
   "full-house": MissingPlayersProgression;
   "humbled": MissingPlayersProgression;
   "earliest-game": TimeOfDayRecordProgression;

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -109,6 +109,19 @@ export class Achievements {
   // Each player's own largest single-game leaderboard jump (ranked before
   // and after). Used for Leap Frog progression.
   bestRankJump: Map<string, number> = new Map();
+  // Best (lowest) leaderboard rank each player has ever held, recorded only
+  // while the ranked cohort had ≥5 players — the same gate the On the
+  // Podium / Touched the Throne awards use, so a "best" here always means a
+  // rank those achievements would count. Used for their progression.
+  bestRankEver: Map<string, number> = new Map();
+  // Best (lowest) pre-match rank of any opponent each player has beaten,
+  // with the same ≥5 ranked cohort gate as Kingslayer. Used for Kingslayer
+  // progression — how close the player has come to beating a #1.
+  bestBeatenRank: Map<string, number> = new Map();
+  // Each player's largest climb ever reached: the most Elo they have been
+  // above their ranked-era all-time low at any point. Used for Climber
+  // progression — the chase regresses when Elo drops, so the best is kept.
+  bestClimb: Map<string, number> = new Map();
   // League-wide running records for the Earliest / Latest Game achievements:
   // the earliest and latest time-of-day (minutes past local midnight, in the
   // browser's timezone) any game has been played to date. Undefined until the
@@ -167,6 +180,9 @@ export class Achievements {
     this.marathonSetRecord = { score: undefined, holder: undefined };
     this.leapFrogRecord = { ranksJumped: undefined, holder: undefined };
     this.bestRankJump.clear();
+    this.bestRankEver.clear();
+    this.bestBeatenRank.clear();
+    this.bestClimb.clear();
     this.earliestGameRecord = { minutesIntoDay: undefined };
     this.latestGameRecord = { minutesIntoDay: undefined };
     this.winStreakRecord = { length: undefined, holder: undefined };
@@ -1235,6 +1251,10 @@ export class Achievements {
         this.climberAllTimeLow.set(playerId, { elo: currentElo, time });
       }
       const low = this.climberAllTimeLow.get(playerId)!;
+      const climb = currentElo - low.elo;
+      if (climb > (this.bestClimb.get(playerId) ?? 0)) {
+        this.bestClimb.set(playerId, climb);
+      }
       if (currentElo - low.elo >= 300 && !climber.has(playerId)) {
         climber.add(playerId);
         this.#addAchievement(
@@ -1246,6 +1266,16 @@ export class Achievements {
             toDate: time,
           }),
         );
+      }
+    };
+
+    // Record the best (lowest) rank a player has ever held. Only called with
+    // ranks observed while the cohort had ≥5 ranked players, matching the
+    // gate on the podium / throne awards.
+    const updateBestRank = (playerId: string, rank: number) => {
+      const best = this.bestRankEver.get(playerId);
+      if (best === undefined || rank < best) {
+        this.bestRankEver.set(playerId, rank);
       }
     };
 
@@ -1266,6 +1296,7 @@ export class Achievements {
         if (!isActiveAt(playerId, time)) continue;
         const rank = getRank(playerId, time);
         if (rank === null) continue;
+        updateBestRank(playerId, rank);
         if (rank === 1 && !touchedThrone.has(playerId)) {
           touchedThrone.add(playerId);
           this.#addAchievement(
@@ -1335,6 +1366,15 @@ export class Achievements {
       const loserRankBefore = getRank(game.loser, game.playedAt);
       const rankedCountBefore = countRankedAt(game.playedAt);
 
+      // Track the best (lowest) pre-match rank of an opponent the winner has
+      // beaten, for Kingslayer progression. Same ≥5 cohort gate as the award.
+      if (loserRankBefore !== null && rankedCountBefore >= 5) {
+        const bestBeaten = this.bestBeatenRank.get(game.winner);
+        if (bestBeaten === undefined || loserRankBefore < bestBeaten) {
+          this.bestBeatenRank.set(game.winner, loserRankBefore);
+        }
+      }
+
       // Kingslayer: loser was #1 going into the match. One-time per
       // player. Requires ≥5 ranked players so being "#1" actually means
       // outranking a real cohort, not a tiny pool.
@@ -1380,6 +1420,13 @@ export class Achievements {
       const winnerRankAfter = getRank(game.winner, game.playedAt);
       const loserRankAfter = getRank(game.loser, game.playedAt);
       const rankedCount = countRankedAt(game.playedAt);
+
+      // Track both participants' best rank ever (the recheck below skips
+      // them). Non-participants are covered by the recheck's own update.
+      if (rankedCount >= 5) {
+        if (winnerRankAfter !== null) updateBestRank(game.winner, winnerRankAfter);
+        if (loserRankAfter !== null) updateBestRank(game.loser, loserRankAfter);
+      }
 
       // Touched the Throne: first time the player ever sits at rank #1.
       // The player must already be ranked entering the match, and there
@@ -2252,9 +2299,9 @@ export class Achievements {
         );
       }
 
-      // Check for Group Stage Star: a player who finished their group stage
+      // Check for Group Play Star: a player who finished their group play
       // with zero losses and zero own-skips (opponent skips that gave them a
-      // free win still count). Awarded once per tournament group stage.
+      // free win still count). Awarded once per tournament's group play.
       if (t.groupPlay && t.groupPlay.groupPlayEnded !== undefined) {
         const endedAt = t.groupPlay.groupPlayEnded;
         t.groupPlay.groupScores.forEach((score, playerId) => {
@@ -2436,7 +2483,7 @@ export class Achievements {
       "longest-win-streak": {
         earned: 0,
         current: 0,
-        personalBest: 0,
+        best: 0,
         target: this.winStreakRecord.length === undefined ? undefined : this.winStreakRecord.length + 1,
         recordHolder: this.winStreakRecord.holder,
       },
@@ -2449,7 +2496,7 @@ export class Achievements {
       "longest-lose-streak": {
         earned: 0,
         current: 0,
-        personalBest: 0,
+        best: 0,
         target: this.loseStreakRecord.length === undefined ? undefined : this.loseStreakRecord.length + 1,
         recordHolder: this.loseStreakRecord.holder,
       },
@@ -2507,21 +2554,21 @@ export class Achievements {
       "hero-of-the-day": {
         earned: 0,
         current: 0,
-        personalBest: 0,
+        best: 0,
         target: this.gamesInDayRecord.count === undefined ? undefined : this.gamesInDayRecord.count + 1,
         recordHolder: this.gamesInDayRecord.holder,
       },
       "hero-of-the-week": {
         earned: 0,
         current: 0,
-        personalBest: 0,
+        best: 0,
         target: this.gamesInWeekRecord.count === undefined ? undefined : this.gamesInWeekRecord.count + 1,
         recordHolder: this.gamesInWeekRecord.holder,
       },
       "hero-of-the-month": {
         earned: 0,
         current: 0,
-        personalBest: 0,
+        best: 0,
         target: this.gamesInMonthRecord.count === undefined ? undefined : this.gamesInMonthRecord.count + 1,
         recordHolder: this.gamesInMonthRecord.holder,
       },
@@ -2579,6 +2626,16 @@ export class Achievements {
     let consistencyCount = 0;
     let bestDeuceSetWon = 0;
     const streaksPerOpponent = new Map<string, number>();
+    // Highest win streak the player has EVER held against a single opponent —
+    // streaksPerOpponent only carries live streaks, which reset when that
+    // opponent wins one back. Used as the Domination / Humiliation best.
+    let bestStreakPerOpponentEver = 0;
+    // Every game timestamp of this player, in play order. Used for the
+    // best-ever values of the window-based chases: Hat Trick (90-minute win
+    // window), the activity streaks and the longest absence.
+    const playerGameTimes: number[] = [];
+    // Timestamps of this player's wins, in play order — Hat Trick input.
+    const playerWinTimes: number[] = [];
     // Perfect Day progression: wins / losses grouped by local calendar day.
     const perfectDayStats = new Map<number, { wins: number; losses: number }>();
     // Hero of the Week / Month progression: the player's games per local
@@ -2646,6 +2703,7 @@ export class Achievements {
       if (!isWinner && !isLoser) return;
 
       gamesPlayedCount++;
+      playerGameTimes.push(game.playedAt);
 
       // Track first active time
       if (firstActiveAt === null) {
@@ -2708,13 +2766,17 @@ export class Achievements {
       opponentData.lastGame = game.playedAt;
 
       if (isWinner) {
+        playerWinTimes.push(game.playedAt);
+
         // Track win streak against all
         currentWinStreakAll++;
         currentLoseStreakAll = 0;
         longestWinStreakAll = Math.max(longestWinStreakAll, currentWinStreakAll);
 
         // Track win streak against specific opponent
-        streaksPerOpponent.set(opponent, (streaksPerOpponent.get(opponent) || 0) + 1);
+        const opponentStreak = (streaksPerOpponent.get(opponent) || 0) + 1;
+        streaksPerOpponent.set(opponent, opponentStreak);
+        bestStreakPerOpponentEver = Math.max(bestStreakPerOpponentEver, opponentStreak);
 
         // Count donuts (only for winners)
         if (game.score?.setPoints) {
@@ -2775,6 +2837,7 @@ export class Achievements {
     progression["donut-1"].current = donutCount;
     progression["donut-5"].current = donutCount;
     progression["streak-all-10"].current = currentWinStreakAll;
+    progression["streak-all-10"].best = longestWinStreakAll;
     progression["close-calls"].current = closeCallsCount;
     progression["edge-lord"].current = edgeLordCount;
     progression["consistency-is-key"].current = consistencyCount;
@@ -2784,15 +2847,17 @@ export class Achievements {
     progression["global-player"].current = opponentsPlayed.size;
     progression["global-player"].opponents = opponentsPlayed;
     progression["punching-bag"].current = currentLoseStreakAll;
+    progression["punching-bag"].best = longestLoseStreakAll;
     progression["never-give-up"].current = currentLoseStreakAll;
+    progression["never-give-up"].best = longestLoseStreakAll;
 
     // Longest Win / Lose Streak: the live streak is what can still grow into
     // the league record, so that is the progress. The player's longest ever
     // run is reported alongside it.
     progression["longest-win-streak"].current = currentWinStreakAll;
-    progression["longest-win-streak"].personalBest = longestWinStreakAll;
+    progression["longest-win-streak"].best = longestWinStreakAll;
     progression["longest-lose-streak"].current = currentLoseStreakAll;
-    progression["longest-lose-streak"].personalBest = longestLoseStreakAll;
+    progression["longest-lose-streak"].best = longestLoseStreakAll;
 
     // Perfect Day progression tracks TODAY's live attempt: the number of
     // games won today with zero losses so far. A single loss today nullifies
@@ -2806,6 +2871,16 @@ export class Achievements {
     progression["perfect-day"].current =
       todayStat && todayStat.losses === 0 ? Math.min(todayStat.wins, 5) : 0;
 
+    // Perfect Day best: the most wins on any fully undefeated day — the
+    // player's closest attempt ever, today's live attempt included.
+    let bestUndefeatedDay = 0;
+    perfectDayStats.forEach((stats) => {
+      if (stats.losses === 0) {
+        bestUndefeatedDay = Math.max(bestUndefeatedDay, stats.wins);
+      }
+    });
+    progression["perfect-day"].best = bestUndefeatedDay;
+
     // Hero of the Day / Week / Month: only the current period's games can
     // still grow into the record, so that is the progress. The player's
     // busiest period ever is reported alongside it.
@@ -2814,21 +2889,21 @@ export class Achievements {
     perfectDayStats.forEach((stats) => {
       busiestDay = Math.max(busiestDay, stats.wins + stats.losses);
     });
-    progression["hero-of-the-day"].personalBest = busiestDay;
+    progression["hero-of-the-day"].best = busiestDay;
 
     progression["hero-of-the-week"].current = gamesPerWeek.get(this.#weekStartOf(nowMs)) ?? 0;
     let busiestWeek = 0;
     gamesPerWeek.forEach((count) => {
       busiestWeek = Math.max(busiestWeek, count);
     });
-    progression["hero-of-the-week"].personalBest = busiestWeek;
+    progression["hero-of-the-week"].best = busiestWeek;
 
     progression["hero-of-the-month"].current = gamesPerMonth.get(this.#monthStartOf(nowMs)) ?? 0;
     let busiestMonth = 0;
     gamesPerMonth.forEach((count) => {
       busiestMonth = Math.max(busiestMonth, count);
     });
-    progression["hero-of-the-month"].personalBest = busiestMonth;
+    progression["hero-of-the-month"].best = busiestMonth;
 
     // Perfect Week progression tracks THIS week's live attempt: of the three
     // possible 5-consecutive-day runs (Mon–Fri, Tue–Sat, Wed–Sun), the most
@@ -2861,6 +2936,20 @@ export class Achievements {
     }
     progression["perfect-week"].current = perfectWeekProgress;
 
+    // Perfect Week best: across every week the player has played, the most
+    // won days inside one of the three 5-day runs — their closest attempt.
+    let bestPerfectWeekRun = 0;
+    perfectWeekDaysWon.forEach((daysWon) => {
+      for (let start = 0; start <= 2; start++) {
+        let daysWonInRun = 0;
+        for (let offset = start; offset < start + 5; offset++) {
+          if (daysWon.has(offset)) daysWonInRun++;
+        }
+        bestPerfectWeekRun = Math.max(bestPerfectWeekRun, daysWonInRun);
+      }
+    });
+    progression["perfect-week"].best = bestPerfectWeekRun;
+
     // Calculate hat-trick progression (wins within last 90 minutes)
     const NINETY_MINUTES = 90 * 60 * 1000;
     const currentTime = Date.now();
@@ -2881,6 +2970,18 @@ export class Achievements {
 
     progression["hat-trick"].current = recentWins.length;
 
+    // Hat Trick best: the most wins the player has ever fit inside a single
+    // 90-minute window, found with a sliding window over their win times.
+    let bestHatTrickWindow = 0;
+    let hatTrickWindowStart = 0;
+    playerWinTimes.forEach((winTime, index) => {
+      while (winTime - playerWinTimes[hatTrickWindowStart] > NINETY_MINUTES) {
+        hatTrickWindowStart++;
+      }
+      bestHatTrickWindow = Math.max(bestHatTrickWindow, index - hatTrickWindowStart + 1);
+    });
+    progression["hat-trick"].best = bestHatTrickWindow;
+
 
     // Get list of opponents we've already earned achievements with
     const earnedBestFriendsOpponents = new Set<string>();
@@ -2898,23 +2999,41 @@ export class Achievements {
     let maxGamesUnderTarget = 0; // Track highest count that hasn't reached target yet
     const opponentGamesInLastYear = new Map<string, { count: number; timespan: number }>();
 
+    // Best Friends best: the most games ever played with one opponent inside
+    // any 1-year window — the current count decays as games age out of the
+    // rolling window, so the closest attempt is kept separately.
+    let bestFriendsBest = 0;
+
     gamesPerOpponent.forEach((_, opponent) => {
       // Count games with this opponent in the last year
       let gamesInLastYear = 0;
       let firstGameInWindow: number | null = null;
+      const sharedGameTimes: number[] = [];
 
       this.parent.games.forEach((game) => {
         const isPlayerGame =
           (game.winner === playerId && game.loser === opponent) ||
           (game.loser === playerId && game.winner === opponent);
+        if (!isPlayerGame) return;
+
+        sharedGameTimes.push(game.playedAt);
 
         // Check if game is within last year from now
-        if (isPlayerGame && now - game.playedAt <= ONE_YEAR) {
+        if (now - game.playedAt <= ONE_YEAR) {
           gamesInLastYear++;
           if (firstGameInWindow === null) {
             firstGameInWindow = game.playedAt;
           }
         }
+      });
+
+      // Sliding window over this opponent's shared game times.
+      let windowStart = 0;
+      sharedGameTimes.forEach((time, index) => {
+        while (time - sharedGameTimes[windowStart] > ONE_YEAR) {
+          windowStart++;
+        }
+        bestFriendsBest = Math.max(bestFriendsBest, index - windowStart + 1);
       });
 
       if (gamesInLastYear > 0 && firstGameInWindow !== null) {
@@ -2935,6 +3054,7 @@ export class Achievements {
     // Use maxGamesUnderTarget if it exists, otherwise show maxGamesInLastYear
     // (which would be 50+ if all opponents are over the threshold)
     progression["best-friends"].current = maxGamesUnderTarget > 0 ? maxGamesUnderTarget : maxGamesInLastYear;
+    progression["best-friends"].best = bestFriendsBest;
     progression["best-friends"].perOpponent = opponentGamesInLastYear;
 
     // Track max streaks under target for streak-player achievements
@@ -2961,7 +3081,9 @@ export class Achievements {
 
     // Set current to max under target, or 0 if all are at/over the target
     progression["streak-player-10"].current = maxStreakUnder10;
+    progression["streak-player-10"].best = bestStreakPerOpponentEver;
     progression["streak-player-20"].current = maxStreakUnder20;
+    progression["streak-player-20"].best = bestStreakPerOpponentEver;
 
     // Calculate active period with 30-day reset logic
     const activityPeriod = this.#calculateActivityPeriod(playerId);
@@ -2978,6 +3100,28 @@ export class Achievements {
       progression["active-1-year"].current = ongoingPeriod;
       progression["active-2-years"].current = ongoingPeriod;
     }
+
+    // Regular / Dedicated / Veteran best: the longest activity streak the
+    // player has ever kept — their games walked with the same 30-day reset
+    // the awards use, and the live streak counted up to now while it is
+    // still alive.
+    const THIRTY_DAYS = 30 * 24 * 60 * 60 * 1000;
+    let bestActivityStreak = 0;
+    let activityStreakStart: number | null = null;
+    let previousGameAt: number | null = null;
+    for (const gameAt of playerGameTimes) {
+      if (activityStreakStart === null || gameAt - previousGameAt! >= THIRTY_DAYS) {
+        activityStreakStart = gameAt;
+      }
+      previousGameAt = gameAt;
+      bestActivityStreak = Math.max(bestActivityStreak, gameAt - activityStreakStart);
+    }
+    if (activityStreakStart !== null && previousGameAt !== null && now - previousGameAt < THIRTY_DAYS) {
+      bestActivityStreak = Math.max(bestActivityStreak, now - activityStreakStart);
+    }
+    progression["active-6-months"].best = bestActivityStreak;
+    progression["active-1-year"].best = bestActivityStreak;
+    progression["active-2-years"].best = bestActivityStreak;
 
     // Anniversary progress counts toward the next anniversary the player can
     // still earn, and resets to 0 each year. The "target year" is the earliest
@@ -3029,6 +3173,19 @@ export class Achievements {
 
       progression["back-after-2-years"].current = timeSinceLastActivity;
       progression["back-after-2-years"].lastActiveAt = lastActiveAt;
+    }
+
+    // Welcome Back / Long Time No See / A Cinderella Story best: the longest
+    // gap without a game the player has ever had, the still-open gap since
+    // their last game included.
+    if (lastActiveAt !== null) {
+      let longestAbsence = now - lastActiveAt;
+      for (let i = 1; i < playerGameTimes.length; i++) {
+        longestAbsence = Math.max(longestAbsence, playerGameTimes[i] - playerGameTimes[i - 1]);
+      }
+      progression["back-after-6-months"].best = longestAbsence;
+      progression["back-after-1-year"].best = longestAbsence;
+      progression["back-after-2-years"].best = longestAbsence;
     }
 
     // Season progress
@@ -3104,6 +3261,28 @@ export class Achievements {
       const currentElo = this.parent.leaderboard.getPlayerSummary(playerId).elo;
       progression["climber"].current = Math.max(0, currentElo - climberLow.elo);
     }
+    // Climber best: the highest the player has ever climbed above their low —
+    // the chase regresses when Elo drops, so the closest attempt is kept.
+    progression["climber"].best = this.bestClimb.get(playerId);
+
+    // On the Podium / Touched the Throne best: the best (lowest) rank the
+    // player has ever held. Kingslayer best: the best (lowest) pre-match rank
+    // of an opponent they have beaten. All recorded only while the ranked
+    // cohort had ≥5 players, matching the gates on the awards themselves.
+    progression["on-the-podium"].best = this.bestRankEver.get(playerId);
+    progression["touched-the-throne"].best = this.bestRankEver.get(playerId);
+    progression["kingslayer"].best = this.bestBeatenRank.get(playerId);
+
+    // Group Play Star best: the most wins the player has had in one
+    // tournament's group play — their strongest group play so far.
+    let bestGroupStageWins = 0;
+    this.parent.tournaments.getTournaments().forEach((tournament) => {
+      const score = tournament.groupPlay?.groupScores.get(playerId);
+      if (score) {
+        bestGroupStageWins = Math.max(bestGroupStageWins, score.wins);
+      }
+    });
+    progression["group-stage-star"].best = bestGroupStageWins;
 
     // Full House / Humbled progression: how many of the currently ranked
     // players (excluding the player themselves) this player has beaten /
@@ -3317,6 +3496,14 @@ type HeroPeriodState = {
 // Progression Types
 type BaseProgression = {
   earned: number; // How many times this achievement has been earned
+  // The player's best-ever value for chases whose progress resets or decays
+  // (streaks, calendar periods, time windows, ranks) — how close they have
+  // ever come. Undefined for cumulative chases, where `current` IS the best.
+  // Counts and Elo climbs share the unit of `current`; for the rank-based
+  // chases (On the Podium, Touched the Throne, Kingslayer) it is a leaderboard
+  // rank where LOWER is better; for the duration chases (Regular / Welcome
+  // Back families) it is milliseconds, rendered as days.
+  best?: number;
 };
 
 type ProgressionWithTarget = BaseProgression & {
@@ -3427,7 +3614,7 @@ type HeroRecordProgression = BaseProgression & {
   recordHolder?: string;
   // The player's own busiest period ever, which may be busier than the
   // current one. Shown so they can see how their best compares.
-  personalBest: number;
+  best: number;
 };
 
 type StreakRecordProgression = BaseProgression & {
@@ -3443,7 +3630,7 @@ type StreakRecordProgression = BaseProgression & {
   recordHolder?: string;
   // The player's own longest streak ever, which may be longer than the one
   // they are on now. Shown so they can see how their best compares.
-  personalBest: number;
+  best: number;
 };
 
 // Earliest / Latest Game are record-breaking achievements with no numeric

--- a/frontend/src/pages/changelog/changelog-page.tsx
+++ b/frontend/src/pages/changelog/changelog-page.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { Link } from "react-router-dom";
 import { classNames } from "../../common/class-names";
+import { relativeTimeString } from "../../common/date-utils";
 import { ChangelogPost, changelogTagCounts, getChangelogPosts } from "../../client/changelog/changelog-posts";
 import { ALL_CHANGELOG_TAGS } from "../../client/changelog/changelog-tags";
 import { ChangelogTagPill } from "./changelog-tag-pill";
@@ -88,7 +89,9 @@ const PostCard: React.FC<{ post: ChangelogPost }> = ({ post }) => {
         "hover:bg-secondary-background hover:text-secondary-text hover:border-secondary-background transition-colors",
       )}
     >
-      <p className="text-xs opacity-60 tabular-nums">{formatPostDate(post.date)}</p>
+      <p className="text-xs opacity-60 tabular-nums">
+        {formatPostDate(post.date)} · {relativeTimeString(postDateAsDate(post.date))}
+      </p>
       <h3 className="text-lg sm:text-xl font-semibold mt-1">{post.title}</h3>
       <p className="text-sm opacity-80 mt-2">{post.summary}</p>
       <div className="flex flex-wrap gap-1.5 mt-3">
@@ -100,8 +103,14 @@ const PostCard: React.FC<{ post: ChangelogPost }> = ({ post }) => {
   );
 };
 
+// Post dates are day-granular; anchoring them to local noon keeps both the
+// formatted date and the relative time on the intended calendar day.
+function postDateAsDate(isoDate: string): Date {
+  return new Date(`${isoDate}T12:00:00`);
+}
+
 export function formatPostDate(isoDate: string): string {
-  const date = new Date(`${isoDate}T12:00:00`);
+  const date = postDateAsDate(isoDate);
   if (Number.isNaN(date.getTime())) return isoDate;
   return date.toLocaleDateString(undefined, { year: "numeric", month: "long", day: "numeric" });
 }

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -737,9 +737,10 @@ type ProgressTabProps = {
   playerId: string;
 };
 
-// Achievement types whose "best" is a leaderboard rank — lower is better,
-// shown as "#N".
-const RANK_BEST_TYPES = new Set(["on-the-podium", "touched-the-throne", "kingslayer"]);
+// Achievement types whose "best" is a rank — lower is better, shown as "#N".
+// The first three are leaderboard ranks; Season's Champion is the best final
+// rank in a finished season.
+const RANK_BEST_TYPES = new Set(["on-the-podium", "touched-the-throne", "kingslayer", "season-winner"]);
 
 // Renders a progression's best-ever value in the unit the chase is measured
 // in: ranks as "#N", the duration chases as days, everything else as a count.
@@ -926,10 +927,23 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                               )}
                             {/* The player's best-ever value, for chases whose
                                 progress resets or decays — how close they have
-                                ever come, next to where they stand now. */}
+                                ever come, next to where they stand now. When
+                                the number alone is thin, the opponent it was
+                                achieved with is named. */}
                             {data.best !== undefined && data.best > 0 && (
                               <span className="text-xs text-secondary-text/70 font-normal ml-2">
                                 Best: {formatBestValue(type, data.best)}
+                                {"bestOpponent" in data && data.bestOpponent && (
+                                  <> with {context.playerName(data.bestOpponent)}</>
+                                )}
+                                {"bestFromElo" in data &&
+                                  data.bestFromElo !== undefined &&
+                                  data.bestToElo !== undefined && (
+                                    <>
+                                      {" "}
+                                      ({fmtNum(data.bestFromElo)} → {fmtNum(data.bestToElo)})
+                                    </>
+                                  )}
                               </span>
                             )}
                           </span>
@@ -1274,11 +1288,18 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                   ) : (
                     // Fallback for achievements without targets (like tournament
                     // achievements). The rank chases (On the Podium, Touched the
-                    // Throne, Kingslayer) carry a best-ever rank shown here.
+                    // Throne, Kingslayer) carry a best-ever rank shown here, and
+                    // Group Play Star its best "N of M" group play.
                     <div className="mt-2 text-xs text-secondary-text/70">
                       {data.earned > 0 ? `Earned ${data.earned} time${data.earned > 1 ? "s" : ""}` : "No progress yet"}
                       {data.best !== undefined && data.best > 0 && (
-                        <span className="ml-2">Best: {formatBestValue(type, data.best)}</span>
+                        <span className="ml-2">
+                          Best: {formatBestValue(type, data.best)}
+                          {"bestOutOf" in data && data.bestOutOf !== undefined && <> of {fmtNum(data.bestOutOf)}</>}
+                          {"bestOpponent" in data && data.bestOpponent && (
+                            <> ({context.playerName(data.bestOpponent)})</>
+                          )}
+                        </span>
                       )}
                     </div>
                   )}

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -299,8 +299,8 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
     icon: "🛑",
   },
   "group-stage-star": {
-    title: "Group Stage Star",
-    description: "Go undefeated in a tournament group stage",
+    title: "Group Play Star",
+    description: "Go undefeated in a tournament's group play",
     icon: "⭐",
   },
   "full-house": {
@@ -737,6 +737,18 @@ type ProgressTabProps = {
   playerId: string;
 };
 
+// Achievement types whose "best" is a leaderboard rank — lower is better,
+// shown as "#N".
+const RANK_BEST_TYPES = new Set(["on-the-podium", "touched-the-throne", "kingslayer"]);
+
+// Renders a progression's best-ever value in the unit the chase is measured
+// in: ranks as "#N", the duration chases as days, everything else as a count.
+function formatBestValue(type: string, best: number): string {
+  if (RANK_BEST_TYPES.has(type)) return `#${fmtNum(best)}`;
+  if (type.startsWith("active-") || type.startsWith("back-after-")) return formatTimePeriod(best);
+  return fmtNum(best) ?? "";
+}
+
 type ProgressSort = "default" | "progress-desc" | "progress-asc";
 const progressSortOptions: { value: ProgressSort; label: string }[] = [
   { value: "default", label: "Default" },
@@ -912,6 +924,14 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                                   )
                                 </span>
                               )}
+                            {/* The player's best-ever value, for chases whose
+                                progress resets or decays — how close they have
+                                ever come, next to where they stand now. */}
+                            {data.best !== undefined && data.best > 0 && (
+                              <span className="text-xs text-secondary-text/70 font-normal ml-2">
+                                Best: {formatBestValue(type, data.best)}
+                              </span>
+                            )}
                           </span>
                         </div>
                       </div>
@@ -1148,18 +1168,12 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                         </div>
                       )}
 
-                      {/* Record holder and personal best for the Hero of the
-                          Day / Week / Month records. The bar tracks the current
-                          period's games, so the player's busiest period ever is
-                          spelt out separately. */}
+                      {/* Record holder for the Hero of the Day / Week / Month
+                          records. The bar tracks the current period's games;
+                          the player's busiest period ever is the shared
+                          "Best" value next to the progress numbers. */}
                       {type in HERO_RECORD_PERIODS && "recordHolder" in data && (
                         <div className="mt-2 text-xs text-secondary-text/70 space-y-1">
-                          {"personalBest" in data && (
-                            <p>
-                              Your busiest {HERO_RECORD_PERIODS[type].noun} ever: {data.personalBest} game
-                              {data.personalBest !== 1 ? "s" : ""}
-                            </p>
-                          )}
                           <p>
                             {data.recordHolder ? (
                               <>
@@ -1181,18 +1195,12 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                         </div>
                       )}
 
-                      {/* Record holder and personal best for the streak records.
-                          The bar tracks the live streak, so the player's longest
-                          ever run is spelt out separately. */}
+                      {/* Record holder for the streak records. The bar tracks
+                          the live streak; the player's longest ever run is the
+                          shared "Best" value next to the progress numbers. */}
                       {(type === "longest-win-streak" || type === "longest-lose-streak") &&
                         "recordHolder" in data && (
                           <div className="mt-2 text-xs text-secondary-text/70 space-y-1">
-                            {"personalBest" in data && (
-                              <p>
-                                Your longest ever: {data.personalBest}{" "}
-                                {type === "longest-win-streak" ? "wins" : "losses"} in a row
-                              </p>
-                            )}
                             <p>
                               {data.recordHolder ? (
                                 <>
@@ -1264,9 +1272,14 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                       )}
                     </div>
                   ) : (
-                    // Fallback for achievements without targets (like tournament achievements)
+                    // Fallback for achievements without targets (like tournament
+                    // achievements). The rank chases (On the Podium, Touched the
+                    // Throne, Kingslayer) carry a best-ever rank shown here.
                     <div className="mt-2 text-xs text-secondary-text/70">
                       {data.earned > 0 ? `Earned ${data.earned} time${data.earned > 1 ? "s" : ""}` : "No progress yet"}
+                      {data.best !== undefined && data.best > 0 && (
+                        <span className="ml-2">Best: {formatBestValue(type, data.best)}</span>
+                      )}
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
This change adds "best" values to achievement progression tracking for achievements whose progress resets or decays. Players can now see their closest attempt alongside their current progress, helping them understand how close they have come to earning achievements.

## Key Changes

**New progression data fields:**
- Added `best` field to progression objects for achievements with resetting progress
- Tracks best-ever values across multiple categories: counts, ranks, durations, and scores

**Leaderboard rank tracking:**
- `bestRankEver`: Records the lowest rank each player has held (gated at ≥5 ranked players, matching award requirements)
- `bestBeatenRank`: Tracks the best rank of opponents beaten, for Kingslayer progression
- `bestClimb`: Records the largest climb above a player's all-time low for Climber progression

**Progress-resetting achievements:**
- Win/lose streaks: `best` shows longest ever run (replaces `personalBest`)
- Perfect Day/Week: `best` shows closest undefeated attempt
- Hat Trick: `best` shows most wins in any 90-minute window (sliding window algorithm)
- Best Friends: `best` shows most games with one opponent in any 1-year window
- Domination/Humiliation streaks: `best` shows highest streak against any opponent
- Activity streaks (Regular/Dedicated/Veteran): `best` shows longest activity period
- Absence streaks (Welcome Back/Long Time No See/Cinderella Story): `best` shows longest gap
- Hero of the Day/Week/Month: `best` shows busiest period (replaces `personalBest`)
- Group Play Star: `best` shows most wins in one tournament's group play

**UI updates:**
- Added `formatBestValue()` function to display best values in appropriate units (ranks as "#N", durations as days, counts as numbers)
- Updated Progress tab to show best values next to current progress
- Removed separate display of `personalBest` for streak and hero records; now uses unified `best` field
- Removed rank-specific achievement display logic for On the Podium, Touched the Throne, and Kingslayer (now shown via best value)

**Terminology:**
- Renamed "Group Stage Star" to "Group Play Star" throughout for consistency with tournament terminology

**Tests:**
- Added tests for best-ever rank tracking with ≥5 player gate
- Added tests for Hat Trick best-ever window calculation
- Added tests for Perfect Day/Week best undefeated attempts
- Added tests for Kingslayer best-beaten-rank progression
- Updated existing tests to expect `best` field instead of `personalBest`

**Changelog:**
- Added post documenting the new best-value feature with examples across all achievement categories

https://claude.ai/code/session_011c43BcK7GVwhcSsVi5aLC3