### PR TITLE
Add automatic refresh on new deployments

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,6 +56,7 @@ import { ChangelogPostPage } from "./pages/changelog/changelog-post-page";
 import { ComparePage } from "./pages/compare/compare-page";
 import { OtherPage } from "./pages/other/other-page";
 import { NotFoundPage } from "./pages/not-found-page";
+import { NewVersionChecker } from "./wrappers/new-version-checker";
 
 const RequireAuth: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   if (!session.isAuthenticated) {
@@ -78,6 +79,7 @@ function App() {
           {clientConfig.snow && <Snowfall radius={[0.2, 1]} speed={[0.1, 0.3]} wind={[0, 1]} />}
           <div className="min-h-screen w-full overflow-auto">
             <HelmetSetter />
+            <NewVersionChecker />
               <EventDbWrapper>
                 <WebSocketRefetcher>
                   <BrowserRouter>

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -56,7 +56,7 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
         "The Later choice protects your work. Use it when you track a game or fill in a form. The popup returns after 30 minutes.",
       ),
       text(
-        "The TV overlay for live games refreshes immediately, without a popup. Detection compares the file name of the deployed script bundle with the running one, so it needs no server support.",
+        "Detection compares the file name of the deployed script bundle with the running one, so it needs no server support.",
       ),
     ],
   },

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -42,6 +42,25 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "auto-refresh-on-new-deployments",
+    title: "Automatic refresh on new deployments",
+    date: "2026-08-06",
+    tags: ["new-feature", "technical"],
+    summary:
+      "The app detects a new deployment and shows a popup. You can refresh now or wait. Without an answer, the page refreshes after 1 minute.",
+    body: [
+      text(
+        "The app checks for a new deployment every 5 minutes, and when you return to the tab. When it finds one, a popup shows 2 choices: Refresh now, or Later. If you do not answer in 1 minute, the page refreshes automatically.",
+      ),
+      text(
+        "The Later choice protects your work. Use it when you track a game or fill in a form. The popup returns after 30 minutes.",
+      ),
+      text(
+        "The TV overlay for live games refreshes immediately, without a popup. Detection compares the file name of the deployed script bundle with the running one, so it needs no server support.",
+      ),
+    ],
+  },
+  {
     slug: "achievement-progress-best-values",
     title: "Best values on achievement progress",
     date: "2026-08-05",

--- a/frontend/src/common/reload-page.ts
+++ b/frontend/src/common/reload-page.ts
@@ -1,0 +1,7 @@
+/**
+ * Wrapper around window.location.reload so components that trigger a reload
+ * can be unit tested (jsdom does not allow mocking window.location directly).
+ */
+export function reloadPage(): void {
+  window.location.reload();
+}

--- a/frontend/src/wrappers/__tests__/new-version-checker.test.tsx
+++ b/frontend/src/wrappers/__tests__/new-version-checker.test.tsx
@@ -65,7 +65,6 @@ describe("NewVersionChecker", () => {
   beforeEach(() => {
     jest.useFakeTimers();
     reloadPageMock.mockClear();
-    window.history.pushState({}, "", "/leader-board");
   });
 
   afterEach(() => {
@@ -155,18 +154,6 @@ describe("NewVersionChecker", () => {
 
     // The countdown restarts after the snooze
     await advanceTime(AUTO_REFRESH_AFTER_SECONDS * ONE_SECOND);
-    expect(reloadPageMock).toHaveBeenCalled();
-  });
-
-  it("refreshes immediately without a popup on the live game TV overlay", async () => {
-    window.history.pushState({}, "", "/live-game/overlay");
-    scriptTag = addRunningBundleScript();
-    mockFetchReturning(NEW_BUNDLE);
-    render(<NewVersionChecker />);
-
-    await advanceTime(CHECK_INTERVAL_MS);
-
-    expect(screen.queryByText(/new version available/i)).not.toBeInTheDocument();
     expect(reloadPageMock).toHaveBeenCalled();
   });
 });

--- a/frontend/src/wrappers/__tests__/new-version-checker.test.tsx
+++ b/frontend/src/wrappers/__tests__/new-version-checker.test.tsx
@@ -1,0 +1,172 @@
+import "@testing-library/jest-dom";
+import { act, render, screen } from "@testing-library/react";
+import {
+  AUTO_REFRESH_AFTER_SECONDS,
+  CHECK_INTERVAL_MS,
+  extractMainBundle,
+  NewVersionChecker,
+  SNOOZE_MS,
+} from "../new-version-checker";
+import { reloadPage } from "../../common/reload-page";
+import { ONE_SECOND } from "../../common/time-in-ms";
+
+jest.mock("../../common/reload-page", () => ({
+  reloadPage: jest.fn(),
+}));
+
+const reloadPageMock = reloadPage as jest.Mock;
+
+const RUNNING_BUNDLE = "static/js/main.abc12345.js";
+const NEW_BUNDLE = "static/js/main.def67890.js";
+
+function indexHtmlWith(bundle: string): string {
+  return `<!DOCTYPE html><html><head></head><body><script defer src="/${bundle}"></script></body></html>`;
+}
+
+function mockFetchReturning(bundle: string) {
+  const fetchMock = jest.fn().mockResolvedValue({
+    ok: true,
+    text: () => Promise.resolve(indexHtmlWith(bundle)),
+  });
+  global.fetch = fetchMock as unknown as typeof fetch;
+  return fetchMock;
+}
+
+function addRunningBundleScript() {
+  const script = document.createElement("script");
+  script.src = `/${RUNNING_BUNDLE}`;
+  document.body.appendChild(script);
+  return script;
+}
+
+async function advanceTime(ms: number) {
+  await act(async () => {
+    jest.advanceTimersByTime(ms);
+  });
+}
+
+describe("extractMainBundle", () => {
+  it("finds the hashed main bundle path in html", () => {
+    expect(extractMainBundle(indexHtmlWith(RUNNING_BUNDLE))).toBe(RUNNING_BUNDLE);
+  });
+
+  it("finds the bundle path in an absolute script url", () => {
+    expect(extractMainBundle(`https://example.com/${RUNNING_BUNDLE}`)).toBe(RUNNING_BUNDLE);
+  });
+
+  it("returns undefined when there is no hashed main bundle (dev server)", () => {
+    expect(extractMainBundle('<script src="/static/js/bundle.js"></script>')).toBeUndefined();
+  });
+});
+
+describe("NewVersionChecker", () => {
+  let scriptTag: HTMLScriptElement | undefined;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    reloadPageMock.mockClear();
+    window.history.pushState({}, "", "/leader-board");
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    scriptTag?.remove();
+    scriptTag = undefined;
+  });
+
+  it("does nothing when no hashed bundle is running (dev server)", async () => {
+    const fetchMock = mockFetchReturning(NEW_BUNDLE);
+    render(<NewVersionChecker />);
+
+    await advanceTime(CHECK_INTERVAL_MS * 2);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(screen.queryByText(/new version available/i)).not.toBeInTheDocument();
+  });
+
+  it("shows no popup while the deployed bundle matches the running bundle", async () => {
+    scriptTag = addRunningBundleScript();
+    const fetchMock = mockFetchReturning(RUNNING_BUNDLE);
+    render(<NewVersionChecker />);
+
+    await advanceTime(CHECK_INTERVAL_MS);
+
+    expect(fetchMock).toHaveBeenCalled();
+    expect(screen.queryByText(/new version available/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the popup when a new deployment is detected", async () => {
+    scriptTag = addRunningBundleScript();
+    mockFetchReturning(NEW_BUNDLE);
+    render(<NewVersionChecker />);
+
+    await advanceTime(CHECK_INTERVAL_MS);
+
+    expect(screen.getByText(/new version available/i)).toBeInTheDocument();
+    expect(reloadPageMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes when 'Refresh now' is clicked", async () => {
+    scriptTag = addRunningBundleScript();
+    mockFetchReturning(NEW_BUNDLE);
+    render(<NewVersionChecker />);
+
+    await advanceTime(CHECK_INTERVAL_MS);
+    await act(async () => {
+      screen.getByRole("button", { name: /refresh now/i }).click();
+    });
+
+    expect(reloadPageMock).toHaveBeenCalled();
+  });
+
+  it("refreshes automatically when the popup is not addressed within 1 minute", async () => {
+    scriptTag = addRunningBundleScript();
+    mockFetchReturning(NEW_BUNDLE);
+    render(<NewVersionChecker />);
+
+    await advanceTime(CHECK_INTERVAL_MS);
+    expect(screen.getByText(/new version available/i)).toBeInTheDocument();
+
+    await advanceTime((AUTO_REFRESH_AFTER_SECONDS - 1) * ONE_SECOND);
+    expect(reloadPageMock).not.toHaveBeenCalled();
+
+    await advanceTime(ONE_SECOND);
+    expect(reloadPageMock).toHaveBeenCalled();
+  });
+
+  it("snoozes on 'Later' and shows the popup again after the snooze period", async () => {
+    scriptTag = addRunningBundleScript();
+    mockFetchReturning(NEW_BUNDLE);
+    render(<NewVersionChecker />);
+
+    await advanceTime(CHECK_INTERVAL_MS);
+    await act(async () => {
+      screen.getByRole("button", { name: /later/i }).click();
+    });
+
+    expect(screen.queryByText(/new version available/i)).not.toBeInTheDocument();
+
+    // No auto refresh while snoozed
+    await advanceTime(AUTO_REFRESH_AFTER_SECONDS * 2 * ONE_SECOND);
+    expect(reloadPageMock).not.toHaveBeenCalled();
+
+    await advanceTime(SNOOZE_MS);
+    expect(screen.getByText(/new version available/i)).toBeInTheDocument();
+
+    // The countdown restarts after the snooze
+    await advanceTime(AUTO_REFRESH_AFTER_SECONDS * ONE_SECOND);
+    expect(reloadPageMock).toHaveBeenCalled();
+  });
+
+  it("refreshes immediately without a popup on the live game TV overlay", async () => {
+    window.history.pushState({}, "", "/live-game/overlay");
+    scriptTag = addRunningBundleScript();
+    mockFetchReturning(NEW_BUNDLE);
+    render(<NewVersionChecker />);
+
+    await advanceTime(CHECK_INTERVAL_MS);
+
+    expect(screen.queryByText(/new version available/i)).not.toBeInTheDocument();
+    expect(reloadPageMock).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/wrappers/new-version-checker.tsx
+++ b/frontend/src/wrappers/new-version-checker.tsx
@@ -14,9 +14,6 @@ import { reloadPage } from "../common/reload-page";
  * state like game tracking or form input), a popup offers "Refresh now" or
  * "Later". If the popup is not addressed within 1 minute, the page refreshes
  * automatically. "Later" snoozes the popup for 30 minutes.
- *
- * Exception: the live game TV overlay is unattended, so it refreshes
- * immediately without a popup.
  */
 
 export const CHECK_INTERVAL_MS = 5 * ONE_MINUTE;
@@ -71,11 +68,6 @@ export const NewVersionChecker: React.FC = () => {
       if (!deployedBundle || deployedBundle === runningBundle) return;
 
       newVersionFoundRef.current = true;
-      if (window.location.pathname === "/live-game/overlay") {
-        // The TV overlay is unattended, so there is no state to lose.
-        reloadPage();
-        return;
-      }
       setSecondsLeft(AUTO_REFRESH_AFTER_SECONDS);
       setShowPopup(true);
     }

--- a/frontend/src/wrappers/new-version-checker.tsx
+++ b/frontend/src/wrappers/new-version-checker.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useRef, useState } from "react";
+import { ONE_MINUTE, ONE_SECOND } from "../common/time-in-ms";
+import { reloadPage } from "../common/reload-page";
+
+/**
+ * Detects when a new frontend deployment has happened and refreshes the page.
+ *
+ * How: the production build emits a content-hashed bundle (static/js/main.<hash>.js)
+ * referenced from index.html. We periodically re-fetch index.html (bypassing the
+ * cache) and compare the deployed bundle path with the one currently running.
+ * A mismatch means a new version has been deployed.
+ *
+ * Safeguard: instead of refreshing immediately (which would lose in-progress
+ * state like game tracking or form input), a popup offers "Refresh now" or
+ * "Later". If the popup is not addressed within 1 minute, the page refreshes
+ * automatically. "Later" snoozes the popup for 30 minutes.
+ *
+ * Exception: the live game TV overlay is unattended, so it refreshes
+ * immediately without a popup.
+ */
+
+export const CHECK_INTERVAL_MS = 5 * ONE_MINUTE;
+export const AUTO_REFRESH_AFTER_SECONDS = 60;
+export const SNOOZE_MS = 30 * ONE_MINUTE;
+const MIN_TIME_BETWEEN_CHECKS_MS = ONE_MINUTE;
+
+const MAIN_BUNDLE_PATTERN = /static\/js\/main\.[^"'\s]+\.js/;
+
+export function extractMainBundle(html: string): string | undefined {
+  return html.match(MAIN_BUNDLE_PATTERN)?.[0];
+}
+
+/** The bundle this page is currently running. Undefined on the dev server (unhashed bundle). */
+function getRunningBundle(): string | undefined {
+  const scripts = Array.from(document.querySelectorAll("script"));
+  for (const script of scripts) {
+    const match = extractMainBundle(script.src);
+    if (match) return match;
+  }
+  return undefined;
+}
+
+async function fetchDeployedBundle(): Promise<string | undefined> {
+  try {
+    const response = await fetch("/index.html", { cache: "no-store" });
+    if (!response.ok) return undefined;
+    return extractMainBundle(await response.text());
+  } catch {
+    return undefined;
+  }
+}
+
+export const NewVersionChecker: React.FC = () => {
+  const [showPopup, setShowPopup] = useState(false);
+  const [secondsLeft, setSecondsLeft] = useState(AUTO_REFRESH_AFTER_SECONDS);
+  const newVersionFoundRef = useRef(false);
+  const lastCheckStartedRef = useRef(0);
+  const snoozeTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    const runningBundle = getRunningBundle();
+    if (!runningBundle) return;
+
+    let cancelled = false;
+
+    async function check() {
+      if (newVersionFoundRef.current) return;
+      lastCheckStartedRef.current = Date.now();
+      const deployedBundle = await fetchDeployedBundle();
+      if (cancelled || newVersionFoundRef.current) return;
+      if (!deployedBundle || deployedBundle === runningBundle) return;
+
+      newVersionFoundRef.current = true;
+      if (window.location.pathname === "/live-game/overlay") {
+        // The TV overlay is unattended, so there is no state to lose.
+        reloadPage();
+        return;
+      }
+      setSecondsLeft(AUTO_REFRESH_AFTER_SECONDS);
+      setShowPopup(true);
+    }
+
+    const interval = setInterval(check, CHECK_INTERVAL_MS);
+
+    function onVisibilityChange() {
+      if (document.visibilityState !== "visible") return;
+      if (Date.now() - lastCheckStartedRef.current < MIN_TIME_BETWEEN_CHECKS_MS) return;
+      check();
+    }
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      clearTimeout(snoozeTimeoutRef.current);
+    };
+  }, []);
+
+  // Count down while the popup is open, refresh when it reaches 0
+  useEffect(() => {
+    if (!showPopup) return;
+    const interval = setInterval(() => setSecondsLeft((seconds) => seconds - 1), ONE_SECOND);
+    return () => clearInterval(interval);
+  }, [showPopup]);
+
+  useEffect(() => {
+    if (showPopup && secondsLeft <= 0) {
+      reloadPage();
+    }
+  }, [showPopup, secondsLeft]);
+
+  function snooze() {
+    setShowPopup(false);
+    clearTimeout(snoozeTimeoutRef.current);
+    snoozeTimeoutRef.current = setTimeout(() => {
+      setSecondsLeft(AUTO_REFRESH_AFTER_SECONDS);
+      setShowPopup(true);
+    }, SNOOZE_MS);
+  }
+
+  if (!showPopup) return null;
+
+  return (
+    <div className="fixed bottom-4 left-4 right-4 z-[60] sm:left-auto sm:w-96">
+      <div className="flex flex-col gap-3 rounded-lg bg-secondary-background text-secondary-text p-4 shadow-lg ring-1 ring-primary-text/20">
+        <div>
+          <p className="font-semibold">New version available 🏓</p>
+          <p className="mt-1 text-sm">
+            A new version of the app has been deployed. The page refreshes automatically in {Math.max(0, secondsLeft)}{" "}
+            seconds.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={reloadPage}
+            className="flex-1 rounded-lg bg-primary-background px-4 py-2 font-semibold text-primary-text hover:bg-primary-background/70"
+          >
+            Refresh now
+          </button>
+          <button
+            onClick={snooze}
+            className="flex-1 rounded-lg bg-tertiary-background px-4 py-2 text-tertiary-text hover:bg-tertiary-background/70"
+          >
+            Later
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
Adds a `NewVersionChecker` component that detects when a new frontend deployment has occurred and prompts the user to refresh the page. The detection works by periodically comparing the content-hashed bundle filename in the deployed `index.html` with the currently running bundle.

## Changes
- **New component:** `NewVersionChecker` in `frontend/src/wrappers/new-version-checker.tsx`
  - Checks for new deployments every 5 minutes and when the tab becomes visible
  - Shows a popup when a new version is detected with two options: "Refresh now" or "Later"
  - Auto-refreshes after 60 seconds if the popup is not addressed
  - "Later" snoozes the popup for 30 minutes before showing it again
  - Includes `extractMainBundle()` utility to parse the hashed bundle filename from HTML

- **New utility:** `reloadPage()` in `frontend/src/common/reload-page.ts`
  - Wrapper around `window.location.reload()` to enable testing of reload behavior

- **Comprehensive test suite:** `frontend/src/wrappers/__tests__/new-version-checker.test.tsx`
  - Tests bundle extraction, detection logic, popup behavior, auto-refresh, and snooze functionality
  - Uses fake timers to verify timing-dependent behavior

- **Integration:** Added `NewVersionChecker` to `App.tsx` root component

- **Changelog entry:** Added post documenting the feature for users

## Implementation Details
- Detection requires a content-hashed bundle (production builds only; skipped on dev server)
- Uses `cache: "no-store"` when fetching `index.html` to bypass browser cache
- Includes debouncing to avoid excessive checks when the tab regains visibility
- Countdown timer updates every second while popup is visible
- Snooze state is tracked separately to prevent auto-refresh during snooze period

https://claude.ai/code/session_01MFUy2TpYzKkWjb8Aq64MvT