### PR TITLE
Clarify Giant Hunting counts wins, not distinct opponents

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -52,7 +52,7 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
       list(
         "Everybody's Opponent 🧩 - play every currently ranked player at least once. Wins and losses both count.",
         "Deuce Demon 🔱 - win 10 deuce sets in total. A deuce set is won 12-10 or higher.",
-        "Giant Hunting 🏹 - beat 3 higher-ranked players in 1 day. You can earn it again on a later day.",
+        "Giant Hunting 🏹 - win 3 games against higher-ranked players in 1 day. Wins against the same player count. You can earn it again on a later day.",
         "Party Pooper 💩 - give a player their first loss on a day they had won 5 or more games. This removes their Perfect Day.",
         "Jing Jang ☯️ - a league record. Play the longest run of games where each result is different from the one before: win, loss, win, loss.",
       ),

--- a/frontend/src/client/client-db/__tests__/achievements/giant-hunting.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/giant-hunting.test.ts
@@ -1,10 +1,11 @@
 import { EventType, EventTypeEnum } from "../../event-store/event-types";
 import { TennisTable } from "../../tennis-table";
 
-// Giant Hunting: beat 3 higher-ranked opponents within one local calendar
-// day. A win counts when the opponent's pre-match rank was better (lower)
-// than the player's own, both were ranked, and the ranked cohort had ≥5
-// players. Once per day; a new day is a new chase.
+// Giant Hunting: win 3 games against higher-ranked opponents within one
+// local calendar day — counted per game, not per distinct opponent. A win
+// counts when the opponent's pre-match rank was better (lower) than the
+// player's own, both were ranked, and the ranked cohort had ≥5 players.
+// Once per day; a new day is a new chase.
 // Default GuestClient has gameLimitForRanked = 5.
 
 describe("Giant Hunting Achievement", () => {
@@ -67,6 +68,27 @@ describe("Giant Hunting Achievement", () => {
     expect(awards[0].data.giants).toHaveLength(3);
     expect(awards[0].data.giants.map((g) => g.opponent)).toEqual(["a", "b", "c"]);
     // Every slain giant outranked the hunter going into the match.
+    for (const giant of awards[0].data.giants) {
+      expect(giant.opponentRank).toBeLessThan(giant.playerRank);
+    }
+  });
+
+  it("counts wins, not distinct opponents — 3 wins over the same giant award it", () => {
+    const events: EventType[] = [
+      ...fivePlayerSetup(),
+      // Jan 15: bottom-ranked E beats top-ranked A three times. A must still
+      // outrank E before each game for every win to count.
+      gameAt("h1", new Date(2024, 0, 15, 10).getTime(), "e", "a"),
+      gameAt("h2", new Date(2024, 0, 15, 11).getTime(), "e", "a"),
+      gameAt("h3", new Date(2024, 0, 15, 12).getTime(), "e", "a"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const awards = tt.achievements.getAchievements("e").filter((x) => x.type === "giant-hunting");
+    expect(awards).toHaveLength(1);
+    expect(awards[0].data.giants.map((g) => g.opponent)).toEqual(["a", "a", "a"]);
     for (const giant of awards[0].data.giants) {
       expect(giant.opponentRank).toBeLessThan(giant.playerRank);
     }

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -60,8 +60,10 @@ export const DEUCE_DEMON_TARGET = 10;
 // record exists the floor is irrelevant — only beating the record counts.
 export const JING_JANG_RECORD_FLOOR = 5;
 
-// Higher-ranked opponents a player must beat within one local calendar day
-// for "Giant Hunting". A win counts when the opponent's pre-match rank was
+// Wins over higher-ranked opponents a player needs within one local calendar
+// day for "Giant Hunting". Counted per game, not per distinct opponent — the
+// same giant beaten again counts again while still ranked above the player.
+// A win counts when the opponent's pre-match rank was
 // better (lower) than the player's own pre-match rank, both were ranked, and
 // the ranked cohort had ≥5 players — the gate the other rank achievements use.
 export const GIANT_HUNTING_TARGET = 3;
@@ -1340,8 +1342,9 @@ export class Achievements {
     const climber = new Set<string>();
 
     // Giant Hunting: per-player chase state for the local calendar day being
-    // played — how many higher-ranked opponents they have beaten in it, and
-    // who they were. Reset when a qualifying win lands on a new day.
+    // played — how many wins over higher-ranked opponents it holds so far,
+    // and one entry per win (the same opponent can appear more than once).
+    // Reset when a qualifying win lands on a new day.
     const giantDayState = new Map<
       string,
       { day: number; count: number; giants: { opponent: string; opponentRank: number; playerRank: number }[] }
@@ -1563,8 +1566,10 @@ export class Achievements {
 
       // Giant Hunting: the winner beat an opponent whose pre-match rank was
       // better (lower) than their own. Such wins are counted per local
-      // calendar day; the GIANT_HUNTING_TARGET-th in one day earns the
-      // achievement, once per day (a 4th giant that day does not re-award).
+      // calendar day — per game, not per distinct opponent, so re-beating the
+      // same giant counts while they still outrank the player. The
+      // GIANT_HUNTING_TARGET-th win in one day earns the achievement, once
+      // per day (a 4th giant win that day does not re-award).
       // Both players must be ranked pre-match, with the same ≥5 cohort gate
       // as the other rank achievements.
       if (
@@ -3971,9 +3976,10 @@ type AchievementDefinitions = {
   // Career deuce sets won (winner ≥ 12, loser ≥ 10) reached
   // DEUCE_DEMON_TARGET. A pure counter crossing — no game to point at.
   "deuce-demon": undefined;
-  // Beat GIANT_HUNTING_TARGET higher-ranked opponents within one local
-  // calendar day. `day` is that day's local midnight; `giants` the wins that
-  // filled the day's tally, each with the pre-match ranks of both players.
+  // Won GIANT_HUNTING_TARGET games against higher-ranked opponents within
+  // one local calendar day. `day` is that day's local midnight; `giants` the
+  // wins that filled the day's tally, each with the pre-match ranks of both
+  // players — the same opponent can appear more than once.
   "giant-hunting": {
     day: number;
     giants: { opponent: string; opponentRank: number; playerRank: number }[];

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -342,7 +342,7 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
   },
   "giant-hunting": {
     title: "Giant Hunting",
-    description: "Beat 3 higher-ranked players in a single day",
+    description: "Win 3 games against higher-ranked players in a single day (the same player can count more than once)",
     icon: "🏹",
   },
   "party-pooper": {


### PR DESCRIPTION
The achievement awards 3 wins over higher-ranked players in one day,
and the same opponent can fill more than one of them while they still
outrank the player. The description, changelog entry and code comments
said "beat 3 higher-ranked players", which read as 3 distinct players.
Reword them to count wins, and add a test that pins the same-opponent
behavior down.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016aQAkDdkbj5Tx2hf15Wavt