### PR TITLE
Add point-by-point tracking to live game scoring

### DIFF
--- a/DenoServer/db/database.ts
+++ b/DenoServer/db/database.ts
@@ -16,6 +16,13 @@ export type LiveGameState = {
   };
   currentSet: SetPoint;
   completedSets: SetPoint[];
+  /**
+   * One char per point of the current set in the order the points were scored:
+   * "1" = point to player 1, "2" = point to player 2.
+   */
+  currentSetSequence: string;
+  /** Point sequence of each completed set, same encoding as currentSetSequence. */
+  completedSetSequences: string[];
   /** Which player (1 or 2) served the first point of the current set. */
   firstServer: 1 | 2;
   startedAt: number | null;

--- a/DenoServer/event-store/event-types.ts
+++ b/DenoServer/event-store/event-types.ts
@@ -46,7 +46,8 @@ export type GameScore = GenericEvent<
     /**
      * Point-by-point log, one string per set in the order the sets were played.
      * Each char is one point in the order it was scored: "W" = point to the game
-     * winner, "L" = point to the game loser.
+     * winner, "L" = point to the game loser. A string ends when the set was
+     * marked won — the last char is not necessarily the set winner's point.
      */
     pointSequences?: string[];
   }

--- a/DenoServer/event-store/event-types.ts
+++ b/DenoServer/event-store/event-types.ts
@@ -40,7 +40,16 @@ export type GameCreated = GenericEvent<EventTypeEnum.GAME_CREATED, { playedAt: n
 export type GameDeleted = GenericEvent<EventTypeEnum.GAME_DELETED, null>;
 export type GameScore = GenericEvent<
   EventTypeEnum.GAME_SCORE,
-  { setsWon: { gameWinner: number; gameLoser: number }; setPoints?: { gameWinner: number; gameLoser: number }[] }
+  {
+    setsWon: { gameWinner: number; gameLoser: number };
+    setPoints?: { gameWinner: number; gameLoser: number }[];
+    /**
+     * Point-by-point log, one string per set in the order the sets were played.
+     * Each char is one point in the order it was scored: "W" = point to the game
+     * winner, "L" = point to the game loser.
+     */
+    pointSequences?: string[];
+  }
 >;
 
 export type TournamentCreated = GenericEvent<

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -80,6 +80,25 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
     ],
   },
   {
+    slug: "point-by-point-log-on-tracked-games",
+    title: "Tracked games record every point",
+    date: "2026-08-13",
+    tags: ["technical"],
+    summary:
+      "A game tracked live now saves the order of every point, not only the set scores. The app does not show the data yet.",
+    body: [
+      text(
+        "The track game page and the broadcasted live game record each point as it is scored. When the game is saved, the `GAME_SCORE` event stores one string per set. Each character is one point, in the order the points were scored: `W` for a point to the game winner, `L` for a point to the game loser.",
+      ),
+      text(
+        "The end of each string is the moment the set was won. The storage cost is 1 character per point. Validation rejects a log that does not match the set points.",
+      ),
+      text(
+        "Only games tracked live get the log. A game added with the normal form, an edited score, or a live game that started before this change saves without it.",
+      ),
+    ],
+  },
+  {
     slug: "live-win-prediction-extended-matches",
     title: "Live win% prediction supports extended matches",
     date: "2026-08-12",

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -88,10 +88,10 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
       "A game tracked live now saves the order of every point, not only the set scores. The app does not show the data yet.",
     body: [
       text(
-        "The track game page and the broadcasted live game record each point as it is scored. When the game is saved, the `GAME_SCORE` event stores one string per set. Each character is one point, in the order the points were scored: `W` for a point to the game winner, `L` for a point to the game loser.",
+        "The track game page and the broadcasted live game record each point. When you save the game, the `GAME_SCORE` event stores one string per set. Each character is one point, in scoring order. `W` is a point to the game winner. `L` is a point to the game loser.",
       ),
       text(
-        "The end of each string is the moment the set was won. The storage cost is 1 character per point. Validation rejects a log that does not match the set points.",
+        "A string ends when a player wins the set. The storage cost is 1 character for each point. Validation rejects a log that does not match the set points.",
       ),
       text(
         "Only games tracked live get the log. A game added with the normal form, an edited score, or a live game that started before this change saves without it.",

--- a/frontend/src/client/client-db/__tests__/event-store/games-projector.test.ts
+++ b/frontend/src/client/client-db/__tests__/event-store/games-projector.test.ts
@@ -223,6 +223,74 @@ describe("validateScoreGame", () => {
     expect(result.message).toBe("Points are invalid. Loser must win the correct amount of sets");
   });
 
+  it("accepts point sequences that match the set points", () => {
+    const result = projector.validateScoreGame(
+      scoreEvent("game-1", {
+        setsWon: { gameWinner: 2, gameLoser: 1 },
+        setPoints: [
+          { gameWinner: 3, gameLoser: 1 },
+          { gameWinner: 1, gameLoser: 2 },
+          { gameWinner: 2, gameLoser: 0 },
+        ],
+        pointSequences: ["WLWW", "LWL", "WW"],
+      }),
+    );
+    expect(result).toEqual({ valid: true });
+  });
+
+  it("rejects point sequences without set points", () => {
+    const result = projector.validateScoreGame(
+      scoreEvent("game-1", {
+        setsWon: { gameWinner: 2, gameLoser: 0 },
+        pointSequences: ["WW", "WW"],
+      }),
+    );
+    expectInvalid(result);
+    expect(result.message).toBe("Point sequences require set points");
+  });
+
+  it("rejects point sequences when the number of sequences does not match the number of sets", () => {
+    const result = projector.validateScoreGame(
+      scoreEvent("game-1", {
+        setsWon: { gameWinner: 2, gameLoser: 0 },
+        setPoints: [
+          { gameWinner: 2, gameLoser: 0 },
+          { gameWinner: 2, gameLoser: 1 },
+        ],
+        pointSequences: ["WW"],
+      }),
+    );
+    expectInvalid(result);
+    expect(result.message).toBe("Point sequences are invalid. There must be one sequence per set");
+  });
+
+  it("rejects point sequences with characters other than W and L", () => {
+    const result = projector.validateScoreGame(
+      scoreEvent("game-1", {
+        setsWon: { gameWinner: 1, gameLoser: 0 },
+        setPoints: [{ gameWinner: 2, gameLoser: 0 }],
+        pointSequences: ["W1"],
+      }),
+    );
+    expectInvalid(result);
+    expect(result.message).toBe("Point sequences are invalid. Only 'W' and 'L' points are allowed");
+  });
+
+  it("rejects a point sequence whose point counts do not match its set points", () => {
+    const result = projector.validateScoreGame(
+      scoreEvent("game-1", {
+        setsWon: { gameWinner: 2, gameLoser: 0 },
+        setPoints: [
+          { gameWinner: 2, gameLoser: 0 },
+          { gameWinner: 2, gameLoser: 1 },
+        ],
+        pointSequences: ["WW", "WLL"],
+      }),
+    );
+    expectInvalid(result);
+    expect(result.message).toBe("Point sequences are invalid. Sequence for set 2 does not match the set points");
+  });
+
   it("currently accepts a score for a game that does not exist (documented gap)", () => {
     // validateScoreGame never checks the game stream, so a GAME_SCORE event
     // for an unknown game passes validation (the projection then no-ops).

--- a/frontend/src/client/client-db/event-store/event-types.ts
+++ b/frontend/src/client/client-db/event-store/event-types.ts
@@ -44,9 +44,10 @@ export type GameScore = GenericEvent<
     /**
      * Point-by-point log, one string per set in the order the sets were played.
      * Each char is one point in the order it was scored: "W" = point to the game
-     * winner, "L" = point to the game loser. The end of a string is the moment
-     * the set was won. Requires setPoints, and each string must count up to the
-     * corresponding set's points.
+     * winner, "L" = point to the game loser. A string ends when the set was
+     * marked won — the last char is not necessarily the set winner's point.
+     * Requires setPoints, and each string must count up to the corresponding
+     * set's points.
      */
     pointSequences?: string[];
   }

--- a/frontend/src/client/client-db/event-store/event-types.ts
+++ b/frontend/src/client/client-db/event-store/event-types.ts
@@ -38,7 +38,18 @@ export type GameCreated = GenericEvent<EventTypeEnum.GAME_CREATED, { playedAt: n
 export type GameDeleted = GenericEvent<EventTypeEnum.GAME_DELETED, null>;
 export type GameScore = GenericEvent<
   EventTypeEnum.GAME_SCORE,
-  { setsWon: { gameWinner: number; gameLoser: number }; setPoints?: { gameWinner: number; gameLoser: number }[] }
+  {
+    setsWon: { gameWinner: number; gameLoser: number };
+    setPoints?: { gameWinner: number; gameLoser: number }[];
+    /**
+     * Point-by-point log, one string per set in the order the sets were played.
+     * Each char is one point in the order it was scored: "W" = point to the game
+     * winner, "L" = point to the game loser. The end of a string is the moment
+     * the set was won. Requires setPoints, and each string must count up to the
+     * corresponding set's points.
+     */
+    pointSequences?: string[];
+  }
 >;
 
 export type TournamentCreated = GenericEvent<

--- a/frontend/src/client/client-db/event-store/projectors/games-projector.ts
+++ b/frontend/src/client/client-db/event-store/projectors/games-projector.ts
@@ -94,6 +94,30 @@ export class GamesProjector {
       }
     }
 
+    if (event.data.pointSequences) {
+      if (!event.data.setPoints) {
+        return { valid: false, message: "Point sequences require set points" };
+      }
+      if (event.data.pointSequences.length !== event.data.setPoints.length) {
+        return { valid: false, message: "Point sequences are invalid. There must be one sequence per set" };
+      }
+      for (let setIndex = 0; setIndex < event.data.pointSequences.length; setIndex++) {
+        const sequence = event.data.pointSequences[setIndex];
+        if (/^[WL]*$/.test(sequence) === false) {
+          return { valid: false, message: "Point sequences are invalid. Only 'W' and 'L' points are allowed" };
+        }
+        const winnerPoints = sequence.split("").filter((point) => point === "W").length;
+        const loserPoints = sequence.length - winnerPoints;
+        const set = event.data.setPoints[setIndex];
+        if (winnerPoints !== set.gameWinner || loserPoints !== set.gameLoser) {
+          return {
+            valid: false,
+            message: `Point sequences are invalid. Sequence for set ${setIndex + 1} does not match the set points`,
+          };
+        }
+      }
+    }
+
     return { valid: true };
   }
 }

--- a/frontend/src/common/point-sequences.test.ts
+++ b/frontend/src/common/point-sequences.test.ts
@@ -1,0 +1,55 @@
+import { appendPointToSequence, removeLastPointFromSequence, toEventPointSequences } from "./point-sequences";
+
+describe("appendPointToSequence", () => {
+  it("appends the player's digit to the sequence", () => {
+    expect(appendPointToSequence("", 1)).toBe("1");
+    expect(appendPointToSequence("112", 2)).toBe("1122");
+  });
+});
+
+describe("removeLastPointFromSequence", () => {
+  it("removes the player's last point and keeps later points", () => {
+    expect(removeLastPointFromSequence("1121", 2)).toBe("111");
+    expect(removeLastPointFromSequence("1121", 1)).toBe("112");
+  });
+
+  it("returns the sequence unchanged when the player has no points", () => {
+    expect(removeLastPointFromSequence("111", 2)).toBe("111");
+    expect(removeLastPointFromSequence("", 1)).toBe("");
+  });
+});
+
+describe("toEventPointSequences", () => {
+  const completedSets = [
+    { player1: 3, player2: 1 },
+    { player1: 1, player2: 2 },
+  ];
+  const setSequences = ["1211", "212"];
+
+  it("encodes sequences as W/L from the game winner's perspective", () => {
+    expect(toEventPointSequences({ setSequences, completedSets, player1IsGameWinner: true })).toEqual([
+      "WLWW",
+      "LWL",
+    ]);
+    expect(toEventPointSequences({ setSequences, completedSets, player1IsGameWinner: false })).toEqual([
+      "LWLL",
+      "WLW",
+    ]);
+  });
+
+  it("returns undefined when there are no completed sets", () => {
+    expect(toEventPointSequences({ setSequences: [], completedSets: [], player1IsGameWinner: true })).toBeUndefined();
+  });
+
+  it("returns undefined when a set has no sequence", () => {
+    expect(
+      toEventPointSequences({ setSequences: ["1211"], completedSets, player1IsGameWinner: true }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when a sequence does not match its set's points", () => {
+    expect(
+      toEventPointSequences({ setSequences: ["1211", "211"], completedSets, player1IsGameWinner: true }),
+    ).toBeUndefined();
+  });
+});

--- a/frontend/src/common/point-sequences.ts
+++ b/frontend/src/common/point-sequences.ts
@@ -1,0 +1,58 @@
+/**
+ * Point-by-point tracking during a live game.
+ *
+ * While a game is tracked the winner is unknown, so points are collected per
+ * set as a string of "1"/"2" chars — one char per point, in the order the
+ * points were scored, naming the player slot that won the point. When the game
+ * is saved the sequences are re-encoded from the game winner's perspective
+ * ("W"/"L") to match how a GAME_SCORE event stores its setPoints.
+ */
+
+export type TrackedSetPoints = { player1: number; player2: number };
+
+export function appendPointToSequence(sequence: string, player: 1 | 2): string {
+  return sequence + String(player);
+}
+
+/**
+ * Undo one point for a player: drops that player's last point from the
+ * sequence, keeping the points scored after it.
+ */
+export function removeLastPointFromSequence(sequence: string, player: 1 | 2): string {
+  const index = sequence.lastIndexOf(String(player));
+  if (index === -1) return sequence;
+  return sequence.slice(0, index) + sequence.slice(index + 1);
+}
+
+function sequenceMatchesSet(sequence: string, set: TrackedSetPoints): boolean {
+  const player1Points = sequence.split("").filter((point) => point === "1").length;
+  const player2Points = sequence.length - player1Points;
+  return player1Points === set.player1 && player2Points === set.player2;
+}
+
+/**
+ * Re-encodes tracked "1"/"2" sequences to the "W"/"L" sequences stored on a
+ * GAME_SCORE event. Returns undefined when the sequences do not align with the
+ * completed sets — e.g. a live game that started before point tracking existed —
+ * so the game is saved without point-level data instead of failing validation.
+ */
+export function toEventPointSequences(params: {
+  setSequences: string[];
+  completedSets: TrackedSetPoints[];
+  player1IsGameWinner: boolean;
+}): string[] | undefined {
+  const { setSequences, completedSets, player1IsGameWinner } = params;
+  if (completedSets.length === 0) return undefined;
+  if (setSequences.length !== completedSets.length) return undefined;
+  if (setSequences.some((sequence, index) => sequenceMatchesSet(sequence, completedSets[index]) === false)) {
+    return undefined;
+  }
+
+  const gameWinnerDigit = player1IsGameWinner ? "1" : "2";
+  return setSequences.map((sequence) =>
+    sequence
+      .split("")
+      .map((point) => (point === gameWinnerDigit ? "W" : "L"))
+      .join(""),
+  );
+}

--- a/frontend/src/pages/add-game/track-game.tsx
+++ b/frontend/src/pages/add-game/track-game.tsx
@@ -110,8 +110,10 @@ export const TrackGamePage: React.FC = () => {
     const next: SetPoint = { ...currentSetScore, [key]: currentSetScore[key] - 1 };
     setCurrentSetScore(next);
     setCurrentSetSequence((prev) => removeLastPointFromSequence(prev, player as 1 | 2));
-    // Undoing a point drops the last 2 samples and appends one for the restored score.
-    setWinPercentHistory((prev) => [...prev.slice(0, -2), computeWinPercent(next)]);
+    // Undoing a point drops the last 2 samples and appends one for the restored
+    // score, so the history keeps one sample per point. Undoing the only point
+    // of the match just empties the history.
+    setWinPercentHistory((prev) => (prev.length <= 1 ? [] : [...prev.slice(0, -2), computeWinPercent(next)]));
   };
 
   const setWon = (player: number) => {

--- a/frontend/src/pages/add-game/track-game.tsx
+++ b/frontend/src/pages/add-game/track-game.tsx
@@ -21,6 +21,11 @@ import { Predictions } from "../../client/client-db/predictions";
 import { WinPercentGraph } from "./win-percent-graph";
 import { session } from "../../services/auth";
 import { useLiveGameQuery, useUpdateLiveGameMutation } from "../live-game/use-live-game";
+import {
+  appendPointToSequence,
+  removeLastPointFromSequence,
+  toEventPointSequences,
+} from "../../common/point-sequences";
 
 interface SetPoint {
   player1: number;
@@ -33,6 +38,8 @@ interface MatchData {
     player2: number;
   };
   setPoints?: SetPoint[];
+  /** Point sequence of each completed set: "1"/"2" chars in the order the points were scored. */
+  setSequences: string[];
 }
 
 type Stage = "player-selection" | "scoring" | "summary";
@@ -49,11 +56,14 @@ export const TrackGamePage: React.FC = () => {
   const [matchData, setMatchData] = useState<MatchData>({
     setsWon: { player1: 0, player2: 0 },
     setPoints: [],
+    setSequences: [],
   });
   const [currentSetScore, setCurrentSetScore] = useState<SetPoint>({
     player1: 0,
     player2: 0,
   });
+  // "1"/"2" per point of the current set, in the order the points were scored.
+  const [currentSetSequence, setCurrentSetSequence] = useState<string>("");
   const [firstServer, setFirstServer] = useState<Server>(1);
   // Player 1's live win chance sampled after every point, for the summary graph.
   const [winPercentHistory, setWinPercentHistory] = useState<number[]>([]);
@@ -90,6 +100,7 @@ export const TrackGamePage: React.FC = () => {
     const key = `player${player}` as keyof SetPoint;
     const next: SetPoint = { ...currentSetScore, [key]: currentSetScore[key] + 1 };
     setCurrentSetScore(next);
+    setCurrentSetSequence((prev) => appendPointToSequence(prev, player as 1 | 2));
     setWinPercentHistory((prev) => [...prev, computeWinPercent(next)]);
   };
 
@@ -98,6 +109,7 @@ export const TrackGamePage: React.FC = () => {
     if (currentSetScore[key] === 0) return;
     const next: SetPoint = { ...currentSetScore, [key]: currentSetScore[key] - 1 };
     setCurrentSetScore(next);
+    setCurrentSetSequence((prev) => removeLastPointFromSequence(prev, player as 1 | 2));
     // Undoing a point drops the last 2 samples and appends one for the restored score.
     setWinPercentHistory((prev) => [...prev.slice(0, -2), computeWinPercent(next)]);
   };
@@ -114,9 +126,11 @@ export const TrackGamePage: React.FC = () => {
         player2: prev.setsWon.player2 + (player === 2 ? 1 : 0),
       },
       setPoints: [...(prev.setPoints || []), newSetPoint],
+      setSequences: [...prev.setSequences, currentSetSequence],
     }));
 
     setCurrentSetScore({ player1: 0, player2: 0 });
+    setCurrentSetSequence("");
     // Alternate who serves first in the next set, per table tennis convention.
     setFirstServer((prev) => (prev === 1 ? 2 : 1));
   };
@@ -166,6 +180,11 @@ export const TrackGamePage: React.FC = () => {
                 gameLoser: player1 === winner ? set.player2 : set.player1,
               }))
             : undefined,
