### PR TITLE
Add Reunion achievement for playing an opponent again after a year

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -42,6 +42,25 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "reunion-achievement",
+    title: "New achievement: Reunion 🫂",
+    date: "2026-08-07",
+    tags: ["feature-update"],
+    summary:
+      "Reunion 🫂 is a new achievement. Play a game against an opponent when your previous game against each other was 1 year or more ago.",
+    body: [
+      text(
+        "The app measures the gap for each pair of players. Games against other opponents do not reset the gap. Both players in the reunion game earn the achievement. The result of the game does not matter.",
+      ),
+      text(
+        "You can earn the achievement many times. A new gap of 1 year or more with the same opponent earns it again. Each other opponent has an independent gap.",
+      ),
+      text(
+        "The Progress tab on the player page shows your longest open gap against an active player, and names that opponent. Play that opponent to earn the achievement when the gap is 1 year or more.",
+      ),
+    ],
+  },
+  {
     slug: "sweet-revenge-achievement",
     title: "New achievement: Sweet Revenge 😈",
     date: "2026-08-06",

--- a/frontend/src/client/client-db/__tests__/achievements/reunion.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/reunion.test.ts
@@ -1,0 +1,218 @@
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { TennisTable } from "../../tennis-table";
+
+describe("TennisTable", () => {
+  describe("Reunion", () => {
+    const ONE_DAY = 24 * 60 * 60 * 1000;
+    const ONE_YEAR = 365 * ONE_DAY;
+    const T0 = 1_500_000_000_000; // fixed base time, well in the past
+
+    const baseEvents = (): EventType[] => [
+      { type: EventTypeEnum.PLAYER_CREATED, stream: "alice", time: 1, data: { name: "Alice" } },
+      { type: EventTypeEnum.PLAYER_CREATED, stream: "bob", time: 2, data: { name: "Bob" } },
+      { type: EventTypeEnum.PLAYER_CREATED, stream: "carol", time: 3, data: { name: "Carol" } },
+    ];
+
+    const game = (id: string, playedAt: number, winner = "alice", loser = "bob"): EventType => ({
+      type: EventTypeEnum.GAME_CREATED,
+      stream: id,
+      time: playedAt,
+      data: { winner, loser, playedAt },
+    });
+
+    function reunionsFor(events: EventType[], playerId: string) {
+      const tt = new TennisTable({ events });
+      tt.achievements.calculateAchievements();
+      return tt.achievements.getAchievements(playerId).filter((a) => a.type === "reunion");
+    }
+
+    it("awards both players when the pair's previous game was exactly one year ago", () => {
+      const events = [...baseEvents(), game("g0", T0), game("g1", T0 + ONE_YEAR)];
+
+      for (const [player, opponent] of [
+        ["alice", "bob"],
+        ["bob", "alice"],
+      ]) {
+        const earned = reunionsFor(events, player);
+        expect(earned).toHaveLength(1);
+        expect(earned[0]).toStrictEqual({
+          type: "reunion",
+          earnedBy: player,
+          earnedAt: T0 + ONE_YEAR,
+          data: { gameId: "g1", opponent, lastGameAt: T0 },
+        });
+      }
+    });
+
+    it("does not award when the gap is just short of one year", () => {
+      const events = [...baseEvents(), game("g0", T0), game("g1", T0 + ONE_YEAR - 1)];
+      expect(reunionsFor(events, "alice")).toHaveLength(0);
+      expect(reunionsFor(events, "bob")).toHaveLength(0);
+    });
+
+    it("does not award on a pair's first ever game", () => {
+      const events = [...baseEvents(), game("g0", T0)];
+      expect(reunionsFor(events, "alice")).toHaveLength(0);
+      expect(reunionsFor(events, "bob")).toHaveLength(0);
+    });
+
+    it("measures the gap per opponent pair — games against others in between do not reset it", () => {
+      // Alice plays Bob once, then plays Carol every month for a year, then
+      // plays Bob again. Alice was active the whole time, but the Alice–Bob
+      // gap still spans the full year.
+      const events = [...baseEvents(), game("g0", T0, "alice", "bob")];
+      for (let month = 1; month <= 11; month++) {
+        events.push(game(`gc${month}`, T0 + month * 30 * ONE_DAY, "alice", "carol"));
+      }
+      events.push(game("g1", T0 + ONE_YEAR, "alice", "bob"));
+
+      const earned = reunionsFor(events, "alice");
+      expect(earned).toHaveLength(1);
+      expect(earned[0].data).toStrictEqual({ gameId: "g1", opponent: "bob", lastGameAt: T0 });
+      // Bob earns it too — the gap belongs to the pair.
+      expect(reunionsFor(events, "bob")).toHaveLength(1);
+    });
+
+    it("measures the gap from the pair's most recent game, not their first", () => {
+      // Games at T0 and T0 + 6 months; a game a year after T0 is only 6
+      // months after the pair's latest game, so no reunion.
+      const events = [
+        ...baseEvents(),
+        game("g0", T0),
+        game("g1", T0 + 182 * ONE_DAY),
+        game("g2", T0 + ONE_YEAR),
+      ];
+      expect(reunionsFor(events, "alice")).toHaveLength(0);
+    });
+
+    it("win or lose does not matter — the returning loser earns it too", () => {
+      const events = [...baseEvents(), game("g0", T0, "alice", "bob"), game("g1", T0 + ONE_YEAR, "bob", "alice")];
+      expect(reunionsFor(events, "alice")).toHaveLength(1);
+      expect(reunionsFor(events, "bob")).toHaveLength(1);
+    });
+
+    it("only the game that closes the gap awards — an immediate rematch does not", () => {
+      const events = [
+        ...baseEvents(),
+        game("g0", T0),
+        game("g1", T0 + ONE_YEAR),
+        game("g2", T0 + ONE_YEAR + 1000), // rematch minutes later
+      ];
+      const earned = reunionsFor(events, "alice");
+      expect(earned).toHaveLength(1);
+      expect(earned[0].data.gameId).toBe("g1");
+    });
+
+    it("can be earned again with the same opponent after another year-long gap", () => {
+      const events = [
+        ...baseEvents(),
+        game("g0", T0),
+        game("g1", T0 + ONE_YEAR),
+        game("g2", T0 + 2 * ONE_YEAR + ONE_DAY),
+      ];
+      const earned = reunionsFor(events, "alice").sort((a, b) => a.earnedAt - b.earnedAt);
+      expect(earned).toHaveLength(2);
+      expect(earned.map((a) => a.data.gameId)).toStrictEqual(["g1", "g2"]);
+    });
+
+    it("can be earned with several opponents independently", () => {
+      const events = [
+        ...baseEvents(),
+        game("g0", T0, "alice", "bob"),
+        game("g1", T0 + ONE_DAY, "alice", "carol"),
+        game("g2", T0 + ONE_YEAR, "alice", "bob"),
+        game("g3", T0 + ONE_YEAR + ONE_DAY, "alice", "carol"),
+      ];
+      const earned = reunionsFor(events, "alice").sort((a, b) => a.earnedAt - b.earnedAt);
+      expect(earned).toHaveLength(2);
+      expect(earned.map((a) => a.data.opponent)).toStrictEqual(["bob", "carol"]);
+    });
+
+    it("awards a gap far beyond one year once — there are no higher tiers", () => {
+      const events = [...baseEvents(), game("g0", T0), game("g1", T0 + 3 * ONE_YEAR)];
+      const earned = reunionsFor(events, "alice");
+      expect(earned).toHaveLength(1);
+      expect(earned[0].data.lastGameAt).toBe(T0);
+    });
+
+    // --- Progression --------------------------------------------------------
+
+    function progressionFor(events: EventType[], playerId = "alice") {
+      const tt = new TennisTable({ events });
+      tt.achievements.calculateAchievements();
+      return tt.achievements.getPlayerProgression(playerId).reunion;
+    }
+
+    it("tracks the longest open gap against an active opponent", () => {
+      const lastBobGame = Date.now() - 100 * ONE_DAY;
+      const events = [
+        ...baseEvents(),
+        game("g0", lastBobGame, "alice", "bob"),
+        game("g1", Date.now() - 10 * ONE_DAY, "alice", "carol"),
+      ];
+      const progression = progressionFor(events);
+
+      expect(progression.earned).toBe(0);
+      expect(progression.target).toBe(ONE_YEAR);
+      expect(progression.current).toBeGreaterThan(99 * ONE_DAY);
+      expect(progression.current).toBeLessThan(101 * ONE_DAY);
+      expect(progression.gapOpponent).toBe("bob");
+      expect(progression.gapLastGameAt).toBe(lastBobGame);
+      // The open gap is also the player's best so far.
+      expect(progression.best).toBe(progression.current);
+      expect(progression.bestOpponent).toBe("bob");
+    });
+
+    it("ignores open gaps against deactivated opponents", () => {
+      const events = [
+        ...baseEvents(),
+        game("g0", Date.now() - 100 * ONE_DAY, "alice", "bob"),
+        game("g1", Date.now() - 10 * ONE_DAY, "alice", "carol"),
+        {
+          type: EventTypeEnum.PLAYER_DEACTIVATED,
+          stream: "bob",
+          time: Date.now() - 5 * ONE_DAY,
+          data: null,
+        } as EventType,
+      ];
+      const progression = progressionFor(events);
+
+      // Bob is retired, so the chase points at Carol's 10-day gap instead.
+      expect(progression.current).toBeGreaterThan(9 * ONE_DAY);
+      expect(progression.current).toBeLessThan(11 * ONE_DAY);
+      expect(progression.gapOpponent).toBe("carol");
+    });
+
+    it("keeps the longest closed gap as the best value", () => {
+      // A 200-day gap closed long ago; every open gap now is shorter.
+      const events = [
+        ...baseEvents(),
+        game("g0", Date.now() - 250 * ONE_DAY, "alice", "bob"),
+        game("g1", Date.now() - 50 * ONE_DAY, "alice", "bob"),
+        game("g2", Date.now() - ONE_DAY, "alice", "bob"),
+      ];
+      const progression = progressionFor(events);
+
+      expect(progression.best).toBe(200 * ONE_DAY);
+      expect(progression.bestOpponent).toBe("bob");
+    });
+
+    it("counts each earn in the progression earned field", () => {
+      const events = [
+        ...baseEvents(),
+        game("g0", T0),
+        game("g1", T0 + ONE_YEAR),
+        game("g2", T0 + 2 * ONE_YEAR + ONE_DAY),
+      ];
+      expect(progressionFor(events).earned).toBe(2);
+    });
+
+    it("has no progress before the player has any opponent history", () => {
+      const progression = progressionFor([...baseEvents()]);
+      expect(progression.current).toBe(0);
+      expect(progression.earned).toBe(0);
+      expect(progression.gapOpponent).toBeUndefined();
+      expect(progression.best).toBeUndefined();
+    });
+  });
+});

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -232,7 +232,7 @@ export class Achievements {
         edgeLordCount: number;
         consistencyCount: number;
         opponentsPlayed: Set<string>;
-        gamesPerOpponent: Map<string, { count: number; firstGame: number }>;
+        gamesPerOpponent: Map<string, { count: number; firstGame: number; lastGame: number }>;
         firstOpponentFor: Set<string>; // Track players this person was first opponent for
         hatTrickWins: { playedAt: number }[]; // Track recent wins for hat-trick
         gamesPlayed: number; // Total games played, used for the "ranked" achievement
@@ -454,22 +454,48 @@ export class Achievements {
         );
       }
 
-      // Track games per opponent for best-friends achievement
+      // Track games per opponent for the best-friends and reunion achievements
       if (!winner.gamesPerOpponent.has(game.loser)) {
-        winner.gamesPerOpponent.set(game.loser, { count: 0, firstGame: game.playedAt });
+        winner.gamesPerOpponent.set(game.loser, { count: 0, firstGame: game.playedAt, lastGame: game.playedAt });
       }
       if (!loser.gamesPerOpponent.has(game.winner)) {
-        loser.gamesPerOpponent.set(game.winner, { count: 0, firstGame: game.playedAt });
+        loser.gamesPerOpponent.set(game.winner, { count: 0, firstGame: game.playedAt, lastGame: game.playedAt });
       }
 
       const winnerOpponentData = winner.gamesPerOpponent.get(game.loser)!;
       const loserOpponentData = loser.gamesPerOpponent.get(game.winner)!;
 
+      const ONE_YEAR = 365 * 24 * 60 * 60 * 1000;
+
+      // Check for "Reunion": the pair's previous game against each other was
+      // a year or more ago. The gap is shared, so both players earn it. Must
+      // be checked before lastGame is moved forward to this game. The two
+      // trackers mirror the same pair history, so one gap check covers both.
+      if (winnerOpponentData.count > 0 && game.playedAt - winnerOpponentData.lastGame >= ONE_YEAR) {
+        this.#addAchievement(
+          game.winner,
+          this.#createAchievement("reunion", game.winner, game.playedAt, {
+            gameId: game.id,
+            opponent: game.loser,
+            lastGameAt: winnerOpponentData.lastGame,
+          }),
+        );
+        this.#addAchievement(
+          game.loser,
+          this.#createAchievement("reunion", game.loser, game.playedAt, {
+            gameId: game.id,
+            opponent: game.winner,
+            lastGameAt: loserOpponentData.lastGame,
+          }),
+        );
+      }
+
       winnerOpponentData.count++;
