### PR TITLE
Add expected score simulation for unranked players on player page

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -42,6 +42,25 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "unranked-expected-score-simulation",
+    title: "Simulated expected score for unranked players",
+    date: "2026-08-13",
+    tags: ["feature-update"],
+    summary:
+      "The Overview tab of an unranked player has a button that simulates the expected score and rank for that player.",
+    body: [
+      text(
+        "An unranked player has no score on the leaderboard. The Overview tab of the player page now has a button that simulates the expected score for that player.",
+      ),
+      text(
+        "The simulation uses the same model as the expected leaderboard: the average of 5 000 simulated leaderboards where every ranked player and this player play each other. The result shows the expected score and the expected rank.",
+      ),
+      text(
+        "The player is not ranked, so the simulation has insufficient data. A warning shows this before the simulation and with the result.",
+      ),
+    ],
+  },
+  {
     slug: "live-win-prediction-extended-matches",
     title: "Live win% prediction supports extended matches",
     date: "2026-08-12",

--- a/frontend/src/client/client-db/predictions.ts
+++ b/frontend/src/client/client-db/predictions.ts
@@ -445,22 +445,24 @@ export class Predictions {
   // Simulated game generation
   // ---------------------------------------------------------------------------
 
-  generateSimulatedGames(targetGamesPerPlayer = 400): Game[] {
-    const rankedPlayerIds = this.getAllPlayerIds().filter((id) => {
+  generateSimulatedGames(targetGamesPerPlayer = 400, includeUnrankedPlayerId?: string): Game[] {
+    const simulatedPlayerIds = this.getAllPlayerIds().filter((id) => {
       const isActive = this.parent.eventStore.playersProjector.getPlayer(id)?.active === true;
+      // The explicitly included player joins the simulation regardless of game count
+      if (id === includeUnrankedPlayerId) return isActive;
       return this.getPlayerTotalGames(id) >= this.parent.client.gameLimitForRanked && isActive;
     });
 
-    if (rankedPlayerIds.length < 2) return [];
+    if (simulatedPlayerIds.length < 2) return [];
 
-    const gamesPerPairing = Math.max(1, Math.round(targetGamesPerPlayer / (rankedPlayerIds.length - 1)));
+    const gamesPerPairing = Math.max(1, Math.round(targetGamesPerPlayer / (simulatedPlayerIds.length - 1)));
 
     const predictedGamesTemp: { winner: string; loser: string }[][] = [];
 
-    for (let i = 0; i < rankedPlayerIds.length; i++) {
-      for (let j = i + 1; j < rankedPlayerIds.length; j++) {
-        const p1 = rankedPlayerIds[i];
-        const p2 = rankedPlayerIds[j];
+    for (let i = 0; i < simulatedPlayerIds.length; i++) {
+      for (let j = i + 1; j < simulatedPlayerIds.length; j++) {
+        const p1 = simulatedPlayerIds[i];
+        const p2 = simulatedPlayerIds[j];
 
         const direct = this.getDirectFraction(p1, p2);
         const oneLayer = this.getOneLayerFraction(p1, p2);

--- a/frontend/src/client/client-db/simulations.ts
+++ b/frontend/src/client/client-db/simulations.ts
@@ -45,9 +45,9 @@ export class Simulations {
     return wins / (loss || 1);
   }
 
-  expectedLeaderBoard(onProgress?: (progress: number) => void): ExpectedLeaderboard {
+  expectedLeaderBoard(onProgress?: (progress: number) => void, includeUnrankedPlayerId?: string): ExpectedLeaderboard {
     const currentLeaderboard = this.parent.leaderboard.getLeaderboard();
-    const predictedGames = this.parent.predictions.generateSimulatedGames();
+    const predictedGames = this.parent.predictions.generateSimulatedGames(undefined, includeUnrankedPlayerId);
 
     const simResultMap = new Map<string, number[]>();
 
@@ -80,7 +80,11 @@ export class Simulations {
     return {
       current: currentLeaderboard.rankedPlayers.map(({ id, rank, elo }) => ({ id, rank, score: elo })),
       expected: avgSimResult
-        .filter((player) => currentLeaderboard.rankedPlayers.some((ranked) => ranked.id === player.id))
+        .filter(
+          (player) =>
+            player.id === includeUnrankedPlayerId ||
+            currentLeaderboard.rankedPlayers.some((ranked) => ranked.id === player.id),
+        )
         .map((player, index) => ({ ...player, rank: index + 1 })),
     };
   }

--- a/frontend/src/client/client-db/web-worker/web-worker.ts
+++ b/frontend/src/client/client-db/web-worker/web-worker.ts
@@ -5,7 +5,10 @@ import { TennisTable } from "../tennis-table";
 import { TournamentPredictionResult } from "../tournaments/prediction";
 
 export type WorkerMessage =
-  | { type: "start-expected-leaderboard"; data: { events: EventType[]; referenceTime?: number } }
+  | {
+      type: "start-expected-leaderboard";
+      data: { events: EventType[]; referenceTime?: number; includeUnrankedPlayerId?: string };
+    }
   | { type: "expected-leaderboard-progress"; data: { progress: number } }
   | { type: "expected-leaderboard-result"; data: { result: ExpectedLeaderboard } }
   | { type: "start-simulating-elo-over-time"; data: { playerId: string; events: EventType[] } }
@@ -36,8 +39,9 @@ function handleWorkerMessage(message: WorkerMessage) {
         events: message.data.events,
         referenceTime: message.data.referenceTime,
       });
-      const result = tennisTableForLeaderboard.simulations.expectedLeaderBoard((progress) =>
-        postWorkerMessage({ type: "expected-leaderboard-progress", data: { progress } }),
+      const result = tennisTableForLeaderboard.simulations.expectedLeaderBoard(
+        (progress) => postWorkerMessage({ type: "expected-leaderboard-progress", data: { progress } }),
+        message.data.includeUnrankedPlayerId,
       );
       postWorkerMessage({ type: "expected-leaderboard-result", data: { result } });
       break;

--- a/frontend/src/hooks/use-unranked-expected-score-worker.ts
+++ b/frontend/src/hooks/use-unranked-expected-score-worker.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { WorkerMessage } from "../client/client-db/web-worker/web-worker";
+import { useEventDbContext } from "../wrappers/event-db-context";
+import { ExpectedLeaderboard } from "../client/client-db/simulations";
+import { createModernWorker } from "./use-elo-simulation-worker";
+
+/**
+ * Expected-leaderboard simulation that also includes one unranked player, so
+ * their expected score can be shown on the player page. Unlike
+ * useExpectedLeaderboardWorker it does not start on mount — call start().
+ */
+export function useUnrankedExpectedScoreWorker(playerId: string) {
+  const context = useEventDbContext();
+
+  const workerRef = useRef<Worker | null>(null);
+  const [result, setResult] = useState<ExpectedLeaderboard | null>(null);
+  const [progress, setProgress] = useState(0);
+  const [running, setRunning] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      workerRef.current?.terminate();
+    };
+  }, []);
+
+  const start = useCallback(() => {
+    if (running || result) return;
+    setRunning(true);
+
+    const worker = createModernWorker();
+
+    if (!worker) {
+      // Fallback: run on the main thread if workers are unavailable
+      setResult(context.simulations.expectedLeaderBoard(undefined, playerId));
+      setProgress(1);
+      setRunning(false);
+      return;
+    }
+    workerRef.current = worker;
+
+    worker.addEventListener("message", (e) => {
+      const message = e.data as WorkerMessage;
+      switch (message.type) {
+        case "expected-leaderboard-progress":
+          setProgress(message.data.progress);
+          break;
+
+        case "expected-leaderboard-result":
+          setProgress(1);
+          setResult(message.data.result);
+          setRunning(false);
+          break;
+      }
+    });
+
+    const message: WorkerMessage = {
+      type: "start-expected-leaderboard",
+      data: { events: context.events, includeUnrankedPlayerId: playerId },
+    };
+    worker.postMessage(message);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [playerId, running, result]);
+
+  return { start, result, progress, running };
+}

--- a/frontend/src/pages/player/player-page.tsx
+++ b/frontend/src/pages/player/player-page.tsx
@@ -216,11 +216,6 @@ export const PlayerPage: React.FC = () => {
               </div>
             )}
 
-            {/* Expected score simulation for unranked players */}
-            {playerId && isActive && !summary.isRanked && summary.games.length > 0 && (
-              <UnrankedExpectedScore playerId={playerId} />
-            )}
-
             {/* Score Timeline */}
             <ContentCard title="Score Timeline">
               {playerId && summary.games.length > 0 && (
@@ -230,6 +225,11 @@ export const PlayerPage: React.FC = () => {
                 </div>
               )}
             </ContentCard>
+
+            {/* Expected score simulation for unranked players */}
+            {playerId && isActive && !summary.isRanked && summary.games.length > 0 && (
+              <UnrankedExpectedScore playerId={playerId} />
+            )}
 
             {/* Quick Stats */}
             {summary.games.length > 0 && (

--- a/frontend/src/pages/player/player-page.tsx
+++ b/frontend/src/pages/player/player-page.tsx
@@ -16,6 +16,7 @@ import { PlayerPredictionsPage } from "./player-predictions-page";
 import { PlayerSeasonStats } from "./player-season-stats";
 import { PlayerPairings } from "./player-pairings";
 import { ContentCard } from "./content-card";
+import { UnrankedExpectedScore } from "./unranked-expected-score";
 import { usePlayerLinkSearch } from "../../hooks/use-player-link-search";
 
 type TabType = "overview" | "games" | "statistics" | "achievements" | "predictions" | "season";
@@ -213,6 +214,11 @@ export const PlayerPage: React.FC = () => {
                   </div>
                 ))}
               </div>
+            )}
+
+            {/* Expected score simulation for unranked players */}
+            {playerId && isActive && !summary.isRanked && summary.games.length > 0 && (
+              <UnrankedExpectedScore playerId={playerId} />
             )}
 
             {/* Score Timeline */}

--- a/frontend/src/pages/player/unranked-expected-score.tsx
+++ b/frontend/src/pages/player/unranked-expected-score.tsx
@@ -1,83 +1,73 @@
+import { useState } from "react";
 import { fmtNum } from "../../common/number-utils";
-import { useEventDbContext } from "../../wrappers/event-db-context";
 import { useUnrankedExpectedScoreWorker } from "../../hooks/use-unranked-expected-score-worker";
-import { ContentCard } from "./content-card";
 
 type Props = {
   playerId: string;
 };
 
 /**
- * Overview card for unranked players: a button (behind an insufficient-data
- * warning) that simulates their expected score by letting every ranked player
- * plus this player play each other, like the expected leaderboard.
+ * Compact overview widget for unranked players: simulates their expected score
+ * by letting every ranked player plus this player play each other, like the
+ * expected leaderboard. The first click arms an insufficient-data warning; the
+ * second click on the same button runs the simulation.
  */
 export const UnrankedExpectedScore: React.FC<Props> = ({ playerId }) => {
-  const context = useEventDbContext();
   const { start, result, progress, running } = useUnrankedExpectedScoreWorker(playerId);
+  const [armed, setArmed] = useState(false);
 
   const playerEntry = result?.expected.find((p) => p.id === playerId);
 
   return (
-    <ContentCard title="Expected score">
-      <div className="rounded-xl border border-yellow-500/40 bg-yellow-500/10 p-4 text-primary-text">
-        {!result && !running && (
-          <div className="text-center">
-            <div className="text-3xl mb-2">⚠️</div>
-            <p className="text-lg font-semibold mb-1">This player is not ranked</p>
-            <p className="text-sm text-primary-text/80 mb-4">
-              A simulated score is based on insufficient data and may be unreliable.
-            </p>
-            <button
-              onClick={start}
-              className="rounded-md bg-tertiary-background px-4 py-2 text-sm font-medium text-tertiary-text hover:bg-tertiary-background/70 transition-colors"
-            >
-              Simulate expected score anyway
-            </button>
-          </div>
-        )}
+    <div className="bg-primary-background text-primary-text rounded-xl px-3 py-2 md:px-6 flex flex-wrap items-center gap-x-4 gap-y-2">
+      <h3 className="text-base font-semibold">Expected score</h3>
 
-        {running && (
-          <div className="text-center">
-            <p className="text-sm text-primary-text/80 mb-4">Simulating 5 000 leaderboards…</p>
-            <div className="h-2.5 w-full rounded-full bg-primary-text/10 overflow-hidden">
-              <div
-                className="h-full rounded-full bg-secondary-background transition-all duration-150"
-                style={{ width: `${Math.round(progress * 100)}%` }}
-              />
-            </div>
-            <p className="text-primary-text/60 text-xs mt-2">{Math.round(progress * 100)} %</p>
-          </div>
-        )}
+      {!result && !running && (
+        <>
+          {armed && (
+            <span className="text-xs text-primary-text/80">
+              ⚠️ This player is not ranked. The result is based on insufficient data and may be unreliable.
+            </span>
+          )}
+          <button
+            onClick={() => (armed ? start() : setArmed(true))}
+            className="rounded-md bg-tertiary-background px-3 py-1.5 text-xs font-medium text-tertiary-text hover:bg-tertiary-background/70 transition-colors"
+          >
+            {armed ? "Simulate anyway" : "Simulate"}
+          </button>
+        </>
+      )}
 
-        {result &&
-          !running &&
-          (playerEntry ? (
-            <div>
-              <div className="flex flex-wrap gap-2 sm:gap-4">
-                <div className="flex-1 min-w-40 bg-primary-background rounded-lg p-4">
-                  <p className="text-sm mb-1">Expected score</p>
-                  <p className="text-2xl font-bold">{fmtNum(playerEntry.score)}</p>
-                </div>
-                <div className="flex-1 min-w-40 bg-primary-background rounded-lg p-4">
-                  <p className="text-sm mb-1">Expected rank</p>
-                  <p className="text-2xl font-bold">
-                    {fmtNum(playerEntry.rank)} <span className="text-base font-light">of {result.expected.length}</span>
-                  </p>
-                </div>
-              </div>
-              <p className="text-xs text-primary-text/80 mt-3">
-                ⚠️ The average of 5 000 simulated leaderboards where every ranked player and{" "}
-                {context.playerName(playerId)} play each other. {context.playerName(playerId)} is not ranked, so the
-                result is based on insufficient data and may be unreliable.
-              </p>
-            </div>
-          ) : (
-            <p className="text-sm text-primary-text/80 text-center">
-              Not enough game data to simulate an expected score for this player.
-            </p>
-          ))}
-      </div>
-    </ContentCard>
+      {running && (
+        <div className="flex-1 min-w-32 flex items-center gap-2">
+          <div className="h-2 flex-1 rounded-full bg-primary-text/10 overflow-hidden">
+            <div
+              className="h-full rounded-full bg-secondary-background transition-all duration-150"
+              style={{ width: `${Math.round(progress * 100)}%` }}
+            />
+          </div>
+          <span className="text-xs text-primary-text/60 whitespace-nowrap">{Math.round(progress * 100)} %</span>
+        </div>
+      )}
+
+      {result &&
+        !running &&
+        (playerEntry ? (
+          <>
+            <span>
+              <span className="text-xl font-bold">{fmtNum(playerEntry.score)}</span>{" "}
+              <span className="text-sm font-light">points</span>
+            </span>
+            <span className="text-sm">
+              rank {fmtNum(playerEntry.rank)} of {result.expected.length}
+            </span>
+            <span className="text-xs text-primary-text/60">⚠️ May be unreliable — player is not ranked</span>
+          </>
+        ) : (
+          <span className="text-xs text-primary-text/80">
+            Not enough game data to simulate an expected score for this player.
+          </span>
+        ))}
+    </div>
   );
 };

--- a/frontend/src/pages/player/unranked-expected-score.tsx
+++ b/frontend/src/pages/player/unranked-expected-score.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import { fmtNum } from "../../common/number-utils";
 import { useUnrankedExpectedScoreWorker } from "../../hooks/use-unranked-expected-score-worker";
 
@@ -59,7 +60,11 @@ export const UnrankedExpectedScore: React.FC<Props> = ({ playerId }) => {
               <span className="text-sm font-light">points</span>
             </span>
             <span className="text-sm">
-              rank {fmtNum(playerEntry.rank)} of {result.expected.length}
+              rank {fmtNum(playerEntry.rank)} of {result.expected.length} on the{" "}
+              <Link to="/simulations/expected-leaderboard" className="underline hover:text-primary-text/70">
+                expected leaderboard
+              </Link>
+              , not the current leaderboard
             </span>
             <span className="text-xs text-primary-text/60">⚠️ May be unreliable — player is not ranked</span>
           </>

--- a/frontend/src/pages/player/unranked-expected-score.tsx
+++ b/frontend/src/pages/player/unranked-expected-score.tsx
@@ -1,0 +1,83 @@
+import { fmtNum } from "../../common/number-utils";
+import { useEventDbContext } from "../../wrappers/event-db-context";
+import { useUnrankedExpectedScoreWorker } from "../../hooks/use-unranked-expected-score-worker";
+import { ContentCard } from "./content-card";
+
+type Props = {
+  playerId: string;
+};
+
+/**
+ * Overview card for unranked players: a button (behind an insufficient-data
+ * warning) that simulates their expected score by letting every ranked player
+ * plus this player play each other, like the expected leaderboard.
+ */
+export const UnrankedExpectedScore: React.FC<Props> = ({ playerId }) => {
+  const context = useEventDbContext();
+  const { start, result, progress, running } = useUnrankedExpectedScoreWorker(playerId);
+
+  const playerEntry = result?.expected.find((p) => p.id === playerId);
+
+  return (
+    <ContentCard title="Expected score">
+      <div className="rounded-xl border border-yellow-500/40 bg-yellow-500/10 p-4 text-primary-text">
+        {!result && !running && (
+          <div className="text-center">
+            <div className="text-3xl mb-2">⚠️</div>
+            <p className="text-lg font-semibold mb-1">This player is not ranked</p>
+            <p className="text-sm text-primary-text/80 mb-4">
+              A simulated score is based on insufficient data and may be unreliable.
+            </p>
+            <button
+              onClick={start}
+              className="rounded-md bg-tertiary-background px-4 py-2 text-sm font-medium text-tertiary-text hover:bg-tertiary-background/70 transition-colors"
+            >
+              Simulate expected score anyway
+            </button>
+          </div>
+        )}
+
+        {running && (
+          <div className="text-center">
+            <p className="text-sm text-primary-text/80 mb-4">Simulating 5 000 leaderboards…</p>
+            <div className="h-2.5 w-full rounded-full bg-primary-text/10 overflow-hidden">
+              <div
+                className="h-full rounded-full bg-secondary-background transition-all duration-150"
+                style={{ width: `${Math.round(progress * 100)}%` }}
+              />
+            </div>
+            <p className="text-primary-text/60 text-xs mt-2">{Math.round(progress * 100)} %</p>
+          </div>
+        )}
+
+        {result &&
+          !running &&
+          (playerEntry ? (
+            <div>
+              <div className="flex flex-wrap gap-2 sm:gap-4">
+                <div className="flex-1 min-w-40 bg-primary-background rounded-lg p-4">
+                  <p className="text-sm mb-1">Expected score</p>
+                  <p className="text-2xl font-bold">{fmtNum(playerEntry.score)}</p>
+                </div>
+                <div className="flex-1 min-w-40 bg-primary-background rounded-lg p-4">
+                  <p className="text-sm mb-1">Expected rank</p>
+                  <p className="text-2xl font-bold">
+                    {fmtNum(playerEntry.rank)} <span className="text-base font-light">of {result.expected.length}</span>
+                  </p>
+                </div>
+              </div>
+              <p className="text-xs text-primary-text/80 mt-3">
+                ⚠️ The average of 5 000 simulated leaderboards where every ranked player and{" "}
+                {context.playerName(playerId)} play each other. {context.playerName(playerId)} is not ranked, so the
+                result is based on insufficient data and may be unreliable.
+              </p>
+            </div>
+          ) : (
+            <p className="text-sm text-primary-text/80 text-center">
+              Not enough game data to simulate an expected score for this player.
+            </p>
+          ))}
+      </div>
+    </ContentCard>
+  );
+};


### PR DESCRIPTION
The Overview tab of an active unranked player with at least one game now
shows an Expected score card. Behind an insufficient-data warning, a
button runs the expected-leaderboard simulation with this player included:
every ranked player plus this player play each other across 5 000
simulated leaderboards. The result shows the player's expected score and
expected rank.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KC7dFyASsnFmyQ2HqzmyMr