### PR TITLE
Add 4 new achievements: Everybody's Opponent, Deuce Demon, Giant Hunting, Party Pooper

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -42,6 +42,25 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "4-new-achievements",
+    title: "4 new achievements",
+    date: "2026-08-09",
+    tags: ["feature-update"],
+    summary:
+      "Everybody's Opponent 🧩, Deuce Demon 🔱, Giant Hunting 🏹 and Party Pooper 💩 are new achievements.",
+    body: [
+      list(
+        "Everybody's Opponent 🧩 - play every currently ranked player at least once. Wins and losses both count.",
+        "Deuce Demon 🔱 - win 10 deuce sets in total. A deuce set is won 12-10 or higher.",
+        "Giant Hunting 🏹 - beat 3 higher-ranked players in 1 day. You can earn it again on a later day.",
+        "Party Pooper 💩 - give a player their first loss on a day they had won 5 or more games. This removes their Perfect Day.",
+      ),
+      text(
+        "The Progress tab on the player page shows your progress for each achievement. For Everybody's Opponent it lists the ranked players you still need to play.",
+      ),
+    ],
+  },
+  {
     slug: "reunion-achievement",
     title: "New achievement: Reunion 🫂",
     date: "2026-08-07",

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -42,18 +42,22 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
-    slug: "4-new-achievements",
-    title: "4 new achievements",
+    slug: "5-new-achievements",
+    title: "5 new achievements",
     date: "2026-08-09",
     tags: ["feature-update"],
     summary:
-      "Everybody's Opponent 🧩, Deuce Demon 🔱, Giant Hunting 🏹 and Party Pooper 💩 are new achievements.",
+      "Everybody's Opponent 🧩, Deuce Demon 🔱, Giant Hunting 🏹, Party Pooper 💩 and Jing Jang ☯️ are new achievements.",
     body: [
       list(
         "Everybody's Opponent 🧩 - play every currently ranked player at least once. Wins and losses both count.",
         "Deuce Demon 🔱 - win 10 deuce sets in total. A deuce set is won 12-10 or higher.",
         "Giant Hunting 🏹 - beat 3 higher-ranked players in 1 day. You can earn it again on a later day.",
         "Party Pooper 💩 - give a player their first loss on a day they had won 5 or more games. This removes their Perfect Day.",
+        "Jing Jang ☯️ - a league record. Play the longest run of games where each result is different from the one before: win, loss, win, loss.",
+      ),
+      text(
+        "Jing Jang works like the other league records. The first run of 5 alternating results sets the record. After that, only a longer run takes the record. The holder's award grows while their run continues.",
       ),
       text(
         "The Progress tab on the player page shows your progress for each achievement. For Everybody's Opponent it lists the ranked players you still need to play.",

--- a/frontend/src/client/client-db/__tests__/achievements/deuce-demon.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/deuce-demon.test.ts
@@ -1,0 +1,138 @@
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { TennisTable } from "../../tennis-table";
+
+// Deuce Demon: win 10 career deuce sets (winner ≥ 12, loser ≥ 10 — the same
+// qualifying rule Marathon Set uses). Either player of a game can win a
+// qualifying set. One-time achievement, awarded on the crossing.
+
+describe("Deuce Demon Achievement", () => {
+  const baseEvents: EventType[] = [
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "alice", time: 1, data: { name: "Alice" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "bob", time: 2, data: { name: "Bob" } },
+  ];
+
+  // A game where `winner` beats `loser` 2 sets to 1: two 12–10 deuce sets to
+  // the winner and one 12–10 deuce set to the loser.
+  const deuceGame = (id: string, time: number, winner: string, loser: string): EventType[] => [
+    {
+      type: EventTypeEnum.GAME_CREATED,
+      stream: id,
+      time,
+      data: { winner, loser, playedAt: time },
+    },
+    {
+      type: EventTypeEnum.GAME_SCORE,
+      stream: id,
+      time: time + 1,
+      data: {
+        setsWon: { gameWinner: 2, gameLoser: 1 },
+        setPoints: [
+          { gameWinner: 12, gameLoser: 10 },
+          { gameWinner: 10, gameLoser: 12 },
+          { gameWinner: 13, gameLoser: 11 },
+        ],
+      },
+    },
+  ];
+
+  // A game with no deuce sets.
+  const plainGame = (id: string, time: number, winner: string, loser: string): EventType[] => [
+    {
+      type: EventTypeEnum.GAME_CREATED,
+      stream: id,
+      time,
+      data: { winner, loser, playedAt: time },
+    },
+    {
+      type: EventTypeEnum.GAME_SCORE,
+      stream: id,
+      time: time + 1,
+      data: {
+        setsWon: { gameWinner: 2, gameLoser: 0 },
+        setPoints: [
+          { gameWinner: 11, gameLoser: 5 },
+          { gameWinner: 11, gameLoser: 9 },
+        ],
+      },
+    },
+  ];
+
+  it("awards after 10 career deuce sets won, stamped at the crossing game", () => {
+    // Each deuceGame gives the game winner 2 deuce sets and the loser 1.
+    // After 5 games Alice has 10 and Bob has 5.
+    const events: EventType[] = [...baseEvents];
+    for (let i = 0; i < 5; i++) {
+      events.push(...deuceGame(`g${i}`, 100 + i * 10, "alice", "bob"));
+    }
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const aliceAwards = tt.achievements.getAchievements("alice").filter((a) => a.type === "deuce-demon");
+    expect(aliceAwards).toHaveLength(1);
+    // Alice reaches 10 in the 5th game (played at 140).
+    expect(aliceAwards[0].earnedAt).toBe(140);
+    expect(tt.achievements.getAchievements("bob").filter((a) => a.type === "deuce-demon")).toHaveLength(0);
+  });
+
+  it("counts deuce sets won by the game LOSER too", () => {
+    // Bob loses every game but wins 1 deuce set per game → 10 games gets him there.
+    const events: EventType[] = [...baseEvents];
+    for (let i = 0; i < 10; i++) {
+      events.push(...deuceGame(`g${i}`, 100 + i * 10, "alice", "bob"));
+    }
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const bobAwards = tt.achievements.getAchievements("bob").filter((a) => a.type === "deuce-demon");
+    expect(bobAwards).toHaveLength(1);
+    expect(bobAwards[0].earnedAt).toBe(190);
+  });
+
+  it("is awarded only once, even as the count keeps growing", () => {
+    const events: EventType[] = [...baseEvents];
+    for (let i = 0; i < 12; i++) {
+      events.push(...deuceGame(`g${i}`, 100 + i * 10, "alice", "bob"));
+    }
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "deuce-demon")).toHaveLength(1);
+  });
+
+  it("does NOT count ordinary sets (11–9 or below, or a 13–9 blowout)", () => {
+    const events: EventType[] = [...baseEvents];
+    for (let i = 0; i < 10; i++) {
+      events.push(...plainGame(`g${i}`, 100 + i * 10, "alice", "bob"));
+    }
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "deuce-demon")).toHaveLength(0);
+    const progression = tt.achievements.getPlayerProgression("alice");
+    expect(progression["deuce-demon"].current).toBe(0);
+  });
+
+  it("tracks progression toward the 10-set target", () => {
+    // 2 deuce games → Alice has 4 deuce sets, Bob has 2.
+    const events: EventType[] = [
+      ...baseEvents,
+      ...deuceGame("g1", 100, "alice", "bob"),
+      ...deuceGame("g2", 200, "alice", "bob"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const aliceProgress = tt.achievements.getPlayerProgression("alice");
+    expect(aliceProgress["deuce-demon"].current).toBe(4);
+    expect(aliceProgress["deuce-demon"].target).toBe(10);
+    expect(aliceProgress["deuce-demon"].earned).toBe(0);
+
+    const bobProgress = tt.achievements.getPlayerProgression("bob");
+    expect(bobProgress["deuce-demon"].current).toBe(2);
+  });
+});

--- a/frontend/src/client/client-db/__tests__/achievements/deuce-demon.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/deuce-demon.test.ts
@@ -135,4 +135,19 @@ describe("Deuce Demon Achievement", () => {
     const bobProgress = tt.achievements.getPlayerProgression("bob");
     expect(bobProgress["deuce-demon"].current).toBe(2);
   });
+
+  it("caps progression at the target so the career total is not exposed", () => {
+    // 8 deuce games → Alice has 16 deuce sets, well past the target of 10.
+    const events: EventType[] = [...baseEvents];
+    for (let i = 0; i < 8; i++) {
+      events.push(...deuceGame(`g${i}`, 100 + i * 10, "alice", "bob"));
+    }
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const progression = tt.achievements.getPlayerProgression("alice");
+    expect(progression["deuce-demon"].current).toBe(10);
+    expect(progression["deuce-demon"].earned).toBe(1);
+  });
 });