+        pointSequences: toEventPointSequences({
+          setSequences: matchData.setSequences,
+          completedSets: setPointsForValidation,
+          player1IsGameWinner: player1 === winner,
+        }),
       },
     };
 
@@ -247,6 +266,8 @@ export const TrackGamePage: React.FC = () => {
         setsWon: { ...matchData.setsWon },
         currentSet: { ...currentSetScore },
         completedSets: matchData.setPoints ?? [],
+        currentSetSequence,
+        completedSetSequences: [...matchData.setSequences],
         firstServer,
         startedAt: now,
         finishedAt: null,
@@ -266,8 +287,10 @@ export const TrackGamePage: React.FC = () => {
     setMatchData({
       setsWon: { player1: 0, player2: 0 },
       setPoints: [],
+      setSequences: [],
     });
     setCurrentSetScore({ player1: 0, player2: 0 });
+    setCurrentSetSequence("");
     setFirstServer(1);
     setWinPercentHistory([]);
     setValidationError("");

--- a/frontend/src/pages/edit-game-score.tsx
+++ b/frontend/src/pages/edit-game-score.tsx
@@ -102,6 +102,10 @@ export const EditGameSore: React.FC = () => {
     }
   }, [winnerSets, loserSets, setPoints.length]);
 
+  // Editing replaces the score event, and the edit form has no point-level
+  // detail — so a point-by-point log from live tracking is lost on save.
+  const hasPointSequences = (game?.score?.pointSequences?.length ?? 0) > 0;
+
   if (!game) return null;
   return (
     <div>
@@ -130,6 +134,12 @@ export const EditGameSore: React.FC = () => {
         {validationError && <div className="bg-black text-red-500 text-center">Error: {validationError}</div>}
       </div>
       <div className="p-6 bg-secondary-background">
+        {hasPointSequences && (
+          <div className="mb-3 p-3 bg-amber-100 border border-amber-400 text-amber-800 rounded-lg text-sm">
+            ⚠️ This game was tracked live, point by point. If you save an edited score, the point-by-point data of
+            this game is discarded.
+          </div>
+        )}
         <div className="flex space-x-3">
           <button
             onClick={() => navigate(-1)}

--- a/frontend/src/pages/live-game/live-game-admin-page.tsx
+++ b/frontend/src/pages/live-game/live-game-admin-page.tsx
@@ -26,6 +26,11 @@ import { LiveGamePredictionCard } from "./live-game-prediction-card";
 import ConfettiExplosion from "react-confetti-explosion";
 import { Server } from "../../common/serve-tracker";
 import { ServeTrackerDisplay } from "../../common/serve-tracker-display";
+import {
+  appendPointToSequence,
+  removeLastPointFromSequence,
+  toEventPointSequences,
+} from "../../common/point-sequences";
 
 type Stage = "scoring" | "confirm";
 
@@ -96,6 +101,8 @@ export const LiveGameAdminPage: React.FC = () => {
       setsWon: { player1: 0, player2: 0 },
       currentSet: { player1: 0, player2: 0 },
       completedSets: [],
+      currentSetSequence: "",
+      completedSetSequences: [],
       firstServer: localState!.firstServer,
       startedAt: Date.now(),
       finishedAt: null,
@@ -115,6 +122,7 @@ export const LiveGameAdminPage: React.FC = () => {
         ...localState!.currentSet,
         [key]: localState!.currentSet[key] + 1,
       },
+      currentSetSequence: appendPointToSequence(localState!.currentSetSequence, player),
     });
   }
 
