### PR TITLE
Fix hall of fame tournament scoring gaps

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -42,6 +42,25 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "hall-of-fame-counts-all-tournaments",
+    title: "Hall of fame score counts all tournaments",
+    date: "2026-08-13",
+    tags: ["bug-fix"],
+    summary:
+      "The career score skipped a tournament when the admin did not set an explicit player order. Such tournaments now count, so some scores are higher.",
+    body: [
+      text(
+        "The tournament part of the career score only counted tournaments with an explicitly set player order. A tournament that took its players from the signup list gave 0 points to every player, also to the winner. Such tournaments now count, for tournaments in progress and for completed tournaments.",
+      ),
+      text(
+        "The score for a tournament in progress shows the round you stand in now. It grows as you advance, and it is the score you keep if you lose your next game.",
+      ),
+      text(
+        "The score breakdown on a hall of fame player page now also shows double elimination results. The second chance semi final counts in the Semis tier, because it gives the same 100 points. Before this change, the points were part of the total but no tier showed them.",
+      ),
+    ],
+  },
+  {
     slug: "unranked-expected-score-simulation",
     title: "Simulated expected score for unranked players",
     date: "2026-08-13",

--- a/frontend/src/client/client-db/__tests__/hall-of-fame/tournament-progression.test.ts
+++ b/frontend/src/client/client-db/__tests__/hall-of-fame/tournament-progression.test.ts
@@ -1,0 +1,201 @@
+import { TennisTable } from "../../tennis-table";
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+
+const TOURNAMENT_ID = "tournament-1";
+const START_DATE = 100_000; // Far in the past so the tournament has started
+
+type BaseOptions = {
+  doubleElimination?: boolean;
+  groupPlay?: boolean;
+  setPlayerOrder?: boolean;
+  startDate?: number;
+};
+
+function baseEvents(players: string[], options?: BaseOptions): EventType[] {
+  const events: EventType[] = [];
+  let time = 1_000;
+  for (const player of players) {
+    events.push({ time: time++, stream: player, type: EventTypeEnum.PLAYER_CREATED, data: { name: player } });
+  }
+  events.push({
+    time: time++,
+    stream: TOURNAMENT_ID,
+    type: EventTypeEnum.TOURNAMENT_CREATED,
+    data: {
+      name: "Test tournament",
+      startDate: options?.startDate ?? START_DATE,
+      groupPlay: options?.groupPlay ?? false,
+      doubleElimination: options?.doubleElimination ?? false,
+    },
+  });
+  for (const player of players) {
+    events.push({ time: time++, stream: TOURNAMENT_ID, type: EventTypeEnum.TOURNAMENT_SIGNUP, data: { player } });
+  }
+  if (options?.setPlayerOrder !== false) {
+    events.push({
+      time: time++,
+      stream: TOURNAMENT_ID,
+      type: EventTypeEnum.TOURNAMENT_SET_PLAYER_ORDER,
+      data: { playerOrder: players },
+    });
+  }
+  return events;
+}
+
+let gameTime = 200_000;
+function gameEvent(winner: string, loser: string): EventType {
+  gameTime += 1;
+  return {
+    time: gameTime,
+    stream: `game-${gameTime}`,
+    type: EventTypeEnum.GAME_CREATED,
+    data: { playedAt: gameTime, winner, loser },
+  };
+}
+
+function progression(events: EventType[], playerId: string) {
+  const tennisTable = new TennisTable({ events });
+  const entry = tennisTable.hallOfFame.getScoreForAnyPlayer(playerId);
+  expect(entry).toBeDefined();
+  return entry!.score.tournamentProgression;
+}
+
+beforeEach(() => {
+  gameTime = 200_000;
+});
+
+const EIGHT = ["P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8"];
+
+describe("Tournament progression scoring for tournaments in progress", () => {
+  // 8 player single elimination, quarterfinals done, one semifinal played
+  const inProgress = [
+    ...baseEvents(EIGHT),
+    gameEvent("P1", "P8"),
+    gameEvent("P4", "P5"),
+    gameEvent("P2", "P7"),
+    gameEvent("P3", "P6"),
+    gameEvent("P1", "P4"), // Semifinal 1
+  ];
+
+  it("scores a player by the round they have reached so far", () => {
+    // P1 won their semifinal and stands in the pending final
+    expect(progression(inProgress, "P1").tournaments).toEqual([
+      { name: "Test tournament", placement: "Final", points: 200 },
+    ]);
+    // P2 won their quarterfinal and stands in the pending semifinal
+    expect(progression(inProgress, "P2").tournaments).toEqual([
+      { name: "Test tournament", placement: "Semi Finals", points: 100 },
+    ]);
+  });
+
+  it("scores an eliminated player by the round they lost in", () => {
+    expect(progression(inProgress, "P4").tournaments).toEqual([
+      { name: "Test tournament", placement: "Semi Finals", points: 100 },
+    ]);
+    expect(progression(inProgress, "P8").tournaments).toEqual([
+      { name: "Test tournament", placement: "Quarter Finals", points: 75 },
+    ]);
+  });
+
+  it("gives no points for a tournament that has not started", () => {
+    const future = baseEvents(EIGHT, { startDate: Date.now() + 1_000_000, setPlayerOrder: false });
+    expect(progression(future, "P1").tournaments).toEqual([]);
+  });
+
+  it("gives participation points during group play", () => {
+    const events = [
+      ...baseEvents(["P1", "P2", "P3", "P4", "P5"], { groupPlay: true }),
+      gameEvent("P1", "P5"),
+      gameEvent("P2", "P4"),
+    ];
+    expect(progression(events, "P1").tournaments).toEqual([
+      { name: "Test tournament", placement: "Participated", points: 25 },
+    ]);
+  });
+});
+
+describe("Tournament progression scoring without an explicitly set player order", () => {
+  it("counts a tournament whose players come from signups", () => {
+    const events = [
+      ...baseEvents(["P1", "P2", "P3", "P4"], { setPlayerOrder: false }),
+      gameEvent("P1", "P4"),
+      gameEvent("P2", "P3"),
+      gameEvent("P1", "P2"),
+    ];
+    expect(progression(events, "P1").tournaments).toEqual([
+      { name: "Test tournament", placement: "Winner", points: 300 },
+    ]);
+    expect(progression(events, "P3").tournaments).toEqual([
+      { name: "Test tournament", placement: "Semi Finals", points: 100 },
+    ]);
+  });
+});
+
+describe("Tournament progression scoring for double elimination", () => {
+  // 8 players, played to completion. Losers bracket runs: P8 and P7 fight back
+  const completed = [
+    ...baseEvents(EIGHT, { doubleElimination: true }),
+    // Winners round 1
+    gameEvent("P1", "P8"),
+    gameEvent("P4", "P5"),
+    gameEvent("P2", "P7"),
+    gameEvent("P3", "P6"),
+    // Losers round 1
+    gameEvent("P8", "P5"),
+    gameEvent("P7", "P6"),
+    // Winners semifinals
+    gameEvent("P1", "P4"),
+    gameEvent("P2", "P3"),
+    // Losers round 2 (drop-ins cross-seeded)
+    gameEvent("P8", "P3"),
+    gameEvent("P7", "P4"),
+    // Losers round 3
+    gameEvent("P8", "P7"),
+    // Winners final (first chance semi final)
+    gameEvent("P1", "P2"),
+    // Second chance semi final: P8 vs P2
+    gameEvent("P2", "P8"),
+    // Grand final
+    gameEvent("P1", "P2"),
+  ];
+
+  it("awards semi final points (100) for reaching the second chance semi final", () => {
+    expect(progression(completed, "P8").tournaments).toEqual([
+      { name: "Test tournament", placement: "Second Chance Semi Final", points: 100 },
+    ]);
+  });
+
+  it("awards the standard tiers to the rest of the field", () => {
+    expect(progression(completed, "P1").tournaments).toEqual([
+      { name: "Test tournament", placement: "Winner", points: 300 },
+    ]);
+    expect(progression(completed, "P2").tournaments).toEqual([
+      { name: "Test tournament", placement: "Final", points: 200 },
+    ]);
+    // P7 lost losers round 3, one game short of the second chance semi final
+    expect(progression(completed, "P7").tournaments).toEqual([
+      { name: "Test tournament", placement: "Second Chance Bracket", points: 75 },
+    ]);
+    // P5 and P6 lost losers round 1
+    expect(progression(completed, "P5").tournaments).toEqual([
+      { name: "Test tournament", placement: "Second Chance Bracket", points: 50 },
+    ]);
+  });
+
+  it("awards semi final points while standing in a pending second chance semi final", () => {
+    // Everything played except the second chance semi final itself (and the grand final)
+    const inProgress = completed.slice(0, -2);
+    // P8 fought back through the losers bracket into the pending second chance semi final
+    expect(progression(inProgress, "P8").tournaments).toEqual([
+      { name: "Test tournament", placement: "Second Chance Semi Final", points: 100 },
+    ]);
+    // P2 lost the first chance semi final and dropped into the same pending game
+    expect(progression(inProgress, "P2").tournaments).toEqual([
+      { name: "Test tournament", placement: "Second Chance Semi Final", points: 100 },
+    ]);
+    // P1 won the first chance bracket and waits in the grand final
+    expect(progression(inProgress, "P1").tournaments).toEqual([
+      { name: "Test tournament", placement: "Final", points: 200 },
+    ]);
+  });
+});

--- a/frontend/src/client/client-db/hall-of-fame.ts
+++ b/frontend/src/client/client-db/hall-of-fame.ts
@@ -290,7 +290,12 @@ export class HallOfFame {
     const tournamentDetails: TournamentDetail[] = [];
 
     for (const tournament of tournaments) {
-      if (!tournament.tournamentConfig.playerOrder?.includes(playerId)) continue;
+      // A tournament that has not started has neither group play nor a bracket: nothing achieved yet
+      if (!tournament.groupPlay && !tournament.bracket) continue;
+      // Same participant source as the bracket and group play: an explicitly set player order,
+      // otherwise everyone who signed up
+      const participants = tournament.tournamentConfig.playerOrder ?? tournament.signedUp.map((s) => s.player);
+      if (!participants.includes(playerId)) continue;
 
       if (tournament.winner === playerId) {
         score += 300;

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
@@ -83,20 +83,22 @@ function renderDetails(breakdown: HallOfFameScoreBreakdown, key: FactorKey): Rea
     case "tournamentProgression": {
       const d = data as HallOfFameScoreBreakdown["tournamentProgression"];
       if (d.tournaments.length === 0) return <p className="text-primary-text text-xs">No tournaments participated</p>;
+      // Placement names vary (e.g. "Semi Finals" and "Second Chance Semi Final" are both worth
+      // 100), so tiers group by points, not by name
       const tournamentTiers = [
-        { label: "🏆 Win", placement: "Winner", pts: 300 },
-        { label: "Final", placement: "Final", pts: 200 },
-        { label: "Semis", placement: "Semi Finals", pts: 100 },
-        { label: "Quarters", placement: "Quarter Finals", pts: 75 },
-        { label: "Bracket", placement: "Bracket", pts: 50 },
-        { label: "Participated", placement: "Participated", pts: 25 },
+        { label: "🏆 Win", pts: 300 },
+        { label: "Final", pts: 200 },
+        { label: "Semis", pts: 100 },
+        { label: "Quarters", pts: 75 },
+        { label: "Bracket", pts: 50 },
+        { label: "Participated", pts: 25 },
       ];
-      const tournamentCounts = new Map<string, number>();
-      d.tournaments.forEach((t) => tournamentCounts.set(t.placement, (tournamentCounts.get(t.placement) || 0) + 1));
+      const tournamentCounts = new Map<number, number>();
+      d.tournaments.forEach((t) => tournamentCounts.set(t.points, (tournamentCounts.get(t.points) || 0) + 1));
       return (
         <div className="flex flex-wrap gap-1.5">
           {tournamentTiers.map((tier) => {
-            const count = tournamentCounts.get(tier.placement) || 0;
+            const count = tournamentCounts.get(tier.pts) || 0;
             return (
               <span key={tier.label} className={classNames("px-2 py-0.5 rounded text-xs inline-flex items-center gap-1.5", count === 0 ? "bg-secondary-background/50 text-secondary-text/75" : "bg-secondary-background text-secondary-text")}>
                 {tier.label}: {tier.pts} pts


### PR DESCRIPTION
Tournaments without an explicitly set player order (players taken from
the signup list) gave 0 tournament points to every participant, both in
progress and completed. Participants are now derived the same way the
bracket seeds them: the set player order, otherwise the signup list.
Tournaments that have not started are skipped so signing up alone does
not award points.

The player page score breakdown matched placements by exact single
elimination names, so double elimination placements (Second Chance Semi
Final, Second Chance Bracket, First Chance Bracket) were counted in the
total but shown in no tier. Tiers now group by points, so the second
chance semi final shows in the 100 point Semis tier.

Adds tests covering in-progress scoring, signup-derived participants,
and double elimination placements including the pending second chance
semi final.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dkwv6t8HRbLwqA3YaeY5Cv