--- a/frontend/src/client/client-db/__tests__/achievements/everybodys-opponent.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/everybodys-opponent.test.ts
@@ -1,0 +1,170 @@
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { TennisTable } from "../../tennis-table";
+
+// Everybody's Opponent: play every currently ranked player at least once —
+// wins and losses both count. Same cohort semantics as Full House / Humbled:
+// the target is the ranked cohort at the moment of the check, ≥5 ranked
+// players required, and the earner does not need to be ranked themselves.
+// Default GuestClient has gameLimitForRanked = 5.
+
+describe("Everybody's Opponent Achievement", () => {
+  const createPlayer = (id: string, time: number): EventType => ({
+    time,
+    stream: id,
+    type: EventTypeEnum.PLAYER_CREATED,
+    data: { name: id },
+  });
+
+  const game = (id: string, time: number, winner: string, loser: string): EventType => ({
+    time,
+    stream: id,
+    type: EventTypeEnum.GAME_CREATED,
+    data: { playedAt: time, winner, loser },
+  });
+
+  const deactivate = (id: string, time: number): EventType => ({
+    time,
+    stream: id,
+    type: EventTypeEnum.PLAYER_DEACTIVATED,
+    data: null,
+  });
+
+  // 5-player double round-robin (20 games). Every player ends with 8 games
+  // (all ranked) and has played every other player.
+  const fivePlayerSetup = (): EventType[] => {
+    const events: EventType[] = [
+      createPlayer("a", 1),
+      createPlayer("b", 2),
+      createPlayer("c", 3),
+      createPlayer("d", 4),
+      createPlayer("e", 5),
+    ];
+    const pairs: [string, string][] = [
+      ["a", "b"], ["a", "c"], ["a", "d"], ["a", "e"],
+      ["b", "c"], ["b", "d"], ["b", "e"],
+      ["c", "d"], ["c", "e"],
+      ["d", "e"],
+    ];
+    let t = 100;
+    for (let round = 0; round < 2; round++) {
+      for (const [winner, loser] of pairs) {
+        events.push(game(`g-${round}-${winner}-${loser}`, t++, winner, loser));
+      }
+    }
+    return events;
+  };
+
+  it("awards every player of a full round-robin — losses count as much as wins", () => {
+    const events = fivePlayerSetup();
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    // A wins everything, E loses everything — both have played everyone.
+    for (const playerId of ["a", "b", "c", "d", "e"]) {
+      const awards = tt.achievements.getAchievements(playerId).filter((x) => x.type === "everybodys-opponent");
+      expect(awards).toHaveLength(1);
+      expect(awards[0].data.count).toBe(4);
+    }
+  });
+
+  it("does NOT award a ranked player who has not played everyone", () => {
+    // F becomes ranked through 5 games against A alone. F has never played
+    // B, C, D or E — no award for F.
+    const events = [...fivePlayerSetup(), createPlayer("f", 500)];
+    for (let i = 0; i < 5; i++) {
+      events.push(game(`f-${i}`, 1000 + i, "a", "f"));
+    }
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("f").filter((x) => x.type === "everybodys-opponent")).toHaveLength(0);
+    // The awards earned while the cohort was A–E stay earned.
+    expect(tt.achievements.getAchievements("b").filter((x) => x.type === "everybodys-opponent")).toHaveLength(1);
+  });
+
+  it("does NOT award when fewer than 5 players are ranked", () => {
+    const events: EventType[] = [
+      createPlayer("a", 1),
+      createPlayer("b", 2),
+      createPlayer("c", 3),
+      createPlayer("d", 4),
+    ];
+    const pairs: [string, string][] = [
+      ["a", "b"], ["a", "c"], ["a", "d"],
+      ["b", "c"], ["b", "d"],
+      ["c", "d"],
+    ];
+    let t = 100;
+    for (let round = 0; round < 2; round++) {
+      for (const [winner, loser] of pairs) {
+        events.push(game(`g-${round}-${winner}-${loser}`, t++, winner, loser));
+      }
+    }
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    for (const playerId of ["a", "b", "c", "d"]) {
+      expect(
+        tt.achievements.getAchievements(playerId).filter((x) => x.type === "everybodys-opponent"),
+      ).toHaveLength(0);
+    }
+  });
+
+  it("completes through a deactivation when the missing opponent leaves the cohort", () => {
+    // F plays 5 early games against B (both become ranked). The round-robin
+    // then ranks A–E, making the cohort A–F — and only B has ever played F.
+    // Deactivating F shrinks the cohort back to A–E, completing the set for
+    // A, C, D and E on the spot.
+    const events: EventType[] = [
+      createPlayer("a", 1),
+      createPlayer("b", 2),
+      createPlayer("c", 3),
+      createPlayer("d", 4),
+      createPlayer("e", 5),
+      createPlayer("f", 6),
+    ];
+    for (let i = 0; i < 5; i++) {
+      events.push(game(`f-${i}`, 10 + i, "b", "f"));
+    }
+    events.push(...fivePlayerSetup().filter((e) => e.type === EventTypeEnum.GAME_CREATED));
+    const deactivationTime = 5000;
+    events.push(deactivate("f", deactivationTime));
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const aAwards = tt.achievements.getAchievements("a").filter((x) => x.type === "everybodys-opponent");
+    expect(aAwards).toHaveLength(1);
+    expect(aAwards[0].earnedAt).toBe(deactivationTime);
+    // B played F directly and completed already during the round-robin.
+    const bAwards = tt.achievements.getAchievements("b").filter((x) => x.type === "everybodys-opponent");
+    expect(bAwards).toHaveLength(1);
+    expect(bAwards[0].earnedAt).toBeLessThan(deactivationTime);
+  });
+
+  it("tracks progression with the players still to play", () => {
+    // F is ranked but has only ever played A.
+    const events = [...fivePlayerSetup(), createPlayer("f", 500)];
+    for (let i = 0; i < 5; i++) {
+      events.push(game(`f-${i}`, 1000 + i, "a", "f"));
+    }
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const fProgress = tt.achievements.getPlayerProgression("f");
+    expect(fProgress["everybodys-opponent"].current).toBe(1);
+    expect(fProgress["everybodys-opponent"].target).toBe(5);
+    expect(Array.from(fProgress["everybodys-opponent"].missing!).sort()).toEqual(["b", "c", "d", "e"]);
+    expect(fProgress["everybodys-opponent"].earned).toBe(0);
+
+    // A has played everyone, F included.
+    const aProgress = tt.achievements.getPlayerProgression("a");
+    expect(aProgress["everybodys-opponent"].current).toBe(5);
+    expect(aProgress["everybodys-opponent"].target).toBe(5);
+    expect(aProgress["everybodys-opponent"].missing!.size).toBe(0);
+    expect(aProgress["everybodys-opponent"].earned).toBe(1);
+  });
+});

--- a/frontend/src/client/client-db/__tests__/achievements/giant-hunting.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/giant-hunting.test.ts
@@ -1,0 +1,231 @@
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { TennisTable } from "../../tennis-table";
+
+// Giant Hunting: beat 3 higher-ranked opponents within one local calendar
+// day. A win counts when the opponent's pre-match rank was better (lower)
+// than the player's own, both were ranked, and the ranked cohort had ≥5
+// players. Once per day; a new day is a new chase.
+// Default GuestClient has gameLimitForRanked = 5.
+
+describe("Giant Hunting Achievement", () => {
+  const createPlayer = (id: string, time: number): EventType => ({
+    time,
+    stream: id,
+    type: EventTypeEnum.PLAYER_CREATED,
+    data: { name: id },
+  });
+
+  const gameAt = (id: string, playedAt: number, winner: string, loser: string): EventType => ({
+    time: playedAt,
+    stream: id,
+    type: EventTypeEnum.GAME_CREATED,
+    data: { playedAt, winner, loser },
+  });
+
+  // 5-player double round-robin on Jan 10 2024 (20 games, minutes apart).
+  // Every player ends with 8 games (all ranked). Standings: A(rank1) B C D
+  // E(rank5), with clear Elo separation.
+  const fivePlayerSetup = (): EventType[] => {
+    const events: EventType[] = [
+      createPlayer("a", 1),
+      createPlayer("b", 2),
+      createPlayer("c", 3),
+      createPlayer("d", 4),
+      createPlayer("e", 5),
+    ];
+    const pairs: [string, string][] = [
+      ["a", "b"], ["a", "c"], ["a", "d"], ["a", "e"],
+      ["b", "c"], ["b", "d"], ["b", "e"],
+      ["c", "d"], ["c", "e"],
+      ["d", "e"],
+    ];
+    let minute = 0;
+    for (let round = 0; round < 2; round++) {
+      for (const [winner, loser] of pairs) {
+        events.push(gameAt(`rr-${round}-${winner}-${loser}`, new Date(2024, 0, 10, 9, minute++).getTime(), winner, loser));
+      }
+    }
+    return events;
+  };
+
+  it("awards the 3rd win over a higher-ranked opponent in one day", () => {
+    const events: EventType[] = [
+      ...fivePlayerSetup(),
+      // Jan 15: bottom-ranked E beats the top 3 in one day.
+      gameAt("h1", new Date(2024, 0, 15, 10).getTime(), "e", "a"),
+      gameAt("h2", new Date(2024, 0, 15, 11).getTime(), "e", "b"),
+      gameAt("h3", new Date(2024, 0, 15, 12).getTime(), "e", "c"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const awards = tt.achievements.getAchievements("e").filter((x) => x.type === "giant-hunting");
+    expect(awards).toHaveLength(1);
+    expect(awards[0].earnedAt).toBe(new Date(2024, 0, 15, 12).getTime());
+    expect(awards[0].data.day).toBe(new Date(2024, 0, 15).getTime());
+    expect(awards[0].data.giants).toHaveLength(3);
+    expect(awards[0].data.giants.map((g) => g.opponent)).toEqual(["a", "b", "c"]);
+    // Every slain giant outranked the hunter going into the match.
+    for (const giant of awards[0].data.giants) {
+      expect(giant.opponentRank).toBeLessThan(giant.playerRank);
+    }
+  });
+
+  it("does NOT award for only 2 giant wins in a day", () => {
+    const events: EventType[] = [
+      ...fivePlayerSetup(),
+      gameAt("h1", new Date(2024, 0, 15, 10).getTime(), "e", "a"),
+      gameAt("h2", new Date(2024, 0, 15, 11).getTime(), "e", "b"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("e").filter((x) => x.type === "giant-hunting")).toHaveLength(0);
+  });
+
+  it("does NOT award when the 3 giant wins are spread over two days", () => {
+    const events: EventType[] = [
+      ...fivePlayerSetup(),
+      gameAt("h1", new Date(2024, 0, 15, 10).getTime(), "e", "a"),
+      gameAt("h2", new Date(2024, 0, 15, 11).getTime(), "e", "b"),
+      gameAt("h3", new Date(2024, 0, 16, 10).getTime(), "e", "c"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("e").filter((x) => x.type === "giant-hunting")).toHaveLength(0);
+  });
+
+  it("does NOT count wins over lower-ranked opponents", () => {
+    const events: EventType[] = [
+      ...fivePlayerSetup(),
+      // Top-ranked A beats 3 lower-ranked players in one day — no giants here.
+      gameAt("h1", new Date(2024, 0, 15, 10).getTime(), "a", "c"),
+      gameAt("h2", new Date(2024, 0, 15, 11).getTime(), "a", "d"),
+      gameAt("h3", new Date(2024, 0, 15, 12).getTime(), "a", "e"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("a").filter((x) => x.type === "giant-hunting")).toHaveLength(0);
+  });
+
+  it("awards once per day, even with a 4th giant win", () => {
+    const events: EventType[] = [
+      ...fivePlayerSetup(),
+      gameAt("h1", new Date(2024, 0, 15, 10).getTime(), "e", "a"),
+      gameAt("h2", new Date(2024, 0, 15, 11).getTime(), "e", "b"),
+      gameAt("h3", new Date(2024, 0, 15, 12).getTime(), "e", "c"),
+      gameAt("h4", new Date(2024, 0, 15, 13).getTime(), "e", "d"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const awards = tt.achievements.getAchievements("e").filter((x) => x.type === "giant-hunting");
+    expect(awards).toHaveLength(1);
+    expect(awards[0].data.giants).toHaveLength(3);
+  });
+
+  it("CAN be earned again on a later day", () => {
+    const events: EventType[] = [
+      ...fivePlayerSetup(),
+      gameAt("h1", new Date(2024, 0, 15, 10).getTime(), "e", "a"),
+      gameAt("h2", new Date(2024, 0, 15, 11).getTime(), "e", "b"),
+      gameAt("h3", new Date(2024, 0, 15, 12).getTime(), "e", "c"),
+      // E's Elo has climbed, so rebuild the gap: the whole field beats E
+      // again, dropping E firmly back to the bottom rank...
+      gameAt("r1", new Date(2024, 0, 16, 10).getTime(), "a", "e"),
+      gameAt("r2", new Date(2024, 0, 16, 11).getTime(), "b", "e"),
+      gameAt("r3", new Date(2024, 0, 16, 12).getTime(), "c", "e"),
+      gameAt("r4", new Date(2024, 0, 16, 13).getTime(), "d", "e"),
+      // ...and E hunts the top 3 down once more on Jan 17.
+      gameAt("h4", new Date(2024, 0, 17, 10).getTime(), "e", "a"),
+      gameAt("h5", new Date(2024, 0, 17, 11).getTime(), "e", "b"),
+      gameAt("h6", new Date(2024, 0, 17, 12).getTime(), "e", "c"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("e").filter((x) => x.type === "giant-hunting")).toHaveLength(2);
+  });
+
+  it("does NOT award when fewer than 5 players are ranked", () => {
+    // 4-player double round-robin — everyone ranked, but the cohort is
+    // below the ≥5 gate.
+    const events: EventType[] = [
+      createPlayer("a", 1),
+      createPlayer("b", 2),
+      createPlayer("c", 3),
+      createPlayer("d", 4),
+    ];
+    const pairs: [string, string][] = [
+      ["a", "b"], ["a", "c"], ["a", "d"],
+      ["b", "c"], ["b", "d"],
+      ["c", "d"],
+    ];
+    let minute = 0;
+    for (let round = 0; round < 2; round++) {
+      for (const [winner, loser] of pairs) {
+        events.push(gameAt(`rr-${round}-${winner}-${loser}`, new Date(2024, 0, 10, 9, minute++).getTime(), winner, loser));
+      }
+    }
+    events.push(gameAt("h1", new Date(2024, 0, 15, 10).getTime(), "d", "a"));
+    events.push(gameAt("h2", new Date(2024, 0, 15, 11).getTime(), "d", "b"));
+    events.push(gameAt("h3", new Date(2024, 0, 15, 12).getTime(), "d", "c"));
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("d").filter((x) => x.type === "giant-hunting")).toHaveLength(0);
+  });
+
+  describe("Progression (live, resets each day)", () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("tracks today's giant wins and the best day ever", () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2024, 0, 15, 20));
+
+      const events: EventType[] = [
+        ...fivePlayerSetup(),
+        gameAt("h1", new Date(2024, 0, 15, 10).getTime(), "e", "a"),
+        gameAt("h2", new Date(2024, 0, 15, 11).getTime(), "e", "b"),
+      ];
+
+      const tt = new TennisTable({ events });
+      tt.achievements.calculateAchievements();
+
+      const progression = tt.achievements.getPlayerProgression("e");
+      expect(progression["giant-hunting"].current).toBe(2);
+      expect(progression["giant-hunting"].target).toBe(3);
+      expect(progression["giant-hunting"].best).toBe(2);
+      expect(progression["giant-hunting"].earned).toBe(0);
+    });
+
+    it("resets progress to 0 the next day, keeping the best", () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2024, 0, 16, 8));
+
+      const events: EventType[] = [
+        ...fivePlayerSetup(),
+        gameAt("h1", new Date(2024, 0, 15, 10).getTime(), "e", "a"),
+        gameAt("h2", new Date(2024, 0, 15, 11).getTime(), "e", "b"),
+      ];
+
+      const tt = new TennisTable({ events });
+      tt.achievements.calculateAchievements();
+
+      const progression = tt.achievements.getPlayerProgression("e");
+      expect(progression["giant-hunting"].current).toBe(0);
+      expect(progression["giant-hunting"].best).toBe(2);
+    });
+  });
+});

