### PR TITLE
Replace player links with filter buttons in season score log

### DIFF
--- a/frontend/src/pages/seasons/season-score-log.tsx
+++ b/frontend/src/pages/seasons/season-score-log.tsx
@@ -1,4 +1,4 @@
-import { Link, useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router-dom";
 import { useEventDbContext } from "../../wrappers/event-db-context";
 import { Season } from "../../client/client-db/seasons/season";
 import { ProfilePicture } from "../player/profile-picture";
@@ -167,27 +167,27 @@ export const SeasonScoreLog = ({ season }: Props) => {
             return (
             <tr key={idx} className="text-xs xs:text-sm md:text-base">
               <td className="py-1 px-1 xs:px-2 md:px-3 w-[35%] max-w-0">
-                <Link
-                  to={`/season/player?seasonStart=${season.start}&playerId=${imp.playerId}`}
-                  className="flex items-center gap-1 md:gap-2 font-medium hover:underline min-w-0"
+                <button
+                  onClick={() => setPlayerFilter(imp.playerId)}
+                  className="flex items-center gap-1 md:gap-2 font-medium hover:underline min-w-0 w-full text-left"
                 >
                   <div className="md:hidden shrink-0"><ProfilePicture playerId={imp.playerId} size={18} border={1} shape="rounded" /></div>
                   <div className="hidden md:block shrink-0"><ProfilePicture playerId={imp.playerId} size={30} border={2} shape="rounded" /></div>
                   <span className="truncate">{context.playerName(imp.playerId)}</span>
-                </Link>
+                </button>
               </td>
               <td className="py-1 px-1 xs:px-2 md:px-3 text-right font-bold w-[1%] whitespace-nowrap">
                 +{fmtNum(imp.improvement)}
               </td>
               <td className="py-1 px-1 xs:px-2 md:px-3 w-[35%] max-w-0">
-                <Link
-                  to={`/season/player?seasonStart=${season.start}&playerId=${imp.opponentId}`}
-                  className="flex items-center gap-1 md:gap-2 hover:underline min-w-0"
+                <button
+                  onClick={() => setOpponentFilter(imp.opponentId)}
+                  className="flex items-center gap-1 md:gap-2 hover:underline min-w-0 w-full text-left"
                 >
                   <div className="md:hidden shrink-0"><ProfilePicture playerId={imp.opponentId} size={18} border={1} shape="rounded" /></div>
                   <div className="hidden md:block shrink-0"><ProfilePicture playerId={imp.opponentId} size={30} border={2} shape="rounded" /></div>
                   <span className="truncate">{context.playerName(imp.opponentId)}</span>
-                </Link>
+                </button>
               </td>
               <td className="py-1 px-1 xs:px-2 md:px-3 w-[1%] whitespace-nowrap">
                 {/* Tiny screens: sets on top, per-set points below (max 3 sets per line). xs+: inline. */}


### PR DESCRIPTION
## Summary
Changed the season score log table to filter players inline rather than navigating to a separate player page. Player names in both the "player" and "opponent" columns now trigger filter state updates instead of routing to `/season/player`.

## Changes
- Removed `Link` import from react-router-dom (no longer needed)
- Replaced two `<Link>` components with `<button>` elements that call `setPlayerFilter()` and `setOpponentFilter()` respectively
- Added `w-full text-left` classes to button styling to maintain layout and text alignment
- Removed route-based navigation (`to` prop with query parameters) in favor of local state management

## Implementation Details
The change improves UX by keeping users on the current page while filtering results, rather than requiring navigation away and back. The button styling preserves the visual appearance of the original links (hover underline, flex layout with profile pictures and names).

https://claude.ai/code/session_01DmPQ5oy98myHJRETESiki8