### PR TITLE
Show only the duration on timeline rows

### DIFF
--- a/frontend/src/pages/tournament/stats/timeline-widget.tsx
+++ b/frontend/src/pages/tournament/stats/timeline-widget.tsx
@@ -19,8 +19,6 @@ type Row = {
   started: boolean;
   /** Undefined while the row still has games left to play */
   end?: number;
-  gamesPlayed: number;
-  gamesTotal: number;
 };
 
 /**
@@ -85,8 +83,6 @@ export const TournamentTimelineWidget: React.FC<{ tournament: Tournament }> = ({
       start: section.start,
       started: section.started,
       end: section.completed ? section.lastGameAt : undefined,
-      gamesPlayed: section.gamesPlayed,
-      gamesTotal: section.gamesTotal,
     });
     // A single sub section would just repeat its section
     if (section.subSections.length <= 1) continue;
@@ -98,8 +94,6 @@ export const TournamentTimelineWidget: React.FC<{ tournament: Tournament }> = ({
         start: sub.start,
         started: sub.started,
         end: sub.completed ? sub.lastGameAt : undefined,
-        gamesPlayed: sub.gamesPlayed,
-        gamesTotal: sub.gamesTotal,
       });
     }
   }
@@ -215,9 +209,6 @@ const TimelineRow: React.FC<{
           )}
         >
           {notStarted ? "not started" : formatDays(days)}
-        </p>
-        <p className="text-[0.65rem] font-light">
-          {fmtNum(row.gamesPlayed)}/{fmtNum(row.gamesTotal)} games
         </p>
       </div>
 


### PR DESCRIPTION
Each timeline row had a second line under the duration with its games count, e.g. "3/4 games". Dropping it leaves a single line of days per row and saves vertical space. The widget header keeps the tournament-wide "N of M games played" total.

The per-row `gamesPlayed`/`gamesTotal` fields had no remaining use in the widget, so they are removed from its `Row` type as well.

Follow-up to #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdC84GFGvj9qC1jgRSgcFd

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdC84GFGvj9qC1jgRSgcFd)_