--- a/frontend/src/client/client-db/__tests__/achievements/jing-jang.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/jing-jang.test.ts
@@ -1,0 +1,201 @@
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { TennisTable } from "../../tennis-table";
+
+// Jing Jang: the league record for the longest run of strictly alternating
+// results — win, loss, win, loss (or the mirror). The first run to reach 5
+// games establishes the record; after that only a longer run takes it. While
+// the holder keeps alternating, the award grows with the run instead of
+// handing out one per game.
+
+describe("Jing Jang Achievement", () => {
+  const baseEvents: EventType[] = [
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "alice", time: 1, data: { name: "Alice" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "bob", time: 2, data: { name: "Bob" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "carol", time: 3, data: { name: "Carol" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "dave", time: 4, data: { name: "Dave" } },
+  ];
+
+  const game = (id: string, time: number, winner: string, loser: string): EventType => ({
+    time,
+    stream: id,
+    type: EventTypeEnum.GAME_CREATED,
+    data: { playedAt: time, winner, loser },
+  });
+
+  // Alice alternates W L W L W ... — wins against Bob, losses to Carol — so
+  // neither opponent builds an alternating run of their own (Bob only ever
+  // loses, Carol only ever wins).
+  const aliceAlternation = (games: number, startTime: number): EventType[] => {
+    const events: EventType[] = [];
+    for (let i = 0; i < games; i++) {
+      const time = startTime + i * 10;
+      if (i % 2 === 0) events.push(game(`a-${i}`, time, "alice", "bob"));
+      else events.push(game(`a-${i}`, time, "carol", "alice"));
+    }
+    return events;
+  };
+
+  const jingJangs = (tt: TennisTable, playerId: string) =>
+    tt.achievements.getAchievements(playerId).filter((a) => a.type === "jing-jang");
+
+  it("establishes the first record at 5 alternating results", () => {
+    const events: EventType[] = [...baseEvents, ...aliceAlternation(5, 100)];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const awards = jingJangs(tt, "alice");
+    expect(awards).toHaveLength(1);
+    expect(awards[0]).toStrictEqual({
+      type: "jing-jang",
+      earnedBy: "alice",
+      earnedAt: 140,
+      data: { streakLength: 5, startedAt: 100, previousRecord: undefined },
+    });
+    expect(tt.achievements.jingJangRecord).toStrictEqual({ length: 5, holder: "alice" });
+  });
+
+  it("does NOT award below the 5-game floor", () => {
+    const events: EventType[] = [...baseEvents, ...aliceAlternation(4, 100)];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(jingJangs(tt, "alice")).toHaveLength(0);
+    expect(tt.achievements.jingJangRecord.length).toBeUndefined();
+  });
+
+  it("grows the holder's award as the alternation continues, instead of awarding again", () => {
+    const events: EventType[] = [...baseEvents, ...aliceAlternation(7, 100)];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const awards = jingJangs(tt, "alice");
+    expect(awards).toHaveLength(1);
+    expect(awards[0].data.streakLength).toBe(7);
+    expect(awards[0].data.startedAt).toBe(100);
+    // earnedAt moves with the run — the 7th game.
+    expect(awards[0].earnedAt).toBe(160);
+    expect(tt.achievements.jingJangRecord).toStrictEqual({ length: 7, holder: "alice" });
+  });
+
+  it("a repeated result breaks the run", () => {
+    // Alice: W W L W L — the double win means no run ever passes 4.
+    const events: EventType[] = [
+      ...baseEvents,
+      game("g1", 100, "alice", "bob"),
+      game("g2", 110, "alice", "bob"),
+      game("g3", 120, "carol", "alice"),
+      game("g4", 130, "alice", "bob"),
+      game("g5", 140, "carol", "alice"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(jingJangs(tt, "alice")).toHaveLength(0);
+  });
+
+  it("a standing record must be strictly exceeded", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      // Alice sets the record at 5, then breaks her own run with a repeat win.
+      ...aliceAlternation(5, 100),
+      game("a-break", 150, "alice", "bob"),
+      // Dave alternates 6: W L W L W L (wins vs Bob, losses to Carol).
+      game("d-0", 200, "dave", "bob"),
+      game("d-1", 210, "carol", "dave"),
+      game("d-2", 220, "dave", "bob"),
+      game("d-3", 230, "carol", "dave"),
+      game("d-4", 240, "dave", "bob"),
+      game("d-5", 250, "carol", "dave"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    // Dave's run of 5 (at time 240) only matches the record — no award until
+    // the 6th alternating result exceeds it.
+    const daveAwards = jingJangs(tt, "dave");
+    expect(daveAwards).toHaveLength(1);
+    expect(daveAwards[0].data.streakLength).toBe(6);
+    expect(daveAwards[0].data.previousRecord).toBe(5);
+    expect(daveAwards[0].earnedAt).toBe(250);
+    // Alice keeps the award her record run earned, at the length it held.
+    const aliceAwards = jingJangs(tt, "alice");
+    expect(aliceAwards).toHaveLength(1);
+    expect(aliceAwards[0].data.streakLength).toBe(5);
+    expect(tt.achievements.jingJangRecord).toStrictEqual({ length: 6, holder: "dave" });
+  });
+
+  it("a pure head-to-head see-saw: the winner takes the tie, then the record trades", () => {
+    // Alice and Bob trade wins for 6 games (Alice wins the odd games). Both
+    // runs reach 5 on game 5 — the winner (Alice) is checked first and takes
+    // the record. On game 6 Bob's run reaches 6 first (he won it) and takes
+    // the record over.
+    const events: EventType[] = [
+      ...baseEvents,
+      game("g1", 100, "alice", "bob"),
+      game("g2", 110, "bob", "alice"),
+      game("g3", 120, "alice", "bob"),
+      game("g4", 130, "bob", "alice"),
+      game("g5", 140, "alice", "bob"),
+      game("g6", 150, "bob", "alice"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const aliceAwards = jingJangs(tt, "alice");
+    expect(aliceAwards).toHaveLength(1);
+    expect(aliceAwards[0].data.streakLength).toBe(5);
+    const bobAwards = jingJangs(tt, "bob");
+    expect(bobAwards).toHaveLength(1);
+    expect(bobAwards[0].data.streakLength).toBe(6);
+    expect(bobAwards[0].data.previousRecord).toBe(5);
+    expect(tt.achievements.jingJangRecord).toStrictEqual({ length: 6, holder: "bob" });
+  });
+
+  describe("Progression", () => {
+    it("tracks the live run and the longest ever, with no target before a record exists", () => {
+      // Alice: W L W W — the repeat breaks a run of 3; the live run is 1.
+      const events: EventType[] = [
+        ...baseEvents,
+        game("g1", 100, "alice", "bob"),
+        game("g2", 110, "carol", "alice"),
+        game("g3", 120, "alice", "bob"),
+        game("g4", 130, "alice", "bob"),
+      ];
+
+      const tt = new TennisTable({ events });
+      tt.achievements.calculateAchievements();
+
+      const progression = tt.achievements.getPlayerProgression("alice")["jing-jang"];
+      expect(progression.current).toBe(1);
+      expect(progression.best).toBe(3);
+      expect(progression.target).toBeUndefined();
+      expect(progression.recordHolder).toBeUndefined();
+      expect(progression.earned).toBe(0);
+    });
+
+    it("targets one beyond the record once it exists, naming the holder", () => {
+      const events: EventType[] = [
+        ...baseEvents,
+        ...aliceAlternation(5, 100),
+        // Dave has a live alternation of 2.
+        game("d-0", 200, "dave", "bob"),
+        game("d-1", 210, "carol", "dave"),
+      ];
+
+      const tt = new TennisTable({ events });
+      tt.achievements.calculateAchievements();
+
+      const progression = tt.achievements.getPlayerProgression("dave")["jing-jang"];
+      expect(progression.current).toBe(2);
+      expect(progression.best).toBe(2);
+      expect(progression.target).toBe(6);
+      expect(progression.recordHolder).toBe("alice");
+    });
+  });
+});

--- a/frontend/src/client/client-db/__tests__/achievements/party-pooper.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/party-pooper.test.ts
@@ -1,0 +1,152 @@
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { TennisTable } from "../../tennis-table";
+
+// Party Pooper: hand an opponent their first loss of a day on which they had
+// already won 5 or more games — destroying the Perfect Day they had secured.
+// Awarded immediately, once per opponent per day.
+
+describe("Party Pooper Achievement", () => {
+  const baseEvents: EventType[] = [
+    { time: 1000, stream: "player-1", type: EventTypeEnum.PLAYER_CREATED, data: { name: "Alice" } },
+    { time: 2000, stream: "player-2", type: EventTypeEnum.PLAYER_CREATED, data: { name: "Bob" } },
+    { time: 3000, stream: "player-3", type: EventTypeEnum.PLAYER_CREATED, data: { name: "Charlie" } },
+  ];
+
+  // Games at 09:00, 10:00, ... on the given local calendar day.
+  function winsOnDay(
+    year: number,
+    month: number,
+    day: number,
+    winner: string,
+    losers: string[],
+    streamPrefix: string,
+  ): EventType[] {
+    return losers.map((loser, i) => {
+      const playedAt = new Date(year, month, day, 9 + i).getTime();
+      return {
+        time: playedAt,
+        stream: `${streamPrefix}-${i}`,
+        type: EventTypeEnum.GAME_CREATED,
+        data: { playedAt, winner, loser },
+      };
+    });
+  }
+
+  function gameAt(year: number, month: number, day: number, hour: number, winner: string, loser: string): EventType {
+    const playedAt = new Date(year, month, day, hour).getTime();
+    return {
+      time: playedAt,
+      stream: `g-${winner}-${loser}-${hour}`,
+      type: EventTypeEnum.GAME_CREATED,
+      data: { playedAt, winner, loser },
+    };
+  }
+
+  it("awards the winner who hands a 5-0 player their first loss of the day", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      // Player 1 wins 5 games on Jan 15 (09:00–13:00).
+      ...winsOnDay(2024, 0, 15, "player-1", ["player-2", "player-3", "player-2", "player-3", "player-2"], "w"),
+      // Player 3 beats player 1 at 15:00 — the perfect day is destroyed.
+      gameAt(2024, 0, 15, 15, "player-3", "player-1"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const awards = tt.achievements.getAchievements("player-3").filter((a) => a.type === "party-pooper");
+    expect(awards).toHaveLength(1);
+    expect(awards[0].data.opponent).toBe("player-1");
+    expect(awards[0].data.opponentWins).toBe(5);
+    expect(awards[0].data.day).toBe(new Date(2024, 0, 15).getTime());
+    expect(awards[0].earnedAt).toBe(new Date(2024, 0, 15, 15).getTime());
+
+    // The spoiled player earns no Perfect Day for that day.
+    expect(tt.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-day")).toHaveLength(0);
+  });
+
+  it("does NOT award when the opponent had only 4 wins", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      ...winsOnDay(2024, 0, 15, "player-1", ["player-2", "player-3", "player-2", "player-3"], "w"),
+      gameAt(2024, 0, 15, 15, "player-3", "player-1"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("player-3").filter((a) => a.type === "party-pooper")).toHaveLength(0);
+  });
+
+  it("does NOT award when the opponent already lost earlier that day", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      // Player 1 loses at 08:00, then wins 5 games — no perfect day to spoil.
+      gameAt(2024, 0, 15, 8, "player-2", "player-1"),
+      ...winsOnDay(2024, 0, 15, "player-1", ["player-2", "player-3", "player-2", "player-3", "player-2"], "w"),
+      gameAt(2024, 0, 15, 15, "player-3", "player-1"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("player-3").filter((a) => a.type === "party-pooper")).toHaveLength(0);
+  });
+
+  it("does NOT award for a loss on the day AFTER the undefeated day", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      ...winsOnDay(2024, 0, 15, "player-1", ["player-2", "player-3", "player-2", "player-3", "player-2"], "w"),
+      // The loss lands the next morning — the perfect day already stands.
+      gameAt(2024, 0, 16, 9, "player-3", "player-1"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(tt.achievements.getAchievements("player-3").filter((a) => a.type === "party-pooper")).toHaveLength(0);
+    // And the perfect day survives.
+    expect(tt.achievements.getAchievements("player-1").filter((a) => a.type === "perfect-day")).toHaveLength(1);
+  });
+
+  it("counts wins past 5 — spoiling a 7-0 day records 7 wins", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      ...winsOnDay(
+        2024,
+        0,
+        15,
+        "player-1",
+        ["player-2", "player-3", "player-2", "player-3", "player-2", "player-3", "player-2"],
+        "w",
+      ),
+      gameAt(2024, 0, 15, 20, "player-3", "player-1"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const awards = tt.achievements.getAchievements("player-3").filter((a) => a.type === "party-pooper");
+    expect(awards).toHaveLength(1);
+    expect(awards[0].data.opponentWins).toBe(7);
+  });
+
+  it("can be earned twice in one day against two different undefeated players", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      // Players 1 and 2 each rack up 5 wins against player 3.
+      ...winsOnDay(2024, 0, 15, "player-1", ["player-3", "player-3", "player-3", "player-3", "player-3"], "a"),
+      ...winsOnDay(2024, 0, 15, "player-2", ["player-3", "player-3", "player-3", "player-3", "player-3"], "b"),
+      // Player 3 then beats both of them in the evening.
+      gameAt(2024, 0, 15, 20, "player-3", "player-1"),
+      gameAt(2024, 0, 15, 21, "player-3", "player-2"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const awards = tt.achievements.getAchievements("player-3").filter((a) => a.type === "party-pooper");
+    expect(awards).toHaveLength(2);
+    expect(awards.map((a) => a.data.opponent).sort()).toEqual(["player-1", "player-2"]);
+  });
+});

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -3249,7 +3249,9 @@ export class Achievements {
     progression["edge-lord"].current = edgeLordCount;
     progression["consistency-is-key"].current = consistencyCount;
     progression["marathon-set"].current = bestDeuceSetWon;
-    progression["deuce-demon"].current = deuceSetsWonCount;
+    // Deuce Demon progress caps at the target: the count never resets, so
+    // going beyond would leak the player's career deuce-set total.
+    progression["deuce-demon"].current = Math.min(deuceSetsWonCount, DEUCE_DEMON_TARGET);
     progression["variety-player"].current = opponentsPlayed.size;
     progression["variety-player"].opponents = opponentsPlayed;
     progression["global-player"].current = opponentsPlayed.size;

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -53,6 +53,13 @@ export function isMilestoneGameNumber(gameNumber: number): boolean {
 // achievement is earned once.
 export const DEUCE_DEMON_TARGET = 10;
 
+// Shortest run of strictly alternating results — win, loss, win, loss (or
+// loss, win, loss, win) — that can establish the very first Jing Jang
+// record. Every game is trivially a run of 1 and any two mixed results a run
+// of 2, so the first record should take a genuinely long see-saw. Once a
+// record exists the floor is irrelevant — only beating the record counts.
+export const JING_JANG_RECORD_FLOOR = 5;
+
 // Higher-ranked opponents a player must beat within one local calendar day
 // for "Giant Hunting". A win counts when the opponent's pre-match rank was
 // better (lower) than the player's own pre-match rank, both were ranked, and
@@ -170,6 +177,15 @@ export class Achievements {
     length: undefined,
     holder: undefined,
   };
+  // League-wide running record for the Jing Jang achievement: the longest
+  // run of strictly alternating results (win, loss, win, loss — or the
+  // mirror) any player has put together to date. Undefined until a run
+  // reaches JING_JANG_RECORD_FLOOR and establishes the first record. Used by
+  // the progression view so players can see the mark they need to beat.
+  jingJangRecord: { length: number | undefined; holder: string | undefined } = {
+    length: undefined,
+    holder: undefined,
+  };
   // League-wide running records for the Hero of the Day / Week / Month
   // achievements: the most games a single player has played in one local
   // calendar day / week (Monday-start) / month. Undefined until a period
@@ -223,6 +239,7 @@ export class Achievements {
     this.latestGameRecord = { minutesIntoDay: undefined };
     this.winStreakRecord = { length: undefined, holder: undefined };
     this.loseStreakRecord = { length: undefined, holder: undefined };
+    this.jingJangRecord = { length: undefined, holder: undefined };
     this.gamesInDayRecord = { count: undefined, holder: undefined };
     this.gamesInWeekRecord = { count: undefined, holder: undefined };
     this.gamesInMonthRecord = { count: undefined, holder: undefined };
@@ -246,6 +263,15 @@ export class Achievements {
         // once another player takes the record over.
         openWinStreakRecord: StreakRecordAchievement | undefined;
         openLoseStreakRecord: StreakRecordAchievement | undefined;
+        // Jing Jang chase state: the run of strictly alternating results the
+        // player is on right now, the result of their previous game (undefined
+        // before their first), and — like the streak records — the award the
+        // running alternation earned while the player still holds the record
+        // with it.
+        jingJangStreak: number;
+        jingJangStartedAt: number;
+        jingJangLastWasWin: boolean | undefined;
+        openJingJangRecord: StreakRecordAchievement | undefined;
         // Per-period state for the Hero of the Day / Week / Month records:
         // the local calendar period (its start timestamp) the player last
         // played in, how many games they have played in it so far, and the
@@ -306,6 +332,10 @@ export class Achievements {
           winStreakPlayer: new Map(),
           openWinStreakRecord: undefined,
           openLoseStreakRecord: undefined,
+          jingJangStreak: 0,
+          jingJangStartedAt: game.playedAt,
+          jingJangLastWasWin: undefined,
+          openJingJangRecord: undefined,
           heroOfTheDay: { periodStart: 0, gamesInPeriod: 0, openRecord: undefined },
           heroOfTheWeek: { periodStart: 0, gamesInPeriod: 0, openRecord: undefined },
           heroOfTheMonth: { periodStart: 0, gamesInPeriod: 0, openRecord: undefined },
@@ -332,6 +362,10 @@ export class Achievements {
           winStreakPlayer: new Map(),
           openWinStreakRecord: undefined,
           openLoseStreakRecord: undefined,
+          jingJangStreak: 0,
+          jingJangStartedAt: game.playedAt,
+          jingJangLastWasWin: undefined,
+          openJingJangRecord: undefined,
           heroOfTheDay: { periodStart: 0, gamesInPeriod: 0, openRecord: undefined },
           heroOfTheWeek: { periodStart: 0, gamesInPeriod: 0, openRecord: undefined },
           heroOfTheMonth: { periodStart: 0, gamesInPeriod: 0, openRecord: undefined },
@@ -405,6 +439,13 @@ export class Achievements {
       // at once the win breaks the tie.
       this.#checkHeroAchievements(game.winner, winner, game.playedAt);
       this.#checkHeroAchievements(game.loser, loser, game.playedAt);
+
+      // Check for "Jing Jang": the league record for the longest run of
+      // strictly alternating results. Both players' runs move on every game;
+      // the winner is checked first, so when both reach the record length at
+      // once the win breaks the tie.
+      this.#updateJingJangStreak(game.winner, winner, true, game.playedAt);
+      this.#updateJingJangStreak(game.loser, loser, false, game.playedAt);
 
       // Check for Welcome Committee achievement
       // If this is the loser's first game ever, the winner is their first opponent
@@ -573,6 +614,7 @@ export class Achievements {
         winner.winStreakAllStartedAt,
         game.playedAt,
         winner.openWinStreakRecord,
+        STREAK_RECORD_FLOOR,
       );
 
       // Check if winner just broke a lose streak
@@ -644,6 +686,7 @@ export class Achievements {
         loser.loseStreakAllStartedAt,
         game.playedAt,
         loser.openLoseStreakRecord,
+        STREAK_RECORD_FLOOR,
       );
 
       // Check for lose streak achievements for loser
@@ -2129,12 +2172,13 @@ export class Achievements {
     }
   }
 
-  // Awards "Longest Win Streak" / "Longest Lose Streak" — the league-wide
-  // records for consecutive wins and consecutive losses. Called with the
-  // player's streak as it stands after the game just played.
+  // Awards "Longest Win Streak" / "Longest Lose Streak" / "Jing Jang" — the
+  // league-wide records for consecutive wins, consecutive losses and
+  // strictly alternating results. Called with the player's streak as it
+  // stands after the game just played.
   //
   // A streak takes the record the moment it passes the standing one (or
-  // reaches STREAK_RECORD_FLOOR, when nobody holds it yet). Extending that
+  // reaches `recordFloor`, when nobody holds it yet). Extending that
   // same streak while still holding the record does not award again — the
   // achievement already earned grows with the streak instead, so an
   // 11th straight win reads as one award worth 11 rather than two worth
@@ -2149,16 +2193,17 @@ export class Achievements {
   // Returns the award this streak now owns, to be stored on the player's
   // tracker and passed back in on their next game.
   #checkStreakRecordAchievement(
-    type: "longest-win-streak" | "longest-lose-streak",
+    type: "longest-win-streak" | "longest-lose-streak" | "jing-jang",
     record: { length: number | undefined; holder: string | undefined },
     playerId: string,
     streakLength: number,
     startedAt: number,
     playedAt: number,
     openRecord: StreakRecordAchievement | undefined,
+    recordFloor: number,
   ): StreakRecordAchievement | undefined {
     const beatsRecord =
-      record.length === undefined ? streakLength >= STREAK_RECORD_FLOOR : streakLength > record.length;
+      record.length === undefined ? streakLength >= recordFloor : streakLength > record.length;
     if (!beatsRecord) {
       return openRecord;
     }
@@ -2176,11 +2221,54 @@ export class Achievements {
     const achievement: StreakRecordAchievement =
       type === "longest-win-streak"
         ? this.#createAchievement("longest-win-streak", playerId, playedAt, data)
-        : this.#createAchievement("longest-lose-streak", playerId, playedAt, data);
+        : type === "longest-lose-streak"
+          ? this.#createAchievement("longest-lose-streak", playerId, playedAt, data)
+          : this.#createAchievement("jing-jang", playerId, playedAt, data);
     this.#addAchievement(playerId, achievement);
     record.length = streakLength;
     record.holder = playerId;
     return achievement;
+  }
+
+  // Jing Jang: the league record for the longest run of strictly alternating
+  // results — win, loss, win, loss (or the mirror). Every game moves the run
+  // of both its players: a result different from the player's previous one
+  // extends their run, a repeated result starts a fresh run at this game (a
+  // run of 1 — the game itself), and a player's first ever game also starts
+  // at 1. The record machinery is shared with the streak records: the first
+  // run to reach JING_JANG_RECORD_FLOOR establishes the record, after that
+  // only a longer run takes it, and the holder's award grows while their
+  // alternation continues instead of handing out one per game.
+  #updateJingJangStreak(
+    playerId: string,
+    tracker: {
+      jingJangStreak: number;
+      jingJangStartedAt: number;
+      jingJangLastWasWin: boolean | undefined;
+      openJingJangRecord: StreakRecordAchievement | undefined;
+    },
+    won: boolean,
+    playedAt: number,
+  ) {
+    if (tracker.jingJangLastWasWin === undefined || tracker.jingJangLastWasWin === won) {
+      tracker.jingJangStreak = 1;
+      tracker.jingJangStartedAt = playedAt;
+      tracker.openJingJangRecord = undefined;
+    } else {
+      tracker.jingJangStreak++;
+    }
+    tracker.jingJangLastWasWin = won;
+
+    tracker.openJingJangRecord = this.#checkStreakRecordAchievement(
+      "jing-jang",
+      this.jingJangRecord,
+      playerId,
+      tracker.jingJangStreak,
+      tracker.jingJangStartedAt,
+      playedAt,
+      tracker.openJingJangRecord,
+      JING_JANG_RECORD_FLOOR,
+    );
   }
 
   // Local midnight of the day containing `ms`.
@@ -2769,6 +2857,13 @@ export class Achievements {
         target: this.loseStreakRecord.length === undefined ? undefined : this.loseStreakRecord.length + 1,
         recordHolder: this.loseStreakRecord.holder,
       },
+      "jing-jang": {
+        earned: 0,
+        current: 0,
+        best: 0,
+        target: this.jingJangRecord.length === undefined ? undefined : this.jingJangRecord.length + 1,
+        recordHolder: this.jingJangRecord.holder,
+      },
 
       // Rank & Score
       "on-the-podium": { earned: 0 },
@@ -2896,6 +2991,12 @@ export class Achievements {
     // the streak they are on now. Shown alongside the league streak records.
     let longestWinStreakAll = 0;
     let longestLoseStreakAll = 0;
+    // Jing Jang: the alternation run the player is on now, and their longest
+    // ever. The run moves on every game — extended by a result different
+    // from the previous one, restarted at 1 by a repeat.
+    let currentJingJang = 0;
+    let longestJingJang = 0;
+    let jingJangLastWasWin: boolean | undefined = undefined;
     let donutCount = 0;
     let closeCallsCount = 0;
     let edgeLordCount = 0;
@@ -2996,6 +3097,15 @@ export class Achievements {
 
       // Track last active time
       lastActiveAt = game.playedAt;
+
+      // Jing Jang progression: move the alternation run with this result.
+      if (jingJangLastWasWin === undefined || jingJangLastWasWin === isWinner) {
+        currentJingJang = 1;
+      } else {
+        currentJingJang++;
+      }
+      jingJangLastWasWin = isWinner;
+      longestJingJang = Math.max(longestJingJang, currentJingJang);
 
       // Perfect Day progression: tally wins / losses per local calendar day.
       const dayStart = new Date(game.playedAt);
@@ -3156,6 +3266,12 @@ export class Achievements {
     progression["longest-win-streak"].best = longestWinStreakAll;
     progression["longest-lose-streak"].current = currentLoseStreakAll;
     progression["longest-lose-streak"].best = longestLoseStreakAll;
+
+    // Jing Jang: the live alternation run is what can still grow into the
+    // league record, so that is the progress. The player's longest ever run
+    // is reported alongside it.
+    progression["jing-jang"].current = currentJingJang;
+    progression["jing-jang"].best = longestJingJang;
 
     // Perfect Day progression tracks TODAY's live attempt: the number of
     // games won today with zero losses so far. A single loss today nullifies
@@ -3839,6 +3955,10 @@ type AchievementDefinitions = {
   // of the streak, so startedAt → earnedAt spans the record run.
   "longest-win-streak": StreakRecordAchievementData;
   "longest-lose-streak": StreakRecordAchievementData;
+  // Record-breaking alternation achievement — the longest run of strictly
+  // alternating results (win, loss, win, loss or the mirror). Shares the
+  // streak-record data shape and growth behaviour.
+  "jing-jang": StreakRecordAchievementData;
   "group-stage-star": { tournamentId: string; wins: number };
   "full-house": { count: number; firstGameAt: number };
   "humbled": { count: number; firstGameAt: number };
@@ -3954,6 +4074,7 @@ export const ACHIEVEMENT_IS_REACHIEVABLE: Record<AchievementType, boolean> = {
   "streak-ender": true, // Per ended streak
   "longest-win-streak": true, // League records — can be retaken
   "longest-lose-streak": true,
+  "jing-jang": true,
   "group-stage-star": true, // Per tournament's group play
   "full-house": false,
   "humbled": false,
@@ -3990,7 +4111,8 @@ export type Achievement = {
 // interchangeably.
 type StreakRecordAchievement =
   | GenericAchievement<"longest-win-streak">
-  | GenericAchievement<"longest-lose-streak">;
+  | GenericAchievement<"longest-lose-streak">
+  | GenericAchievement<"jing-jang">;
 
 // The award for holding a games-in-a-period record — grown through the
 // day / week / month while the player still holds the record with it. The
@@ -4251,6 +4373,7 @@ export type AchievementProgression = {
   "streak-ender": BaseProgression;
   "longest-win-streak": StreakRecordProgression;
   "longest-lose-streak": StreakRecordProgression;
+  "jing-jang": StreakRecordProgression;
   "hero-of-the-day": HeroRecordProgression;
   "hero-of-the-week": HeroRecordProgression;
   "hero-of-the-month": HeroRecordProgression;

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -47,6 +47,25 @@ export function isMilestoneGameNumber(gameNumber: number): boolean {
   return gameNumber > 0 && gameNumber % MILESTONE_GAME_INTERVAL === 0;
 }
 
+// Career deuce sets a player must win for "Deuce Demon". A qualifying set is
+// won 12–10 or higher (winner ≥ 12, loser ≥ 10 — the same rule Marathon Set
+// uses to recognise a true-deuce set). The count only grows, so the
+// achievement is earned once.
+export const DEUCE_DEMON_TARGET = 10;
+
+// Higher-ranked opponents a player must beat within one local calendar day
+// for "Giant Hunting". A win counts when the opponent's pre-match rank was
+// better (lower) than the player's own pre-match rank, both were ranked, and
+// the ranked cohort had ≥5 players — the gate the other rank achievements use.
+export const GIANT_HUNTING_TARGET = 3;
+
+// Wins an opponent must have in a still-undefeated day for beating them to
+// count as "Party Pooper". It matches Perfect Day's win requirement on
+// purpose: at this count with zero losses the opponent's Perfect Day was
+// already secured pending the end of the day, so the loss provably
+// destroyed one.
+export const PARTY_POOPER_MIN_WINS = 5;
+
 export class Achievements {
   private parent: TennisTable;
   private hasCalculated = false;
@@ -168,6 +187,13 @@ export class Achievements {
     count: undefined,
     holder: undefined,
   };
+  // Giant Hunting bookkeeping from the Elo pass. lastGiantDay is each
+  // player's most recent local calendar day with a win over a higher-ranked
+  // opponent (the day's local midnight and how many such wins it holds so
+  // far); bestGiantDayCount is their best such day ever. Used for Giant
+  // Hunting progression — the chase resets at local midnight.
+  lastGiantDay: Map<string, { day: number; count: number }> = new Map();
+  bestGiantDayCount: Map<string, number> = new Map();
 
   constructor(parent: TennisTable) {
     this.parent = parent;
@@ -200,6 +226,8 @@ export class Achievements {
     this.gamesInDayRecord = { count: undefined, holder: undefined };
     this.gamesInWeekRecord = { count: undefined, holder: undefined };
     this.gamesInMonthRecord = { count: undefined, holder: undefined };
+    this.lastGiantDay.clear();
+    this.bestGiantDayCount.clear();
 
     const playerTracker = new Map<
       string,
@@ -231,6 +259,7 @@ export class Achievements {
         closeCallsCount: number;
         edgeLordCount: number;
         consistencyCount: number;
+        deuceSetsWon: number; // Career deuce sets won, for Deuce Demon
         opponentsPlayed: Set<string>;
         gamesPerOpponent: Map<string, { count: number; firstGame: number; lastGame: number }>;
         firstOpponentFor: Set<string>; // Track players this person was first opponent for
@@ -284,6 +313,7 @@ export class Achievements {
           closeCallsCount: 0,
           edgeLordCount: 0,
           consistencyCount: 0,
+          deuceSetsWon: 0,
           opponentsPlayed: new Set(),
           gamesPerOpponent: new Map(),
           firstOpponentFor: new Set(),
@@ -309,6 +339,7 @@ export class Achievements {
           closeCallsCount: 0,
           edgeLordCount: 0,
           consistencyCount: 0,
+          deuceSetsWon: 0,
           opponentsPlayed: new Set(),
           gamesPerOpponent: new Map(),
           firstOpponentFor: new Set(),
@@ -644,6 +675,10 @@ export class Achievements {
           game.playedAt,
         );
         this.#checkShootoutAchievement(game.winner, game.loser, game.id, game.score.setPoints, game.playedAt);
+
+        // Check for "Deuce Demon": career deuce sets won. Either player can
+        // win a qualifying set regardless of who wins the game.
+        this.#checkDeuceDemonAchievement(game, winner, loser);
       }
 
       // Check for donut achievements (individual sets where loser scored 0)
@@ -843,6 +878,15 @@ export class Achievements {
   // Both are earnable multiple times — once per qualifying day / week.
   // Games are already time-ordered, so the completing win's timestamp is
   // the natural earned-at moment.
+  //
+  // Party Pooper piggybacks on the same per-day stats: it goes to a winner
+  // whose opponent was undefeated that day with PARTY_POOPER_MIN_WINS or
+  // more wins — enough that the day would have ended as a Perfect Day, so
+  // this first loss of the day provably destroyed one. Awarded immediately
+  // (the destruction is final however the day continues) and earnable once
+  // per opponent per day, since the opponent cannot be undefeated again
+  // that day. The spoiled player keeps nothing — their day simply no longer
+  // qualifies as perfect.
   #checkPerfectDayAndWeekAchievements() {
     // Local midnight of the day containing `ms`.
     const dayStartOf = (ms: number): number => {
@@ -899,7 +943,22 @@ export class Achievements {
       const winnerDay = getDayStats(game.winner, day);
       winnerDay.wins++;
       winnerDay.lastWinAt = game.playedAt;
-      getDayStats(game.loser, day).losses++;
+
+      // Party Pooper: checked before the loss is recorded, so `loserDay`
+      // still shows the opponent's day as it stood going into this game.
+      const loserDay = getDayStats(game.loser, day);
+      if (loserDay.losses === 0 && loserDay.wins >= PARTY_POOPER_MIN_WINS) {
+        this.#addAchievement(
+          game.winner,
+          this.#createAchievement("party-pooper", game.winner, game.playedAt, {
+            gameId: game.id,
+            opponent: game.loser,
+            day,
+            opponentWins: loserDay.wins,
+          }),
+        );
+      }
+      loserDay.losses++;
 
       // Perfect Week counts wins on any day; what matters is completing a
       // run of 5 consecutive won days inside the week (start offset 0, 1 or
@@ -969,8 +1028,11 @@ export class Achievements {
     }
   }
 
-  // Awards "Full House" (beat every currently ranked player at least once)
-  // and "Humbled" (lose to every currently ranked player at least once). The
+  // Awards "Full House" (beat every currently ranked player at least once),
+  // "Humbled" (lose to every currently ranked player at least once) and
+  // "Everybody's Opponent" (play every currently ranked player at least
+  // once — wins and losses both count, so it always completes no later
+  // than the first of the other two). The
   // target cohort is the set of ranked players AT THE MOMENT being evaluated,
   // which shifts as players cross the ranked threshold or are deactivated /
   // reactivated (a deactivated player is not ranked). A win / loss counts
@@ -987,10 +1049,10 @@ export class Achievements {
   // Requires ≥5 ranked players in the cohort so completing the set is a real
   // feat, matching the gate used by the rank achievements. The earner
   // does NOT need to be ranked themselves — an unranked player who has beaten
-  // (or lost to) the whole ranked field still qualifies. Each is awarded
-  // once, stamped at the moment the set completes, recording how many players
-  // were beaten / lost to and the player's first game (so the display can
-  // show how long it took).
+  // (or lost to, or played) the whole ranked field still qualifies. Each is
+  // awarded once, stamped at the moment the set completes, recording how many
+  // players were beaten / lost to / played and the player's first game (so
+  // the display can show how long it took).
   #checkFullHouseAndHumbledAchievements() {
     const gameLimit = this.parent.client.gameLimitForRanked;
 
@@ -1029,8 +1091,10 @@ export class Achievements {
     const firstGameAt = new Map<string, number>();
     const beaten = new Map<string, Set<string>>();
     const lostTo = new Map<string, Set<string>>();
+    const played = new Map<string, Set<string>>();
     const fullHouseAwarded = new Set<string>();
     const humbledAwarded = new Set<string>();
+    const everybodysOpponentAwarded = new Set<string>();
 
     const addEdge = (map: Map<string, Set<string>>, key: string, value: string) => {
       let set = map.get(key);
@@ -1092,6 +1156,19 @@ export class Achievements {
             }),
           );
         }
+        if (
+          !everybodysOpponentAwarded.has(playerId) &&
+          coversCohort(played.get(playerId), cohort, playerId)
+        ) {
+          everybodysOpponentAwarded.add(playerId);
+          this.#addAchievement(
+            playerId,
+            this.#createAchievement("everybodys-opponent", playerId, time, {
+              count: targetCount,
+              firstGameAt: firstGameAt.get(playerId)!,
+            }),
+          );
+        }
       }
     };
 
@@ -1125,6 +1202,8 @@ export class Achievements {
         if (!firstGameAt.has(game.loser)) firstGameAt.set(game.loser, game.playedAt);
         addEdge(beaten, game.winner, game.loser);
         addEdge(lostTo, game.loser, game.winner);
+        addEdge(played, game.winner, game.loser);
+        addEdge(played, game.loser, game.winner);
       }
       recheckAt(action.time);
     }
@@ -1216,6 +1295,14 @@ export class Achievements {
     const onPodium = new Set<string>();
     const kingslayed = new Set<string>();
     const climber = new Set<string>();
+
+    // Giant Hunting: per-player chase state for the local calendar day being
+    // played — how many higher-ranked opponents they have beaten in it, and
+    // who they were. Reset when a qualifying win lands on a new day.
+    const giantDayState = new Map<
+      string,
+      { day: number; count: number; giants: { opponent: string; opponentRank: number; playerRank: number }[] }
+    >();
 
     // Per-player map of opponent → net Elo gained from that opponent.
     // When a player first reaches rank #1, the opponent who contributed
@@ -1429,6 +1516,45 @@ export class Achievements {
             gameId: game.id,
           }),
         );
+      }
+
+      // Giant Hunting: the winner beat an opponent whose pre-match rank was
+      // better (lower) than their own. Such wins are counted per local
+      // calendar day; the GIANT_HUNTING_TARGET-th in one day earns the
+      // achievement, once per day (a 4th giant that day does not re-award).
+      // Both players must be ranked pre-match, with the same ≥5 cohort gate
+      // as the other rank achievements.
+      if (
+        winnerRankBefore !== null &&
+        loserRankBefore !== null &&
+        loserRankBefore < winnerRankBefore &&
+        rankedCountBefore >= 5
+      ) {
+        const day = this.#dayStartOf(game.playedAt);
+        let giantState = giantDayState.get(game.winner);
+        if (!giantState || giantState.day !== day) {
+          giantState = { day, count: 0, giants: [] };
+          giantDayState.set(game.winner, giantState);
+        }
+        giantState.count++;
+        giantState.giants.push({
+          opponent: game.loser,
+          opponentRank: loserRankBefore,
+          playerRank: winnerRankBefore,
+        });
+        this.lastGiantDay.set(game.winner, { day, count: giantState.count });
+        if (giantState.count > (this.bestGiantDayCount.get(game.winner) ?? 0)) {
+          this.bestGiantDayCount.set(game.winner, giantState.count);
+        }
+        if (giantState.count === GIANT_HUNTING_TARGET) {
+          this.#addAchievement(
+            game.winner,
+            this.#createAchievement("giant-hunting", game.winner, game.playedAt, {
+              day,
+              giants: [...giantState.giants],
+            }),
+          );
+        }
       }
 
       // Apply Elo update.
@@ -1713,6 +1839,44 @@ export class Achievements {
 
       this.marathonSetRecord = { score: setWinnerScore, holder: setWinnerId };
     });
+  }
+
+  // Awards "Deuce Demon" when a player's career total of won deuce sets
+  // (winner ≥ 12, loser ≥ 10 — the Marathon Set qualifying rule) reaches
+  // DEUCE_DEMON_TARGET. One game can contain several qualifying sets and can
+  // jump the total past the target, so the award triggers on the crossing,
+  // not on an exact count. Earnable once.
+  #checkDeuceDemonAchievement(
+    game: Game,
+    winnerTracker: { deuceSetsWon: number },
+    loserTracker: { deuceSetsWon: number },
+  ) {
+    if (!game.score?.setPoints) return;
+
+    let winnerDeuceSets = 0;
+    let loserDeuceSets = 0;
+    for (const set of game.score.setPoints) {
+      if (set.gameWinner === set.gameLoser) continue;
+      const setWinnerScore = Math.max(set.gameWinner, set.gameLoser);
+      const setLoserScore = Math.min(set.gameWinner, set.gameLoser);
+      if (setWinnerScore < 12 || setLoserScore < 10) continue;
+      if (set.gameWinner > set.gameLoser) winnerDeuceSets++;
+      else loserDeuceSets++;
+    }
+
+    const applyDeuceSets = (playerId: string, tracker: { deuceSetsWon: number }, setsWon: number) => {
+      if (setsWon === 0) return;
+      const before = tracker.deuceSetsWon;
+      tracker.deuceSetsWon += setsWon;
+      if (before < DEUCE_DEMON_TARGET && tracker.deuceSetsWon >= DEUCE_DEMON_TARGET) {
+        this.#addAchievement(
+          playerId,
+          this.#createAchievement("deuce-demon", playerId, game.playedAt, undefined),
+        );
+      }
+    };
+    applyDeuceSets(game.winner, winnerTracker, winnerDeuceSets);
+    applyDeuceSets(game.loser, loserTracker, loserDeuceSets);
   }
 
   // The sets that count toward a game's Shootout score: its
@@ -2581,6 +2745,7 @@ export class Achievements {
       "perfect-day": { current: 0, target: 5, earned: 0 },
       "perfect-week": { current: 0, target: 5, earned: 0 },
       "streak-ender": { earned: 0 },
+      "party-pooper": { earned: 0 },
       // Record-chasing achievements are earned by strictly exceeding the
       // league record, so their target is one beyond it — reaching the
       // target is what earns the award, same as every other progress bar.
@@ -2610,6 +2775,9 @@ export class Achievements {
       "touched-the-throne": { earned: 0 },
       "kingslayer": { earned: 0 },
       "king-maker": { earned: 0 },
+      // Giant Hunting resets at local midnight: current is today's wins over
+      // higher-ranked opponents, best the most in any single day.
+      "giant-hunting": { current: 0, target: GIANT_HUNTING_TARGET, best: 0, earned: 0 },
       "leap-frog": {
         earned: 0,
         current: 0,
@@ -2633,6 +2801,7 @@ export class Achievements {
       "climber": { current: 0, target: 300, earned: 0 },
       "full-house": { current: 0, target: 1, missing: new Set(), earned: 0 },
       "humbled": { current: 0, target: 1, missing: new Set(), earned: 0 },
+      "everybodys-opponent": { current: 0, target: 1, missing: new Set(), earned: 0 },
 
       // Game feats
       "donut-1": { current: 0, target: 1, earned: 0 },
@@ -2642,6 +2811,7 @@ export class Achievements {
       "close-calls": { current: 0, target: 5, earned: 0 },
       "edge-lord": { current: 0, target: 20, earned: 0 },
       "consistency-is-key": { current: 0, target: 5, earned: 0 },
+      "deuce-demon": { current: 0, target: DEUCE_DEMON_TARGET, earned: 0 },
       "photo-finish": { earned: 0 },
       "marathon-set": {
         earned: 0,
@@ -2731,6 +2901,7 @@ export class Achievements {
     let edgeLordCount = 0;
     let consistencyCount = 0;
     let bestDeuceSetWon = 0;
+    let deuceSetsWonCount = 0;
     const streaksPerOpponent = new Map<string, number>();
     // Highest win streak the player has EVER held against a single opponent —
     // streaksPerOpponent only carries live streaks, which reset when that
@@ -2944,8 +3115,11 @@ export class Achievements {
           const setWinnerIsGameWinner = set.gameWinner > set.gameLoser;
           const playerWonSet =
             (isWinner && setWinnerIsGameWinner) || (isLoser && !setWinnerIsGameWinner);
-          if (playerWonSet && setWinnerScore > bestDeuceSetWon) {
-            bestDeuceSetWon = setWinnerScore;
+          if (playerWonSet) {
+            deuceSetsWonCount++;
+            if (setWinnerScore > bestDeuceSetWon) {
+              bestDeuceSetWon = setWinnerScore;
+            }
           }
         });
       }
@@ -2965,6 +3139,7 @@ export class Achievements {
     progression["edge-lord"].current = edgeLordCount;
     progression["consistency-is-key"].current = consistencyCount;
     progression["marathon-set"].current = bestDeuceSetWon;
+    progression["deuce-demon"].current = deuceSetsWonCount;
     progression["variety-player"].current = opponentsPlayed.size;
     progression["variety-player"].opponents = opponentsPlayed;
     progression["global-player"].current = opponentsPlayed.size;
@@ -3425,6 +3600,17 @@ export class Achievements {
     progression["kingslayer"].best = bestBeatenEntry?.rank;
     progression["kingslayer"].bestOpponent = bestBeatenEntry?.opponent;
 
+    // Giant Hunting progression: today's wins over higher-ranked opponents —
+    // the chase resets at local midnight — with the player's best single-day
+    // count ever alongside. Capped at the target so an over-hunted day never
+    // reads past 100%.
+    const giantDay = this.lastGiantDay.get(playerId);
+    progression["giant-hunting"].current =
+      giantDay !== undefined && giantDay.day === this.#dayStartOf(now)
+        ? Math.min(giantDay.count, GIANT_HUNTING_TARGET)
+        : 0;
+    progression["giant-hunting"].best = this.bestGiantDayCount.get(playerId) ?? 0;
+
     // Group Play Star best: the player's group play that came closest to
     // perfect — the highest share of games won, ties broken by more wins, so
     // 3 of 4 beats 3 of 6 and a perfect 3 of 3 beats both. Both numbers are
@@ -3462,10 +3648,17 @@ export class Achievements {
     const enoughRanked = rankedActiveIds.length >= 5;
     const beatenRanked = new Set<string>();
     const lostToRanked = new Set<string>();
+    const playedRanked = new Set<string>();
     if (enoughRanked) {
       this.parent.games.forEach((game) => {
-        if (game.winner === playerId && rankedTargetPool.has(game.loser)) beatenRanked.add(game.loser);
-        if (game.loser === playerId && rankedTargetPool.has(game.winner)) lostToRanked.add(game.winner);
+        if (game.winner === playerId && rankedTargetPool.has(game.loser)) {
+          beatenRanked.add(game.loser);
+          playedRanked.add(game.loser);
+        }
+        if (game.loser === playerId && rankedTargetPool.has(game.winner)) {
+          lostToRanked.add(game.winner);
+          playedRanked.add(game.winner);
+        }
       });
     }
     const rankedTarget = rankedTargetPool.size;
@@ -3474,12 +3667,16 @@ export class Achievements {
     // empty, so the whole target pool shows as missing.
     const fullHouseMissing = new Set([...rankedTargetPool].filter((id) => !beatenRanked.has(id)));
     const humbledMissing = new Set([...rankedTargetPool].filter((id) => !lostToRanked.has(id)));
+    const everybodysOpponentMissing = new Set([...rankedTargetPool].filter((id) => !playedRanked.has(id)));
     progression["full-house"].current = beatenRanked.size;
     progression["full-house"].target = rankedTarget;
     progression["full-house"].missing = fullHouseMissing;
     progression["humbled"].current = lostToRanked.size;
     progression["humbled"].target = rankedTarget;
     progression["humbled"].missing = humbledMissing;
+    progression["everybodys-opponent"].current = playedRanked.size;
+    progression["everybodys-opponent"].target = rankedTarget;
+    progression["everybodys-opponent"].missing = everybodysOpponentMissing;
 
     // Sweet Revenge progression: the missing set is the rivals still to beat
     // — active players holding an unavenged tournament-match win over this
@@ -3645,6 +3842,25 @@ type AchievementDefinitions = {
   "group-stage-star": { tournamentId: string; wins: number };
   "full-house": { count: number; firstGameAt: number };
   "humbled": { count: number; firstGameAt: number };
+  // Played every currently ranked player at least once (wins and losses
+  // both count). Same shape as Full House / Humbled: how many ranked
+  // players the completed set held, and the player's first game.
+  "everybodys-opponent": { count: number; firstGameAt: number };
+  // Career deuce sets won (winner ≥ 12, loser ≥ 10) reached
+  // DEUCE_DEMON_TARGET. A pure counter crossing — no game to point at.
+  "deuce-demon": undefined;
+  // Beat GIANT_HUNTING_TARGET higher-ranked opponents within one local
+  // calendar day. `day` is that day's local midnight; `giants` the wins that
+  // filled the day's tally, each with the pre-match ranks of both players.
+  "giant-hunting": {
+    day: number;
+    giants: { opponent: string; opponentRank: number; playerRank: number }[];
+  };
+  // Handed an opponent their first loss of a day they had already won
+  // PARTY_POOPER_MIN_WINS or more games — destroying the Perfect Day they
+  // had secured. `day` is that day's local midnight and `opponentWins` the
+  // undefeated win count the loss spoiled.
+  "party-pooper": { gameId: string; opponent: string; day: number; opponentWins: number };
   // Record-breaking time-of-day achievements. Awarded to both players of
   // the game that sets a new league-wide earliest / latest time-of-day
   // record. `time` is the "HH:MM" the game was played and `minutesIntoDay`
@@ -3741,6 +3957,10 @@ export const ACHIEVEMENT_IS_REACHIEVABLE: Record<AchievementType, boolean> = {
   "group-stage-star": true, // Per tournament's group play
   "full-house": false,
   "humbled": false,
+  "everybodys-opponent": false,
+  "deuce-demon": false,
+  "giant-hunting": true, // Per qualifying day
+  "party-pooper": true, // Per spoiled perfect day
   "earliest-game": true, // League records — can be retaken
   "latest-game": true,
   "shootout": true, // League record
@@ -4038,6 +4258,10 @@ export type AchievementProgression = {
   "sweet-revenge": MissingPlayersProgression;
   "full-house": MissingPlayersProgression;
   "humbled": MissingPlayersProgression;
+  "everybodys-opponent": MissingPlayersProgression;
+  "deuce-demon": ProgressionWithTarget;
+  "giant-hunting": ProgressionWithTarget;
+  "party-pooper": BaseProgression;
   "earliest-game": TimeOfDayRecordProgression;
   "latest-game": TimeOfDayRecordProgression;
 };

--- a/frontend/src/pages/achievements/achievements-list.tsx
+++ b/frontend/src/pages/achievements/achievements-list.tsx
@@ -283,6 +283,14 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                           : " (first league record!)"}
                       </span>
                     )}
+                  {achievement.type === "jing-jang" && achievement.data && (
+                    <span className="text-[11px] opacity-80">
+                      {achievement.data.streakLength} alternating results in a row
+                      {achievement.data.previousRecord !== undefined
+                        ? ` (prev record ${achievement.data.previousRecord})`
+                        : " (first league record!)"}
+                    </span>
+                  )}
                   {achievement.type === "perfect-day" && achievement.data && (
                     <span className="text-[11px] opacity-80">
                       {achievement.data.wins} wins, 0 losses

--- a/frontend/src/pages/achievements/achievements-list.tsx
+++ b/frontend/src/pages/achievements/achievements-list.tsx
@@ -307,10 +307,16 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                         " in the same tournament"}
                     </span>
                   )}
-                  {(achievement.type === "full-house" || achievement.type === "humbled") &&
+                  {(achievement.type === "full-house" ||
+                    achievement.type === "humbled" ||
+                    achievement.type === "everybodys-opponent") &&
                     achievement.data && (
                       <span className="text-[11px] opacity-80">
-                        {achievement.type === "full-house" ? "Beat " : "Lost to "}
+                        {achievement.type === "full-house"
+                          ? "Beat "
+                          : achievement.type === "humbled"
+                            ? "Lost to "
+                            : "Played "}
                         {achievement.data.count} ranked player
                         {achievement.data.count !== 1 ? "s" : ""} in{" "}
                         {Math.round(
@@ -319,6 +325,19 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                         days
                       </span>
                     )}
+                  {achievement.type === "giant-hunting" && achievement.data && (
+                    <span className="text-[11px] opacity-80">
+                      Beat{" "}
+                      {achievement.data.giants
+                        .map((giant) => `${context.playerName(giant.opponent)} (#${giant.opponentRank})`)
+                        .join(", ")}
+                    </span>
+                  )}
+                  {achievement.type === "party-pooper" && achievement.data && (
+                    <span className="text-[11px] opacity-80">
+                      Spoiled an undefeated day of {achievement.data.opponentWins} wins
+                    </span>
+                  )}
                   {achievement.type === "leap-frog" && achievement.data && (
                     <span className="text-[11px] opacity-80">
                       Jumped {achievement.data.ranksJumped} rank

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -324,6 +324,26 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
     description: "Lose to every currently ranked player at least once",
     icon: "🙇",
   },
+  "everybodys-opponent": {
+    title: "Everybody's Opponent",
+    description: "Play every currently ranked player at least once — wins and losses both count",
+    icon: "🧩",
+  },
+  "deuce-demon": {
+    title: "Deuce Demon",
+    description: "Win 10 deuce sets (a set won 12–10 or higher)",
+    icon: "🔱",
+  },
+  "giant-hunting": {
+    title: "Giant Hunting",
+    description: "Beat 3 higher-ranked players in a single day",
+    icon: "🏹",
+  },
+  "party-pooper": {
+    title: "Party Pooper",
+    description: "Hand a player their first loss of a day they had already won 5 or more games — spoiling their Perfect Day",
+    icon: "💩",
+  },
   "earliest-game": {
     title: "Earliest Game",
     description: "Play the earliest game of the day on record",
@@ -696,11 +716,34 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
                   </p>
                 )}
 
-                {(achievement.type === "full-house" || achievement.type === "humbled") && achievement.data && (
+                {(achievement.type === "full-house" ||
+                  achievement.type === "humbled" ||
+                  achievement.type === "everybodys-opponent") &&
+                  achievement.data && (
+                    <p className="text-xs text-secondary-text/70 mt-2">
+                      {achievement.type === "full-house"
+                        ? "Beat "
+                        : achievement.type === "humbled"
+                          ? "Lost to "
+                          : "Played "}
+                      {achievement.data.count} ranked player{achievement.data.count !== 1 ? "s" : ""} in{" "}
+                      {daysBetween(achievement.data.firstGameAt, achievement.earnedAt)} days
+                    </p>
+                  )}
+
+                {achievement.type === "giant-hunting" && achievement.data && (
                   <p className="text-xs text-secondary-text/70 mt-2">
-                    {achievement.type === "full-house" ? "Beat " : "Lost to "}
-                    {achievement.data.count} ranked player{achievement.data.count !== 1 ? "s" : ""} in{" "}
-                    {daysBetween(achievement.data.firstGameAt, achievement.earnedAt)} days
+                    Beat{" "}
+                    {achievement.data.giants
+                      .map((giant) => `${context.playerName(giant.opponent)} (#${giant.opponentRank})`)
+                      .join(", ")}{" "}
+                    on {dateString(achievement.data.day)}
+                  </p>
+                )}
+
+                {achievement.type === "party-pooper" && achievement.data && (
+                  <p className="text-xs text-secondary-text/70 mt-2">
+                    They were undefeated with {achievement.data.opponentWins} wins that day
                   </p>
                 )}
 
@@ -1168,7 +1211,10 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                         )}
 
                       {/* Missing players for full-house / humbled / sweet-revenge */}
-                      {(type === "full-house" || type === "humbled" || type === "sweet-revenge") &&
+                      {(type === "full-house" ||
+                        type === "humbled" ||
+                        type === "everybodys-opponent" ||
+                        type === "sweet-revenge") &&
                         "missing" in data &&
                         data.missing &&
                         data.missing.size > 0 && (
@@ -1178,7 +1224,9 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                                 ? "Still need to beat:"
                                 : type === "humbled"
                                   ? "Still need to lose to:"
-                                  : "They beat you in a tournament — beat them in a tournament match to avenge it:"}
+                                  : type === "everybodys-opponent"
+                                    ? "Still need to play:"
+                                    : "They beat you in a tournament — beat them in a tournament match to avenge it:"}
                             </p>
                             <div className="flex flex-wrap gap-1">
                               {Array.from(data.missing).map((player: string) => (

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -7,6 +7,7 @@ import {
   AchievementProgression,
   GAMES_IN_PERIOD_RECORD_FLOOR,
   isReachievableAchievement,
+  JING_JANG_RECORD_FLOOR,
   SHOOTOUT_RECORD_FLOOR,
   SHOOTOUT_SETS_COUNTED,
   STREAK_RECORD_FLOOR,
@@ -78,6 +79,11 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
     title: "Longest Lose Streak",
     description: "Suffer the longest run of consecutive losses in league history",
     icon: "🕳️",
+  },
+  "jing-jang": {
+    title: "Jing Jang",
+    description: "Put together the longest run of alternating wins and losses in league history",
+    icon: "☯️",
   },
   "comeback-kid": {
     title: "Comeback Kid",
@@ -681,6 +687,15 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
                         : " (first league record!)"}
                     </p>
                   )}
+
+                {achievement.type === "jing-jang" && achievement.data && (
+                  <p className="text-xs text-secondary-text/70 mt-2">
+                    {achievement.data.streakLength} alternating results in a row
+                    {achievement.data.previousRecord !== undefined
+                      ? ` (previous record: ${achievement.data.previousRecord})`
+                      : " (first league record!)"}
+                  </p>
+                )}
 
                 {achievement.type === "back-from-the-dead" && achievement.data && (
                   <p className="text-xs text-secondary-text/70 mt-2">
@@ -1378,6 +1393,32 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                             </p>
                           </div>
                         )}
+
+                      {/* Record holder for Jing Jang. The bar tracks the live
+                          alternation run; the player's longest ever run is the
+                          shared "Best" value next to the progress numbers. */}
+                      {type === "jing-jang" && "recordHolder" in data && (
+                        <div className="mt-2 text-xs text-secondary-text/70 space-y-1">
+                          <p>
+                            {data.recordHolder ? (
+                              <>
+                                League record held by{" "}
+                                <Link to={{ pathname: "/player/" + data.recordHolder, search }}>
+                                  <span className="text-secondary-text underline">
+                                    {context.playerName(data.recordHolder)}
+                                  </span>
+                                </Link>
+                                . Alternate wins and losses for {data.target} games in a row to take it.
+                              </>
+                            ) : (
+                              <>
+                                No record set yet — alternate wins and losses for {JING_JANG_RECORD_FLOOR} games
+                                in a row to start the record.
+                              </>
+                            )}
+                          </p>
+                        </div>
+                      )}
                     </>
                   ) : type === "marathon-set" ? (
                     <div className="mt-2 text-xs text-secondary-text/70">
@@ -1401,6 +1442,11 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                     <div className="mt-2 text-xs text-secondary-text/70">
                       No league record yet — {type === "longest-win-streak" ? "win" : "lose"}{" "}
                       {STREAK_RECORD_FLOOR} in a row to set the first record.
+                    </div>
+                  ) : type === "jing-jang" ? (
+                    <div className="mt-2 text-xs text-secondary-text/70">
+                      No league record yet — alternate wins and losses for {JING_JANG_RECORD_FLOOR} games in a
+                      row to set the first record.
                     </div>
                   ) : type in HERO_RECORD_PERIODS ? (
                     <div className="mt-2 text-xs text-secondary-text/70">


### PR DESCRIPTION
- Everybody's Opponent 🧩: play every currently ranked player at least
  once (wins and losses both count). Rides the same cohort replay as
  Full House / Humbled, including completion through deactivations, and
  shows the players still to play in the Progress tab.
- Deuce Demon 🔱: win 10 career deuce sets (won 12-10 or higher, the
  Marathon Set qualifying rule). Sets won by the game loser count too.
- Giant Hunting 🏹: beat 3 higher-ranked opponents in one local calendar
  day, both ranked pre-match with the usual >=5 ranked cohort gate.
  Earnable once per day; progression resets at midnight and keeps the
  best day ever.
- Party Pooper 💩: hand an opponent their first loss of a day on which
  they had already won 5+ games, destroying the Perfect Day they had
  secured. Awarded immediately, once per opponent per day.

All four have labels, earned-card details and progression wired into
the player page and the league-wide achievements feed, tests for award
and progression paths, and a changelog post.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TkYRovmCHEhf88GzX3UbWw