+      winnerOpponentData.lastGame = game.playedAt;
       loserOpponentData.count++;
+      loserOpponentData.lastGame = game.playedAt;
 
       // Check for best-friends achievement (50 games within 1 year)
-      const ONE_YEAR = 365 * 24 * 60 * 60 * 1000;
       if (winnerOpponentData.count === 50 && game.playedAt - winnerOpponentData.firstGame <= ONE_YEAR) {
         this.#addAchievement(
           game.winner,
@@ -2659,6 +2685,7 @@ export class Achievements {
       "variety-player": { current: 0, target: 10, opponents: new Set(), earned: 0 },
       "global-player": { current: 0, target: 20, opponents: new Set(), earned: 0 },
       "best-friends": { current: 0, target: 50, perOpponent: new Map(), earned: 0 },
+      "reunion": { current: 0, target: ONE_YEAR, earned: 0 },
       "welcome-committee": { current: 0, target: 3, newPlayers: new Set(), earned: 0 },
       "community-builder": { current: 0, target: 10, newPlayers: new Set(), earned: 0 },
 
@@ -2729,6 +2756,11 @@ export class Achievements {
     const opponentsPlayed = new Set<string>();
     const gamesPerOpponent = new Map<string, { count: number; firstGame: number; lastGame: number }>();
     const firstOpponentForSet = new Set<string>();
+    // Longest gap ever between two consecutive games against the same
+    // opponent — the Reunion best. Open gaps against active opponents are
+    // folded in after the loop.
+    let bestReunionGap = 0;
+    let bestReunionGapOpponent: string | undefined = undefined;
 
     // Track first games for each player to determine who was their first opponent
     const playerFirstGames = new Map<string, { opponent: string; timestamp: number }>();
@@ -2838,11 +2870,18 @@ export class Achievements {
         opponentsPlayed.add(game.winner);
       }
 
-      // Track games per opponent for best-friends progression
+      // Track games per opponent for best-friends and reunion progression
       if (!gamesPerOpponent.has(opponent)) {
         gamesPerOpponent.set(opponent, { count: 0, firstGame: game.playedAt, lastGame: game.playedAt });
       }
       const opponentData = gamesPerOpponent.get(opponent)!;
+      // Reunion best: the gap this game closed against this opponent. A
+      // just-created entry has lastGame === playedAt, so its gap is 0.
+      const closedGap = game.playedAt - opponentData.lastGame;
+      if (closedGap > bestReunionGap) {
+        bestReunionGap = closedGap;
+        bestReunionGapOpponent = opponent;
+      }
       opponentData.count++;
       opponentData.lastGame = game.playedAt;
 
@@ -3457,6 +3496,35 @@ export class Achievements {
     progression["sweet-revenge"].target = revengesTaken + revengeMissing.size;
     progression["sweet-revenge"].missing = revengeMissing;
 
+    // Reunion progression: the longest open gap — the time since the player's
+    // last game against each opponent who is still an active player. Playing
+    // that opponent earns the award once the gap passes a year. The open gaps
+    // also compete for the best value, since any of them may already be the
+    // player's longest.
+    let longestOpenGap = 0;
+    let longestOpenGapOpponent: string | undefined = undefined;
+    let longestOpenGapLastGameAt: number | undefined = undefined;
+    gamesPerOpponent.forEach((data, opponent) => {
+      if (!activePlayerIds.has(opponent)) return;
+      const openGap = now - data.lastGame;
+      if (openGap > longestOpenGap) {
+        longestOpenGap = openGap;
+        longestOpenGapOpponent = opponent;
+        longestOpenGapLastGameAt = data.lastGame;
+      }
+      if (openGap > bestReunionGap) {
+        bestReunionGap = openGap;
+        bestReunionGapOpponent = opponent;
+      }
+    });
+    progression["reunion"].current = longestOpenGap;
+    progression["reunion"].gapOpponent = longestOpenGapOpponent;
+    progression["reunion"].gapLastGameAt = longestOpenGapLastGameAt;
+    if (bestReunionGap > 0) {
+      progression["reunion"].best = bestReunionGap;
+      progression["reunion"].bestOpponent = bestReunionGapOpponent;
+    }
+
     // Count earned achievements
     const achievements = this.getAchievements(playerId);
     achievements.forEach((achievement) => {
@@ -3519,6 +3587,10 @@ type AchievementDefinitions = {
   "variety-player": undefined;
   "global-player": undefined;
   "best-friends": { opponent: string; firstGame: number };
+  // Played an opponent again a year or more after the pair's previous game
+  // against each other. `lastGameAt` is that previous game — the far end of
+  // the gap the reunion closed.
+  "reunion": { gameId: string; opponent: string; lastGameAt: number };
   "welcome-committee": { opponents: string[] };
   "community-builder": { opponents: string[] };
   "punching-bag": { startedAt: number };
@@ -3647,6 +3719,7 @@ export const ACHIEVEMENT_IS_REACHIEVABLE: Record<AchievementType, boolean> = {
   "variety-player": false,
   "global-player": false,
   "best-friends": true, // Per opponent
+  "reunion": true, // Per year-long gap per opponent
   "welcome-committee": false,
   "community-builder": false,
   "punching-bag": true, // Per lose streak
@@ -3767,6 +3840,19 @@ type BestFriendsProgression = ProgressionWithTarget & {
 
 type WelcomeCommitteeProgression = ProgressionWithTarget & {
   newPlayers?: Set<string>; // List of new players this person was first opponent for
+};
+
+// Reunion chases the longest open gap: the time since the player's last game
+// against each opponent who is still an active player. Once the gap passes a
+// year, playing that opponent earns the award. Current and target are
+// milliseconds.
+type ReunionProgression = ProgressionWithTarget & {
+  // Who the longest open gap (the `current` value) is with, and when that
+  // pair's last game was — the opponent to play for the next reunion.
+  gapOpponent?: string;
+  gapLastGameAt?: number;
+  // Who the best-ever gap was with, shown next to the best value.
+  bestOpponent?: string;
 };
 
 // Season Opener is league-wide: every player waits for the same next season
@@ -3925,6 +4011,7 @@ export type AchievementProgression = {
   "variety-player": VarietyPlayerProgression;
   "global-player": VarietyPlayerProgression;
   "best-friends": BestFriendsProgression;
+  "reunion": ReunionProgression;
   "welcome-committee": WelcomeCommitteeProgression;
   "community-builder": WelcomeCommitteeProgression;
   "punching-bag": ProgressionWithTarget;

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -199,6 +199,11 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
     description: "Play 50 games with a single opponent within 1 year",
     icon: "💙",
   },
+  "reunion": {
+    title: "Reunion",
+    description: "Play an opponent again after a year or more since your last game together",
+    icon: "🫂",
+  },
   "welcome-committee": {
     title: "Welcome Committee",
     description: "Be the first opponent for 3 different new players",
@@ -767,7 +772,9 @@ const RANK_BEST_TYPES = new Set(["on-the-podium", "touched-the-throne", "kingsla
 // in: ranks as "#N", the duration chases as days, everything else as a count.
 function formatBestValue(type: string, best: number): string {
   if (RANK_BEST_TYPES.has(type)) return `#${fmtNum(best)}`;
-  if (type.startsWith("active-") || type.startsWith("back-after-")) return formatTimePeriod(best);
+  if (type.startsWith("active-") || type.startsWith("back-after-") || type === "reunion") {
+    return formatTimePeriod(best);
+  }
   return fmtNum(best) ?? "";
 }
 
@@ -901,7 +908,8 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
           type.startsWith("active-") ||
           type.startsWith("back-after-") ||
           type === "anniversary" ||
-          type === "season-opener";
+          type === "season-opener" ||
+          type === "reunion";
 
         return (
           <div
@@ -1003,6 +1011,22 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                           </span>
                         </div>
                       </div>
+
+                      {/* Show who the longest open gap is with for Reunion —
+                          the opponent to play for the next award. */}
+                      {type === "reunion" && "gapOpponent" in data && data.gapOpponent && (
+                        <div className="mt-2 text-xs text-secondary-text/70">
+                          Longest gap: vs{" "}
+                          <Link to={{ pathname: "/player/" + data.gapOpponent, search }}>
+                            <span className="text-secondary-text underline">
+                              {context.playerName(data.gapOpponent)}
+                            </span>
+                          </Link>
+                          {data.gapLastGameAt !== undefined && (
+                            <>, last played {dateString(data.gapLastGameAt)}</>
+                          )}
+                        </div>
+                      )}
 
                       {/* Show last active time for back-after achievements */}
                       {type.startsWith("back-after-") && "lastActiveAt" in data && data.lastActiveAt && (


### PR DESCRIPTION
Awarded to both players of a game when the pair's previous game against
each other was one year or more ago. The gap is per opponent pair, so
playing other people in between does not reset it, and it can be earned
again after each new year-long gap. The Progress tab tracks the longest
open gap against an active opponent and names who to play.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G2Cu89nxfDbYH6jTYUxSdi