### PR TITLE
Show Reunion details as a day count and compact top-5 gap list

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -56,7 +56,7 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
         "You can earn the achievement many times. A new gap of 1 year or more with the same opponent earns it again. Each other opponent has an independent gap.",
       ),
       text(
-        "The Progress tab on the player page shows your longest open gap against an active player, and names that opponent. Play that opponent to earn the achievement when the gap is 1 year or more.",
+        "The Progress tab on the player page lists your 5 longest open gaps against active players, with the number of days for each. Play one of those opponents to earn the achievement when the gap is 1 year or more.",
       ),
     ],
   },

--- a/frontend/src/client/client-db/__tests__/achievements/reunion.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/reunion.test.ts
@@ -156,8 +156,10 @@ describe("TennisTable", () => {
       expect(progression.target).toBe(ONE_YEAR);
       expect(progression.current).toBeGreaterThan(99 * ONE_DAY);
       expect(progression.current).toBeLessThan(101 * ONE_DAY);
-      expect(progression.gapOpponent).toBe("bob");
-      expect(progression.gapLastGameAt).toBe(lastBobGame);
+      // Every active opponent's open gap is listed, Bob's the longest.
+      expect(progression.perOpponent?.size).toBe(2);
+      expect(progression.perOpponent?.get("bob")).toBe(progression.current);
+      expect(progression.perOpponent?.get("carol")).toBeLessThan(11 * ONE_DAY);
       // The open gap is also the player's best so far.
       expect(progression.best).toBe(progression.current);
       expect(progression.bestOpponent).toBe("bob");
@@ -180,7 +182,8 @@ describe("TennisTable", () => {
       // Bob is retired, so the chase points at Carol's 10-day gap instead.
       expect(progression.current).toBeGreaterThan(9 * ONE_DAY);
       expect(progression.current).toBeLessThan(11 * ONE_DAY);
-      expect(progression.gapOpponent).toBe("carol");
+      expect(progression.perOpponent?.has("bob")).toBe(false);
+      expect(progression.perOpponent?.has("carol")).toBe(true);
     });
 
     it("keeps the longest closed gap as the best value", () => {
@@ -211,7 +214,7 @@ describe("TennisTable", () => {
       const progression = progressionFor([...baseEvents()]);
       expect(progression.current).toBe(0);
       expect(progression.earned).toBe(0);
-      expect(progression.gapOpponent).toBeUndefined();
+      expect(progression.perOpponent?.size).toBe(0);
       expect(progression.best).toBeUndefined();
     });
   });

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -3496,30 +3496,26 @@ export class Achievements {
     progression["sweet-revenge"].target = revengesTaken + revengeMissing.size;
     progression["sweet-revenge"].missing = revengeMissing;
 
-    // Reunion progression: the longest open gap — the time since the player's
-    // last game against each opponent who is still an active player. Playing
-    // that opponent earns the award once the gap passes a year. The open gaps
-    // also compete for the best value, since any of them may already be the
-    // player's longest.
+    // Reunion progression: the open gaps — the time since the player's last
+    // game against each opponent who is still an active player. Playing an
+    // opponent earns the award once that gap passes a year. The longest gap
+    // is the bar; the per-opponent map feeds the top-5 list in the UI. Open
+    // gaps also compete for the best value, since any of them may already be
+    // the player's longest.
+    const reunionGaps = new Map<string, number>();
     let longestOpenGap = 0;
-    let longestOpenGapOpponent: string | undefined = undefined;
-    let longestOpenGapLastGameAt: number | undefined = undefined;
     gamesPerOpponent.forEach((data, opponent) => {
       if (!activePlayerIds.has(opponent)) return;
       const openGap = now - data.lastGame;
-      if (openGap > longestOpenGap) {
-        longestOpenGap = openGap;
-        longestOpenGapOpponent = opponent;
-        longestOpenGapLastGameAt = data.lastGame;
-      }
+      reunionGaps.set(opponent, openGap);
+      longestOpenGap = Math.max(longestOpenGap, openGap);
       if (openGap > bestReunionGap) {
         bestReunionGap = openGap;
         bestReunionGapOpponent = opponent;
       }
     });
     progression["reunion"].current = longestOpenGap;
-    progression["reunion"].gapOpponent = longestOpenGapOpponent;
-    progression["reunion"].gapLastGameAt = longestOpenGapLastGameAt;
+    progression["reunion"].perOpponent = reunionGaps;
     if (bestReunionGap > 0) {
       progression["reunion"].best = bestReunionGap;
       progression["reunion"].bestOpponent = bestReunionGapOpponent;
@@ -3847,10 +3843,10 @@ type WelcomeCommitteeProgression = ProgressionWithTarget & {
 // year, playing that opponent earns the award. Current and target are
 // milliseconds.
 type ReunionProgression = ProgressionWithTarget & {
-  // Who the longest open gap (the `current` value) is with, and when that
-  // pair's last game was — the opponent to play for the next reunion.
-  gapOpponent?: string;
-  gapLastGameAt?: number;
+  // Open gap per opponent still in the league: the time since the player's
+  // last game against each of them. The UI lists the longest ones — the
+  // opponents to play for the next reunion.
+  perOpponent?: Map<string, number>;
   // Who the best-ever gap was with, shown next to the best value.
   bestOpponent?: string;
 };

--- a/frontend/src/pages/achievements/achievements-list.tsx
+++ b/frontend/src/pages/achievements/achievements-list.tsx
@@ -113,9 +113,15 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                       League game #{fmtNum(achievement.data.milestone)}
                     </span>
                   )}
-                  {achievement.data && "lastGameAt" in achievement.data && (
+                  {achievement.data && "lastGameAt" in achievement.data && achievement.type !== "reunion" && (
                     <span className="text-[11px] opacity-80">
                       {dateString(achievement.data.lastGameAt)} – {dateString(achievement.earnedAt)}
+                    </span>
+                  )}
+                  {achievement.type === "reunion" && achievement.data && (
+                    <span className="text-[11px] opacity-80">
+                      Reunited after{" "}
+                      {Math.round((achievement.earnedAt - achievement.data.lastGameAt) / (24 * 60 * 60 * 1000))} days
                     </span>
                   )}
                   {achievement.data &&

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -499,9 +499,15 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
                   </p>
                 )}
 
-                {achievement.data && "lastGameAt" in achievement.data && (
+                {achievement.data && "lastGameAt" in achievement.data && achievement.type !== "reunion" && (
                   <p className="text-xs text-secondary-text/70 mt-2">
                     From {dateString(achievement.data.lastGameAt)} to {dateString(achievement.earnedAt)}
+                  </p>
+                )}
+
+                {achievement.type === "reunion" && achievement.data && (
+                  <p className="text-xs text-secondary-text/70 mt-2">
+                    Reunited after {daysBetween(achievement.data.lastGameAt, achievement.earnedAt)} days
                   </p>
                 )}
 
@@ -1012,19 +1018,24 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                         </div>
                       </div>
 
-                      {/* Show who the longest open gap is with for Reunion —
-                          the opponent to play for the next award. */}
-                      {type === "reunion" && "gapOpponent" in data && data.gapOpponent && (
+                      {/* The 5 longest open gaps for Reunion — the opponents
+                          to play for the next award. Inline on one wrapping
+                          line to stay compact. */}
+                      {type === "reunion" && "perOpponent" in data && data.perOpponent && data.perOpponent.size > 0 && (
                         <div className="mt-2 text-xs text-secondary-text/70">
-                          Longest gap: vs{" "}
-                          <Link to={{ pathname: "/player/" + data.gapOpponent, search }}>
-                            <span className="text-secondary-text underline">
-                              {context.playerName(data.gapOpponent)}
-                            </span>
-                          </Link>
-                          {data.gapLastGameAt !== undefined && (
-                            <>, last played {dateString(data.gapLastGameAt)}</>
-                          )}
+                          Longest gaps:{" "}
+                          {Array.from(data.perOpponent.entries() as IterableIterator<[string, number]>)
+                            .sort((a, b) => b[1] - a[1])
+                            .slice(0, 5)
+                            .map(([opponent, gap], index) => (
+                              <span key={opponent}>
+                                {index > 0 && ", "}
+                                <Link to={{ pathname: "/player/" + opponent, search }}>
+                                  <span className="text-secondary-text">{context.playerName(opponent)}</span>
+                                </Link>{" "}
+                                ({Math.floor(gap / (24 * 60 * 60 * 1000))} days)
+                              </span>
+                            ))}
                         </div>
                       )}
 


### PR DESCRIPTION
Follow-up to #148, simplifying how the Reunion 🫂 achievement presents its details.

## Changes

- **Earned cards** (player page and achievements list) now show `Reunited after N days` instead of the from/to date range. The back-after achievements keep their date-range display.
- **Progress tab** on the player page now lists the 5 longest open gaps inline as `name (days), name (days), ...` on one wrapping line, to stay compact on vertical space. Each name links to that player's page.
- The progression data now carries a per-opponent open-gap map (active opponents only) instead of the single longest gap; the bar still tracks the longest gap toward the 1-year target.
- Updated the Reunion changelog post's Progress-tab sentence and the progression tests to match.

## Verification

- `npm run test`: 56 suites, 530 tests passing
- `npm run lint`: clean
- `npm run build`: compiles with only pre-existing source-map warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G2Cu89nxfDbYH6jTYUxSdi

---
_Generated by [Claude Code](https://claude.ai/code/session_01G2Cu89nxfDbYH6jTYUxSdi)_