### PR TITLE
Add 2 new season achievements: So Close and Full Coverage

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -50,7 +50,7 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
       "So Close 😫 and Full Coverage 🗺️ are new season achievements. The app awards both when a season ends.",
     body: [
       list(
-        "So Close 😫 - finish a season with a score within 5% of the winner's score. Every player within 5% earns it, at any rank.",
+        "So Close 😫 - finish a season with a score within 10% of the winner's score. Every player within 10% earns it, at any rank.",
         "Full Coverage 🗺️ - play every other player who played in the season. The season must have 5 or more players.",
       ),
       text(

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -42,6 +42,23 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "2-new-season-achievements",
+    title: "2 new achievements: So Close and Full Coverage",
+    date: "2026-08-09",
+    tags: ["feature-update"],
+    summary:
+      "So Close 😫 and Full Coverage 🗺️ are new season achievements. The app awards both when a season ends.",
+    body: [
+      list(
+        "So Close 😫 - finish a season with a score within 5% of the winner's score. Every player within 5% earns it, at any rank.",
+        "Full Coverage 🗺️ - play every other player who played in the season. The season must have 5 or more players.",
+      ),
+      text(
+        "The Progress tab on the player page shows the Full Coverage players you have not played in the current season.",
+      ),
+    ],
+  },
+  {
     slug: "5-new-achievements",
     title: "5 new achievements",
     date: "2026-08-09",

--- a/frontend/src/client/client-db/__tests__/achievements/full-coverage.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/full-coverage.test.ts
@@ -1,0 +1,137 @@
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { TennisTable } from "../../tennis-table";
+import { determineSeason } from "../../seasons/seasons";
+
+// Full Coverage is awarded when a season ends, to every player who recorded
+// a matchup against every other participant of that season. It requires
+// FULL_COVERAGE_MIN_PLAYERS (5) or more participants.
+describe("Full Coverage Achievement", () => {
+  const baseEvents: EventType[] = [
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "alice", time: 1, data: { name: "Alice" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "bob", time: 2, data: { name: "Bob" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "carol", time: 3, data: { name: "Carol" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "dave", time: 4, data: { name: "Dave" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "erin", time: 5, data: { name: "Erin" } },
+  ];
+
+  const game = (id: string, playedAt: number, winner: string, loser: string): EventType => ({
+    type: EventTypeEnum.GAME_CREATED,
+    stream: id,
+    time: playedAt,
+    data: { winner, loser, playedAt },
+  });
+
+  // Mid-January 2024: safely inside the long-finished Q1 2024 season.
+  const q1 = determineSeason(new Date(2024, 0, 10, 12).getTime());
+  const t = (day: number) => new Date(2024, 0, day, 12).getTime();
+
+  const coverageOf = (tt: TennisTable, playerId: string) =>
+    tt.achievements.getAchievements(playerId).filter((a) => a.type === "full-coverage");
+
+  it("awards every player who played all other participants — win or lose", () => {
+    // Alice and Bob each play all 4 other participants; Carol, Dave and
+    // Erin do not.
+    const events: EventType[] = [
+      ...baseEvents,
+      game("g1", t(8), "alice", "bob"),
+      game("g2", t(9), "alice", "carol"),
+      game("g3", t(10), "dave", "alice"),
+      game("g4", t(11), "erin", "alice"),
+      game("g5", t(12), "bob", "carol"),
+      game("g6", t(13), "bob", "dave"),
+      game("g7", t(14), "erin", "bob"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const alice = coverageOf(tt, "alice");
+    expect(alice).toHaveLength(1);
+    expect(alice[0]).toStrictEqual({
+      type: "full-coverage",
+      earnedBy: "alice",
+      earnedAt: q1.end,
+      data: { seasonStart: q1.start, opponentCount: 4 },
+    });
+    expect(coverageOf(tt, "bob")).toHaveLength(1);
+
+    expect(coverageOf(tt, "carol")).toHaveLength(0);
+    expect(coverageOf(tt, "dave")).toHaveLength(0);
+    expect(coverageOf(tt, "erin")).toHaveLength(0);
+  });
+
+  it("is not awarded in a season with fewer than 5 participants", () => {
+    // Four participants who all play each other — a complete round-robin,
+    // but below the participant gate.
+    const events: EventType[] = [
+      ...baseEvents,
+      game("g1", t(8), "alice", "bob"),
+      game("g2", t(9), "alice", "carol"),
+      game("g3", t(10), "alice", "dave"),
+      game("g4", t(11), "bob", "carol"),
+      game("g5", t(12), "bob", "dave"),
+      game("g6", t(13), "carol", "dave"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    for (const player of ["alice", "bob", "carol", "dave"]) {
+      expect(coverageOf(tt, player)).toHaveLength(0);
+    }
+  });
+
+  it("is not awarded while the season is still running", () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2024, 1, 1, 12).getTime()); // inside the Q1 2024 season
+
+    const events: EventType[] = [
+      ...baseEvents,
+      game("g1", t(8), "alice", "bob"),
+      game("g2", t(9), "alice", "carol"),
+      game("g3", t(10), "dave", "alice"),
+      game("g4", t(11), "erin", "alice"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(coverageOf(tt, "alice")).toHaveLength(0);
+
+    jest.useRealTimers();
+  });
+
+  describe("progress towards the live season's participants", () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("counts matchups against participants and lists who is still to play", () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date(2024, 1, 1, 12).getTime()); // inside the Q1 2024 season
+
+      // Participants so far: alice, bob, carol, dave. Erin has not played.
+      const events: EventType[] = [
+        ...baseEvents,
+        game("g1", t(8), "alice", "bob"),
+        game("g2", t(9), "alice", "carol"),
+        game("g3", t(10), "bob", "dave"),
+      ];
+
+      const tt = new TennisTable({ events });
+      tt.achievements.calculateAchievements();
+
+      const alice = tt.achievements.getPlayerProgression("alice")["full-coverage"];
+      expect(alice.current).toBe(2);
+      expect(alice.target).toBe(3);
+      expect(alice.missing).toStrictEqual(new Set(["dave"]));
+      expect(alice.earned).toBe(0);
+
+      // A player outside the season still needs everyone who has played.
+      const erin = tt.achievements.getPlayerProgression("erin")["full-coverage"];
+      expect(erin.current).toBe(0);
+      expect(erin.target).toBe(4);
+      expect(erin.missing).toStrictEqual(new Set(["alice", "bob", "carol", "dave"]));
+    });
+  });
+});

--- a/frontend/src/client/client-db/__tests__/achievements/so-close.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/so-close.test.ts
@@ -4,7 +4,7 @@ import { determineSeason } from "../../seasons/seasons";
 
 // So Close is awarded when a season ends, to every player other than the
 // winner whose final season score is within SO_CLOSE_MAX_DEFICIT_FRACTION
-// (5%) of the winner's score — whatever rank the tiebreakers left them at.
+// (10%) of the winner's score — whatever rank the tiebreakers left them at.
 describe("So Close Achievement", () => {
   const baseEvents: EventType[] = [
     { type: EventTypeEnum.PLAYER_CREATED, stream: "alice", time: 1, data: { name: "Alice" } },
@@ -47,16 +47,16 @@ describe("So Close Achievement", () => {
   const soCloseOf = (tt: TennisTable, playerId: string) =>
     tt.achievements.getAchievements(playerId).filter((a) => a.type === "so-close");
 
-  it("awards every non-winner within 5% of the winner's score — and nobody else", () => {
+  it("awards every non-winner within 10% of the winner's score — and nobody else", () => {
     // A win with all sets and all balls scores a 100 performance. Alice's
     // 11-0 win makes her season score exactly 100.
-    // Bob's 11-1 win scores 25 + 25 + (11/12) * 50 ≈ 95.83 — within 5%.
-    // Dave's 11-2 win scores 25 + 25 + (11/13) * 50 ≈ 92.31 — outside 5%.
+    // Bob's 11-1 win scores 25 + 25 + (11/12) * 50 ≈ 95.83 — within 10%.
+    // Dave's 11-4 win scores 25 + 25 + (11/15) * 50 ≈ 86.67 — outside 10%.
     const events: EventType[] = [
       ...baseEvents,
       ...scoredGame("g1", t(10), "alice", "bob", [{ gameWinner: 11, gameLoser: 0 }]),
       ...scoredGame("g2", t(11), "bob", "carol", [{ gameWinner: 11, gameLoser: 1 }]),
-      ...scoredGame("g3", t(12), "dave", "erin", [{ gameWinner: 11, gameLoser: 2 }]),
+      ...scoredGame("g3", t(12), "dave", "erin", [{ gameWinner: 11, gameLoser: 4 }]),
     ];
 
     const tt = new TennisTable({ events });
@@ -127,7 +127,7 @@ describe("So Close Achievement", () => {
   });
 
   it("is earned once per qualifying season", () => {
-    // Bob finishes within 5% in Q1 AND Q2 2024.
+    // Bob finishes within 10% in Q1 AND Q2 2024.
     const q2Time = (day: number) => new Date(2024, 3, day, 12).getTime();
     const events: EventType[] = [
       ...baseEvents,
@@ -149,7 +149,7 @@ describe("So Close Achievement", () => {
 
   // A game with no recorded score still counts: the winner performs 25 (win
   // only), the loser 0. So a single unscored win makes the winner's 25 the
-  // winning score, and only score ties can be within 5% of it.
+  // winning score, and only score ties can be within 10% of it.
   it("works for seasons of unscored games", () => {
     const events: EventType[] = [
       ...baseEvents,
@@ -161,7 +161,7 @@ describe("So Close Achievement", () => {
     tt.achievements.calculateAchievements();
 
     // Alice and Bob both scored 25; Alice wins on fewer pairings. Bob's tied
-    // score is within 5%.
+    // score is within 10%.
     expect(soCloseOf(tt, "alice")).toHaveLength(0);
     expect(soCloseOf(tt, "bob")).toHaveLength(1);
     expect(soCloseOf(tt, "carol")).toHaveLength(0);

--- a/frontend/src/client/client-db/__tests__/achievements/so-close.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/so-close.test.ts
@@ -1,0 +1,169 @@
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { TennisTable } from "../../tennis-table";
+import { determineSeason } from "../../seasons/seasons";
+
+// So Close is awarded when a season ends, to every player other than the
+// winner whose final season score is within SO_CLOSE_MAX_DEFICIT_FRACTION
+// (5%) of the winner's score — whatever rank the tiebreakers left them at.
+describe("So Close Achievement", () => {
+  const baseEvents: EventType[] = [
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "alice", time: 1, data: { name: "Alice" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "bob", time: 2, data: { name: "Bob" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "carol", time: 3, data: { name: "Carol" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "dave", time: 4, data: { name: "Dave" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "erin", time: 5, data: { name: "Erin" } },
+  ];
+
+  const scoredGame = (
+    id: string,
+    playedAt: number,
+    winner: string,
+    loser: string,
+    setPoints: { gameWinner: number; gameLoser: number }[],
+  ): EventType[] => [
+    { type: EventTypeEnum.GAME_CREATED, stream: id, time: playedAt, data: { winner, loser, playedAt } },
+    {
+      type: EventTypeEnum.GAME_SCORE,
+      stream: id,
+      time: playedAt + 1,
+      data: {
+        setsWon: { gameWinner: setPoints.length, gameLoser: 0 },
+        setPoints,
+      },
+    },
+  ];
+
+  const game = (id: string, playedAt: number, winner: string, loser: string): EventType => ({
+    type: EventTypeEnum.GAME_CREATED,
+    stream: id,
+    time: playedAt,
+    data: { winner, loser, playedAt },
+  });
+
+  // Mid-January 2024: safely inside the long-finished Q1 2024 season.
+  const q1 = determineSeason(new Date(2024, 0, 10, 12).getTime());
+  const t = (day: number) => new Date(2024, 0, day, 12).getTime();
+
+  const soCloseOf = (tt: TennisTable, playerId: string) =>
+    tt.achievements.getAchievements(playerId).filter((a) => a.type === "so-close");
+
+  it("awards every non-winner within 5% of the winner's score — and nobody else", () => {
+    // A win with all sets and all balls scores a 100 performance. Alice's
+    // 11-0 win makes her season score exactly 100.
+    // Bob's 11-1 win scores 25 + 25 + (11/12) * 50 ≈ 95.83 — within 5%.
+    // Dave's 11-2 win scores 25 + 25 + (11/13) * 50 ≈ 92.31 — outside 5%.
+    const events: EventType[] = [
+      ...baseEvents,
+      ...scoredGame("g1", t(10), "alice", "bob", [{ gameWinner: 11, gameLoser: 0 }]),
+      ...scoredGame("g2", t(11), "bob", "carol", [{ gameWinner: 11, gameLoser: 1 }]),
+      ...scoredGame("g3", t(12), "dave", "erin", [{ gameWinner: 11, gameLoser: 2 }]),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    // The winner is Alice — she never earns So Close.
+    expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "season-winner")).toHaveLength(1);
+    expect(soCloseOf(tt, "alice")).toHaveLength(0);
+
+    const bob = soCloseOf(tt, "bob");
+    expect(bob).toHaveLength(1);
+    expect(bob[0].earnedAt).toBe(q1.end);
+    expect(bob[0].data?.seasonStart).toBe(q1.start);
+    expect(bob[0].data?.winner).toBe("alice");
+    expect(bob[0].data?.winnerScore).toBeCloseTo(100);
+    expect(bob[0].data?.playerScore).toBeCloseTo(95.833, 2);
+
+    expect(soCloseOf(tt, "carol")).toHaveLength(0);
+    expect(soCloseOf(tt, "dave")).toHaveLength(0);
+    expect(soCloseOf(tt, "erin")).toHaveLength(0);
+  });
+
+  it("awards any rank within the band — a three-way score tie earns it at rank 2 AND rank 3", () => {
+    // Every win is 11-0, pinning each winning performance at exactly 100.
+    // Alice, Bob and Carol all finish on 200; the fewer-pairings tiebreaker
+    // ranks Alice (2 matchups) above Bob (3) above Carol (4). Bob and Carol
+    // both matched the winning score, so both are So Close.
+    const events: EventType[] = [
+      ...baseEvents,
+      ...scoredGame("g1", t(8), "alice", "bob", [{ gameWinner: 11, gameLoser: 0 }]),
+      ...scoredGame("g2", t(9), "alice", "carol", [{ gameWinner: 11, gameLoser: 0 }]),
+      ...scoredGame("g3", t(10), "bob", "carol", [{ gameWinner: 11, gameLoser: 0 }]),
+      ...scoredGame("g4", t(11), "bob", "dave", [{ gameWinner: 11, gameLoser: 0 }]),
+      ...scoredGame("g5", t(12), "carol", "dave", [{ gameWinner: 11, gameLoser: 0 }]),
+      ...scoredGame("g6", t(13), "carol", "erin", [{ gameWinner: 11, gameLoser: 0 }]),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const seasonWinners = tt.achievements.getAchievements("alice").filter((a) => a.type === "season-winner");
+    expect(seasonWinners).toHaveLength(1);
+
+    expect(soCloseOf(tt, "alice")).toHaveLength(0);
+    expect(soCloseOf(tt, "bob")).toHaveLength(1);
+    expect(soCloseOf(tt, "carol")).toHaveLength(1);
+    expect(soCloseOf(tt, "dave")).toHaveLength(0);
+    expect(soCloseOf(tt, "erin")).toHaveLength(0);
+  });
+
+  it("is not awarded while the season is still running", () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date(2024, 1, 1, 12).getTime()); // inside the Q1 2024 season
+
+    const events: EventType[] = [
+      ...baseEvents,
+      ...scoredGame("g1", t(10), "alice", "bob", [{ gameWinner: 11, gameLoser: 0 }]),
+      ...scoredGame("g2", t(11), "bob", "carol", [{ gameWinner: 11, gameLoser: 1 }]),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    expect(soCloseOf(tt, "bob")).toHaveLength(0);
+    expect(tt.achievements.getAchievements("alice").filter((a) => a.type === "season-winner")).toHaveLength(0);
+
+    jest.useRealTimers();
+  });
+
+  it("is earned once per qualifying season", () => {
+    // Bob finishes within 5% in Q1 AND Q2 2024.
+    const q2Time = (day: number) => new Date(2024, 3, day, 12).getTime();
+    const events: EventType[] = [
+      ...baseEvents,
+      ...scoredGame("g1", t(10), "alice", "bob", [{ gameWinner: 11, gameLoser: 0 }]),
+      ...scoredGame("g2", t(11), "bob", "carol", [{ gameWinner: 11, gameLoser: 1 }]),
+      ...scoredGame("g3", q2Time(10), "alice", "bob", [{ gameWinner: 11, gameLoser: 0 }]),
+      ...scoredGame("g4", q2Time(11), "bob", "carol", [{ gameWinner: 11, gameLoser: 1 }]),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    const bob = soCloseOf(tt, "bob");
+    expect(bob).toHaveLength(2);
+    expect(bob[0].data?.seasonStart).toBe(q1.start);
+    expect(bob[1].data?.seasonStart).toBe(determineSeason(q2Time(10)).start);
+    expect(tt.achievements.getPlayerProgression("bob")["so-close"].earned).toBe(2);
+  });
+
+  // A game with no recorded score still counts: the winner performs 25 (win
+  // only), the loser 0. So a single unscored win makes the winner's 25 the
+  // winning score, and only score ties can be within 5% of it.
+  it("works for seasons of unscored games", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      game("g1", t(10), "alice", "bob"),
+      game("g2", t(11), "bob", "carol"),
+    ];
+
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+
+    // Alice and Bob both scored 25; Alice wins on fewer pairings. Bob's tied
+    // score is within 5%.
+    expect(soCloseOf(tt, "alice")).toHaveLength(0);
+    expect(soCloseOf(tt, "bob")).toHaveLength(1);
+    expect(soCloseOf(tt, "carol")).toHaveLength(0);
+  });
+});

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -75,6 +75,17 @@ export const GIANT_HUNTING_TARGET = 3;
 // destroyed one.
 export const PARTY_POOPER_MIN_WINS = 5;
 
+// Largest deficit to the season winner's final score that still earns "So
+// Close", as a fraction of the winner's score. Every non-winner within the
+// band qualifies, whatever rank the tiebreakers left them at — the score is
+// what they nearly matched, not the position.
+export const SO_CLOSE_MAX_DEFICIT_FRACTION = 0.05;
+
+// Fewest players a season must have for "Full Coverage" — playing everyone
+// in a tiny season is not a feat. Matches the ≥5 cohort gate the rank and
+// full-house achievements use.
+export const FULL_COVERAGE_MIN_PLAYERS = 5;
+
 export class Achievements {
   private parent: TennisTable;
   private hasCalculated = false;
@@ -2684,8 +2695,6 @@ export class Achievements {
     this.parent.seasons.getSeasons().forEach((s) => {
       const leaderboard = s.getLeaderboard();
 
-      // Check participation TODO
-
       // Season Opener: both players of the season's very first game earned
       // it the moment they opened the season — no need to wait for the
       // season to end. Seasons only exist once they contain a game, and
@@ -2710,10 +2719,47 @@ export class Achievements {
         );
       }
 
-      // Check for season winners
+      // The remaining season achievements read the FINAL leaderboard, so
+      // they only exist once the season has ended.
       if (Date.now() > s.end && leaderboard.length > 0) {
         const winner = leaderboard[0].playerId;
         this.#addAchievement(winner, this.#createAchievement("season-winner", winner, s.end, { seasonStart: s.start }));
+
+        // So Close: every non-winner whose final score is within
+        // SO_CLOSE_MAX_DEFICIT_FRACTION of the winner's. Rank does not
+        // matter — a tiebreaker can push a matching score to any position.
+        const winnerScore = leaderboard[0].seasonScore;
+        const soCloseThreshold = winnerScore * (1 - SO_CLOSE_MAX_DEFICIT_FRACTION);
+        for (const entry of leaderboard.slice(1)) {
+          if (entry.seasonScore < soCloseThreshold) continue;
+          this.#addAchievement(
+            entry.playerId,
+            this.#createAchievement("so-close", entry.playerId, s.end, {
+              seasonStart: s.start,
+              winner,
+              winnerScore,
+              playerScore: entry.seasonScore,
+            }),
+          );
+        }
+
+        // Full Coverage: recorded a matchup against every other player who
+        // played in the season. Only decidable at season end — a new
+        // player's first game can reopen the set at any moment before that.
+        // Gated on season size so a tiny season is not a free award.
+        if (leaderboard.length >= FULL_COVERAGE_MIN_PLAYERS) {
+          for (const entry of leaderboard) {
+            if (entry.matchups.size === leaderboard.length - 1) {
+              this.#addAchievement(
+                entry.playerId,
+                this.#createAchievement("full-coverage", entry.playerId, s.end, {
+                  seasonStart: s.start,
+                  opponentCount: entry.matchups.size,
+                }),
+              );
+            }
+          }
+        }
       }
     });
   }
@@ -2982,6 +3028,9 @@ export class Achievements {
       "group-stage-star": { earned: 0 },
       "sweet-revenge": { current: 0, target: 0, missing: new Set(), earned: 0 },
       "season-winner": { current: 0, target: 1, earned: 0 },
+      "so-close": { earned: 0 },
+      // Progress through the live season's participants, filled in below.
+      "full-coverage": { current: 0, target: 1, missing: new Set(), earned: 0 },
       // League-wide countdown to the next season start, filled in below.
       "season-opener": { current: 0, target: 0, earned: 0 },
       "milestone-game": { current: 0, target: MILESTONE_GAME_INTERVAL, earned: 0 },
@@ -3630,6 +3679,20 @@ export class Achievements {
       if (player) {
         progression["season-winner"].current = player.seasonScore;
       }
+
+      // Full Coverage progress: matchups recorded against the live season's
+      // other participants so far, and who is still to be played. New
+      // players can keep joining until the season ends, so the target can
+      // still grow.
+      const fullCoverageMissing = new Set<string>();
+      for (const entry of leaderboard) {
+        if (entry.playerId === playerId) continue;
+        if (!player?.matchups.has(entry.playerId)) fullCoverageMissing.add(entry.playerId);
+      }
+      const participantsToPlay = leaderboard.length - (player ? 1 : 0);
+      progression["full-coverage"].current = player?.matchups.size ?? 0;
+      progression["full-coverage"].target = Math.max(participantsToPlay, 1);
+      progression["full-coverage"].missing = fullCoverageMissing;
     }
 
     // Season's Champion best: the best final rank in a finished season the
@@ -3895,6 +3958,13 @@ type AchievementDefinitions = {
   // player before the revenge — is `lostAt` / `lostTournamentId`.
   "sweet-revenge": { opponent: string; tournamentId: string; lostAt: number; lostTournamentId: string };
   "season-winner": { seasonStart: number };
+  // Finished a season with a score within SO_CLOSE_MAX_DEFICIT_FRACTION of
+  // the winner's final score — any rank but first qualifies.
+  "so-close": { seasonStart: number; winner: string; winnerScore: number; playerScore: number };
+  // Recorded a matchup against every other player who played in the season
+  // (a season of FULL_COVERAGE_MIN_PLAYERS or more). `opponentCount` is how
+  // many opponents the completed set held.
+  "full-coverage": { seasonStart: number; opponentCount: number };
   "nice-game": { gameId: string; opponent: string };
   "less-is-more": { gameId: string; opponent: string; playerPoints: number; opponentPoints: number };
   "close-calls": undefined;
@@ -4051,6 +4121,8 @@ export const ACHIEVEMENT_IS_REACHIEVABLE: Record<AchievementType, boolean> = {
   "tournament-winner": true,
   "sweet-revenge": true, // Per avenged loss — a new loss to that opponent re-arms it
   "season-winner": true, // Per season
+  "so-close": true, // Per season
+  "full-coverage": true, // Per season
   "nice-game": true, // Per qualifying game
   "less-is-more": true,
   "close-calls": false,
@@ -4213,8 +4285,10 @@ type SeasonOpenerProgression = ProgressionWithTarget & {
 
 type MissingPlayersProgression = ProgressionWithTarget & {
   // Currently ranked players the player has not yet beaten (Full House) /
-  // not yet lost to (Humbled), or active tournament rivals the player has
-  // not yet avenged (Sweet Revenge) — i.e. what's left to complete the set.
+  // not yet lost to (Humbled), active tournament rivals the player has not
+  // yet avenged (Sweet Revenge), or the live season's participants the
+  // player has not yet played (Full Coverage) — i.e. what's left to
+  // complete the set.
   missing?: Set<string>;
 };
 
@@ -4347,6 +4421,8 @@ export type AchievementProgression = {
   "tournament-participated": BaseProgression;
   "tournament-winner": BaseProgression;
   "season-winner": ProgressionWithTarget;
+  "so-close": BaseProgression;
+  "full-coverage": MissingPlayersProgression;
   "season-opener": SeasonOpenerProgression;
   "milestone-game": ProgressionWithTarget;
   "nice-game": BaseProgression;

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -79,7 +79,7 @@ export const PARTY_POOPER_MIN_WINS = 5;
 // Close", as a fraction of the winner's score. Every non-winner within the
 // band qualifies, whatever rank the tiebreakers left them at — the score is
 // what they nearly matched, not the position.
-export const SO_CLOSE_MAX_DEFICIT_FRACTION = 0.05;
+export const SO_CLOSE_MAX_DEFICIT_FRACTION = 0.1;
 
 // Fewest players a season must have for "Full Coverage" — playing everyone
 // in a tiny season is not a feat. Matches the ≥5 cohort gate the rank and

--- a/frontend/src/pages/achievements/achievements-list.tsx
+++ b/frontend/src/pages/achievements/achievements-list.tsx
@@ -98,11 +98,14 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                       {dateString(achievement.data.startedAt)} – {dateString(achievement.earnedAt)}
                     </span>
                   )}
-                  {achievement.data && "seasonStart" in achievement.data && achievement.type !== "season-opener" && (
-                    <span className="text-[11px] opacity-80">
-                      Season: {dateString(achievement.data.seasonStart)} – {dateString(achievement.earnedAt)}
-                    </span>
-                  )}
+                  {achievement.data &&
+                    "seasonStart" in achievement.data &&
+                    achievement.type !== "season-opener" &&
+                    achievement.type !== "so-close" && (
+                      <span className="text-[11px] opacity-80">
+                        Season: {dateString(achievement.data.seasonStart)} – {dateString(achievement.earnedAt)}
+                      </span>
+                    )}
                   {achievement.type === "season-opener" && achievement.data && (
                     <span className="text-[11px] opacity-80">
                       Season starting {dateString(achievement.data.seasonStart)}
@@ -110,6 +113,8 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                   )}
                   {achievement.type === "so-close" && achievement.data && (
                     <span className="text-[11px] opacity-80">
+                      Season {context.seasons.getSeasons().findIndex((s) => s.start === achievement.data.seasonStart) + 1}
+                      {" — "}
                       {fmtNum((achievement.data.playerScore / achievement.data.winnerScore) * 100, { digits: 1 })}% of{" "}
                       {context.playerName(achievement.data.winner)}'s winning score
                     </span>

--- a/frontend/src/pages/achievements/achievements-list.tsx
+++ b/frontend/src/pages/achievements/achievements-list.tsx
@@ -108,6 +108,17 @@ export const AchievementsList: React.FC<AchievementsListProps> = ({ achievements
                       Season starting {dateString(achievement.data.seasonStart)}
                     </span>
                   )}
+                  {achievement.type === "so-close" && achievement.data && (
+                    <span className="text-[11px] opacity-80">
+                      {fmtNum((achievement.data.playerScore / achievement.data.winnerScore) * 100, { digits: 1 })}% of{" "}
+                      {context.playerName(achievement.data.winner)}'s winning score
+                    </span>
+                  )}
+                  {achievement.type === "full-coverage" && achievement.data && (
+                    <span className="text-[11px] opacity-80">
+                      Played all {fmtNum(achievement.data.opponentCount)} other players
+                    </span>
+                  )}
                   {achievement.type === "milestone-game" && achievement.data && (
                     <span className="text-[11px] opacity-80">
                       League game #{fmtNum(achievement.data.milestone)}

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -160,6 +160,16 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
     description: "Play in the first game of a new season",
     icon: "🌱",
   },
+  "so-close": {
+    title: "So Close",
+    description: "Finish a season within 5% of the winner's score",
+    icon: "😫",
+  },
+  "full-coverage": {
+    title: "Full Coverage",
+    description: "Play every player who took part in a season of 5 or more players",
+    icon: "🗺️",
+  },
   "milestone-game": {
     title: "Milestone Game",
     description: "Play in a league milestone game — every 500th game played",
@@ -552,6 +562,21 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
                 {achievement.type === "season-opener" && achievement.data && (
                   <p className="text-xs text-secondary-text/70 mt-2">
                     Opened the season starting {dateString(achievement.data.seasonStart)}
+                  </p>
+                )}
+
+                {achievement.type === "so-close" && achievement.data && (
+                  <p className="text-xs text-secondary-text/70 mt-2">
+                    Scored {fmtNum(achievement.data.playerScore, { digits: 1 })} points —{" "}
+                    {fmtNum((achievement.data.playerScore / achievement.data.winnerScore) * 100, { digits: 1 })}% of{" "}
+                    {context.playerName(achievement.data.winner)}'s winning{" "}
+                    {fmtNum(achievement.data.winnerScore, { digits: 1 })}
+                  </p>
+                )}
+
+                {achievement.type === "full-coverage" && achievement.data && (
+                  <p className="text-xs text-secondary-text/70 mt-2">
+                    Played all {fmtNum(achievement.data.opponentCount)} other players of the season
                   </p>
                 )}
 
@@ -1225,10 +1250,11 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                           </div>
                         )}
 
-                      {/* Missing players for full-house / humbled / sweet-revenge */}
+                      {/* Missing players for full-house / humbled / sweet-revenge / full-coverage */}
                       {(type === "full-house" ||
                         type === "humbled" ||
                         type === "everybodys-opponent" ||
+                        type === "full-coverage" ||
                         type === "sweet-revenge") &&
                         "missing" in data &&
                         data.missing &&
@@ -1241,7 +1267,9 @@ const ProgressTab: React.FC<ProgressTabProps> = ({ progression, playerId }) => {
                                   ? "Still need to lose to:"
                                   : type === "everybodys-opponent"
                                     ? "Still need to play:"
-                                    : "They beat you in a tournament — beat them in a tournament match to avenge it:"}
+                                    : type === "full-coverage"
+                                      ? "Still need to play this season:"
+                                      : "They beat you in a tournament — beat them in a tournament match to avenge it:"}
                             </p>
                             <div className="flex flex-wrap gap-1">
                               {Array.from(data.missing).map((player: string) => (

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -162,7 +162,7 @@ export const ACHIEVEMENT_LABELS: Record<string, { title: string; description: st
   },
   "so-close": {
     title: "So Close",
-    description: "Finish a season within 5% of the winner's score",
+    description: "Finish a season within 10% of the winner's score",
     icon: "😫",
   },
   "full-coverage": {

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -553,11 +553,14 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
                   </p>
                 )}
 
-                {achievement.data && "seasonStart" in achievement.data && achievement.type !== "season-opener" && (
-                  <p className="text-xs text-secondary-text/70 mt-2">
-                    Season from {dateString(achievement.data.seasonStart)} to {dateString(achievement.earnedAt)}
-                  </p>
-                )}
+                {achievement.data &&
+                  "seasonStart" in achievement.data &&
+                  achievement.type !== "season-opener" &&
+                  achievement.type !== "so-close" && (
+                    <p className="text-xs text-secondary-text/70 mt-2">
+                      Season from {dateString(achievement.data.seasonStart)} to {dateString(achievement.earnedAt)}
+                    </p>
+                  )}
 
                 {achievement.type === "season-opener" && achievement.data && (
                   <p className="text-xs text-secondary-text/70 mt-2">
@@ -567,7 +570,8 @@ const AchievementsTab: React.FC<AchievementsTabProps> = ({ achievements }) => {
 
                 {achievement.type === "so-close" && achievement.data && (
                   <p className="text-xs text-secondary-text/70 mt-2">
-                    Scored {fmtNum(achievement.data.playerScore, { digits: 1 })} points —{" "}
+                    Season {context.seasons.getSeasons().findIndex((s) => s.start === achievement.data.seasonStart) + 1}:
+                    scored {fmtNum(achievement.data.playerScore, { digits: 1 })} points —{" "}
                     {fmtNum((achievement.data.playerScore / achievement.data.winnerScore) * 100, { digits: 1 })}% of{" "}
                     {context.playerName(achievement.data.winner)}'s winning{" "}
                     {fmtNum(achievement.data.winnerScore, { digits: 1 })}


### PR DESCRIPTION
So Close: awarded when a season ends to every player other than the
winner whose final score is within 5% of the winner's score, at any
rank. Full Coverage: awarded when a season of 5 or more participants
ends to every player who recorded a matchup against all other
participants; the Progress tab lists who is still to be played in the
live season.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017t88NhymodQxGXHxCShLd1