### PR TITLE
Contain page bottom margin so the theme background reaches the page end

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -78,11 +78,14 @@ function App() {
       <ImageKitContext>
         <ThemeProvider>
           {clientConfig.snow && <Snowfall radius={[0.2, 1]} speed={[0.1, 0.3]} wind={[0, 1]} />}
-          {/* No overflow-auto here: it would make this div the scroll container
-              for position:sticky descendants (section headers on the player's
-              achievement Progress tab) while the document does the scrolling,
-              so they would never stick. */}
-          <div className="min-h-screen w-full">
+          {/* flow-root keeps descendant bottom margins (the page wrapper's
+              mb-24 in NavMenu) inside this div, so the themed background
+              reaches the bottom of the document. Do not use overflow-auto
+              for that: it would make this div the scroll container for
+              position:sticky descendants (section headers on the player's
+              achievement Progress tab) while the document does the
+              scrolling, so they would never stick. */}
+          <div className="flow-root min-h-screen w-full">
             <HelmetSetter />
             <NewVersionChecker />
               <EventDbWrapper>


### PR DESCRIPTION
Removing overflow-auto from the App root div (#153) stopped it from
establishing a block formatting context. The page wrapper's mb-24 in
NavMenu then collapsed out through the App root and the ThemeProvider
div, ending the themed background 96px above the bottom of the
document and exposing the body's default background as a band at the
bottom of every page.

flow-root restores the block formatting context, keeping the margin
inside the div, without making it a scroll container - which is what
overflow-auto did, and what would keep position:sticky descendants
(the achievement Progress section headers) from sticking.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01D4Wrbk4ws1NSpF7kVQVPph