@@ -126,6 +134,7 @@ export const LiveGameAdminPage: React.FC = () => {
         ...localState!.currentSet,
         [key]: Math.max(0, localState!.currentSet[key] - 1),
       },
+      currentSetSequence: removeLastPointFromSequence(localState!.currentSetSequence, player),
     });
   }
 
@@ -138,6 +147,8 @@ export const LiveGameAdminPage: React.FC = () => {
       },
       completedSets: [...localState!.completedSets, { ...localState!.currentSet }],
       currentSet: { player1: 0, player2: 0 },
+      completedSetSequences: [...localState!.completedSetSequences, localState!.currentSetSequence],
+      currentSetSequence: "",
       // Alternate who serves first in the next set, per table tennis convention.
       firstServer: localState!.firstServer === 1 ? 2 : 1,
     });
@@ -150,6 +161,8 @@ export const LiveGameAdminPage: React.FC = () => {
       setsWon: { player1: 0, player2: 0 },
       currentSet: { player1: 0, player2: 0 },
       completedSets: [],
+      currentSetSequence: "",
+      completedSetSequences: [],
       firstServer: 1,
       updatedAt: Date.now(),
     });
@@ -209,6 +222,13 @@ export const LiveGameAdminPage: React.FC = () => {
                 gameLoser: player1Won ? set.player2 : set.player1,
               }))
             : undefined,
+        // undefined when the sequences do not align with the completed sets,
+        // e.g. a live game that started before point tracking existed.
+        pointSequences: toEventPointSequences({
+          setSequences: localState!.completedSetSequences,
+          completedSets: localState!.completedSets,
+          player1IsGameWinner: player1Won,
+        }),
       },
     };
 

--- a/frontend/src/pages/live-game/live-game-types.ts
+++ b/frontend/src/pages/live-game/live-game-types.ts
@@ -12,6 +12,13 @@ export type LiveGameState = {
   };
   currentSet: LiveGameSetPoint;
   completedSets: LiveGameSetPoint[];
+  /**
+   * One char per point of the current set in the order the points were scored:
+   * "1" = point to player 1, "2" = point to player 2.
+   */
+  currentSetSequence: string;
+  /** Point sequence of each completed set, same encoding as currentSetSequence. */
+  completedSetSequences: string[];
   /** Which player (1 or 2) served the first point of the current set. */
   firstServer: 1 | 2;
   startedAt: number | null;
@@ -25,6 +32,8 @@ export const emptyLiveGame: LiveGameState = {
   setsWon: { player1: 0, player2: 0 },
   currentSet: { player1: 0, player2: 0 },
   completedSets: [],
+  currentSetSequence: "",
+  completedSetSequences: [],
   firstServer: 1,
   startedAt: null,
   finishedAt: null,


### PR DESCRIPTION
Games tracked on the track game page or the broadcasted live game now
record the sequence of every point scored. The GAME_SCORE event stores
an optional pointSequences field: one string per set, one char per
point (W = game winner, L = game loser), so the array boundaries also
record when each set was won.

The games projector validates that sequences require setPoints, match
the number of sets, contain only W/L, and count up to each set's
points. Live game state carries the sequences (currentSetSequence and
completedSetSequences) through the track-game-to-broadcast handover,
and games from live states that predate the feature save without the
log instead of failing validation.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BSRAi9P9rTekYUEoBMSLmL