### PR TITLE
Add game details page with replayed win % graph

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -56,6 +56,7 @@ import { ChangelogPostPage } from "./pages/changelog/changelog-post-page";
 import { ComparePage } from "./pages/compare/compare-page";
 import { OtherPage } from "./pages/other/other-page";
 import { WhatChangedPage } from "./pages/other/what-changed-page";
+import { GameDetailsPage } from "./pages/game/game-details-page";
 import { PerformancePage } from "./pages/performance/performance-page";
 import { NotFoundPage } from "./pages/not-found-page";
 import { NewVersionChecker } from "./wrappers/new-version-checker";
@@ -150,6 +151,7 @@ function App() {
                         <Route path="/add-game" element={<ChooseAddOrTrack />} />
                         <Route path="/add-game-add" element={<AddGamePageV2 />} />
                         <Route path="/add-game-track" element={<TrackGamePage />} />
+                        <Route path="/game" element={<GameDetailsPage />} />
                         <Route path="/game/edit/score" element={<EditGameSore />} />
                         <Route path="/camera" element={<CameraPage />} />
                         <Route path="/other" element={<OtherPage />} />

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -42,6 +42,28 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "game-details-page",
+    title: "Game details page",
+    date: "2026-08-13",
+    tags: ["new-feature"],
+    summary:
+      "Each game has a page with the score, the Elo it moved, the win % prediction before and after the game, and a win % graph for games tracked live.",
+    body: [
+      text(
+        "A game in the recent games list, on the What changed page, or in the 1v1 match history opens the new game details page. The page shows the players, the score, the time, and the Elo each player won or lost.",
+      ),
+      text(
+        "The page shows the win % prediction between the 2 players before and after the game, each with its confidence.",
+      ),
+      text(
+        "A game with a point-by-point log gets a win % graph. The app replays the recorded points through the live prediction model, with the prediction data as it stood before the game. A 📈 mark next to a score in the game lists shows that the game has the log.",
+      ),
+      text(
+        "2 buttons open related pages: the head-to-head page for the 2 players, and the What changed page with the period of this game preselected.",
+      ),
+    ],
+  },
+  {
     slug: "hall-of-fame-counts-all-tournaments",
     title: "Hall of fame score counts all tournaments",
     date: "2026-08-13",

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -56,7 +56,7 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
         "The page shows the win % prediction between the 2 players before and after the game, each with its confidence.",
       ),
       text(
-        "A game with a point-by-point log gets a win % graph. The app replays the recorded points through the live prediction model, with the prediction data as it stood before the game. A 📈 mark next to a score in the game lists shows that the game has the log.",
+        "A game with a point-by-point log gets a win % graph. The app replays the recorded points through the live prediction model, with the prediction data from before the game. A 📈 mark next to a score in the game lists shows that the game has the log.",
       ),
       text(
         "2 buttons open related pages: the head-to-head page for the 2 players, and the What changed page with the period of this game preselected.",

--- a/frontend/src/common/date-utils.tsx
+++ b/frontend/src/common/date-utils.tsx
@@ -207,3 +207,22 @@ function formatDistance(laterDate: Date, earlierDate: Date, options?: FormatDist
 
   return result[0].toUpperCase() + result.slice(1);
 }
+
+// Convert a millisecond timestamp into the local "YYYY-MM-DDTHH:mm:ss" string
+// expected by a <input type="datetime-local"> element (step 1 for seconds).
+export function toDatetimeLocalValue(ms: number): string {
+  const date = new Date(ms);
+  const pad = (n: number) => n.toString().padStart(2, "0");
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
+  );
+}
+
+// A datetime-local string parses as local time. Returns undefined while the
+// input is incomplete (the browser then reports an empty value).
+export function fromDatetimeLocalValue(value: string): number | undefined {
+  if (!value) return undefined;
+  const ms = new Date(value).getTime();
+  return isNaN(ms) ? undefined : ms;
+}

--- a/frontend/src/hooks/use-state-at.tsx
+++ b/frontend/src/hooks/use-state-at.tsx
@@ -1,0 +1,24 @@
+import { useMemo } from "react";
+import { useEventDbContext } from "../wrappers/event-db-context";
+import { TennisTable } from "../client/client-db/tennis-table";
+import { EventType, EventTypeEnum } from "../client/client-db/event-store/event-types";
+
+// Same "state at a point in time" filter as tournament predictions:
+// games count by when they were played, everything else by event time.
+export function eventsUpTo(events: EventType[], time: number): EventType[] {
+  return events.filter((event) => {
+    if (event.type === EventTypeEnum.GAME_CREATED) {
+      return event.data.playedAt <= time;
+    }
+    return event.time <= time;
+  });
+}
+
+// The full app state projected at a point in time.
+export function useStateAt(time: number | undefined): TennisTable | undefined {
+  const context = useEventDbContext();
+  return useMemo(() => {
+    if (time === undefined) return undefined;
+    return new TennisTable({ events: eventsUpTo(context.events, time), referenceTime: time });
+  }, [context, time]);
+}

--- a/frontend/src/hooks/use-tennis-params.tsx
+++ b/frontend/src/hooks/use-tennis-params.tsx
@@ -6,6 +6,7 @@ const PLAYER_2 = "player2";
 const TOURNAMENT = "tournament";
 const GAME_ID = "gameId";
 const SEASON_START = "seasonStart";
+const TIME = "time";
 
 export function useTennisParams() {
   const [searchParams] = useSearchParams();
@@ -15,6 +16,7 @@ export function useTennisParams() {
   const tournament = searchParams.get(TOURNAMENT);
   const gameId = searchParams.get(GAME_ID);
   const seasonStart = searchParams.get(SEASON_START);
+  const time = searchParams.get(TIME);
 
-  return { playerId, player1, player2, tournament, gameId, seasonStart };
+  return { playerId, player1, player2, tournament, gameId, seasonStart, time };
 }

--- a/frontend/src/pages/game/game-details-page.tsx
+++ b/frontend/src/pages/game/game-details-page.tsx
@@ -1,0 +1,222 @@
+import { useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { useEventDbContext } from "../../wrappers/event-db-context";
+import { useTennisParams } from "../../hooks/use-tennis-params";
+import { useStateAt } from "../../hooks/use-state-at";
+import { fmtNum } from "../../common/number-utils";
+import { RelativeTime, toDatetimeLocalValue } from "../../common/date-utils";
+import { stringToColor } from "../../common/string-to-color";
+import { ProfilePicture } from "../player/profile-picture";
+import { Fraction, Predictions } from "../../client/client-db/predictions";
+import { TennisTable } from "../../client/client-db/tennis-table";
+import { WinPercentGraph } from "../add-game/win-percent-graph";
+import { replayWinPercentHistory } from "./game-win-replay";
+
+/**
+ * Details about a single game, identified by its played-at timestamp (unique
+ * per game) in the `time` url param: who played and the score, the Elo the
+ * game moved, the pairing win % prediction before and after the game, and the
+ * win % over the game replayed from the point-by-point log. Everything the
+ * game changed beyond that (leaderboards, achievements) lives on the What
+ * changed page, linked with the game's own 2-second window preselected.
+ */
+// The overall pairing prediction (direct + indirect, combined by confidence)
+// in a projected state, from the winner's perspective.
+function pairingPrediction(state: TennisTable | undefined, winner: string, loser: string): Fraction | undefined {
+  if (!state) return undefined;
+  const direct = state.predictions.getDirectFraction(winner, loser);
+  const oneLayer = state.predictions.getOneLayerFraction(winner, loser);
+  const twoLayer = state.predictions.getTwoLayerFraction(winner, loser);
+  return Predictions.combinePrioritizedFractions([direct, oneLayer, twoLayer]);
+}
+
+export const GameDetailsPage: React.FC = () => {
+  const context = useEventDbContext();
+  const navigate = useNavigate();
+  const { time } = useTennisParams();
+  const playedAt = time !== null && /^\d+$/.test(time) ? Number(time) : undefined;
+  const game = useMemo(
+    () => (playedAt === undefined ? undefined : context.games.find((g) => g.playedAt === playedAt)),
+    [context, playedAt],
+  );
+
+  // The app state just before and just at the game. Both drive the pairing
+  // prediction; the pre-game one also seeds the win % replay.
+  const preState = useStateAt(game ? game.playedAt - 1 : undefined);
+  const postState = useStateAt(game?.playedAt);
+
+  // Elo moved by this game, from the players' game log entries.
+  const eloExchange = useMemo(() => {
+    if (!game) return undefined;
+    const leaderboardMap = context.leaderboard.getCachedLeaderboardMap();
+    const winnerGame = leaderboardMap.get(game.winner)?.games.find((g) => g.time === game.playedAt);
+    const loserGame = leaderboardMap.get(game.loser)?.games.find((g) => g.time === game.playedAt);
+    if (!winnerGame || !loserGame) return undefined;
+    return {
+      winner: { diff: winnerGame.pointsDiff, after: winnerGame.eloAfterGame },
+      loser: { diff: loserGame.pointsDiff, after: loserGame.eloAfterGame },
+    };
+  }, [context, game]);
+
+  const preGamePrediction = useMemo(
+    () => (game ? pairingPrediction(preState, game.winner, game.loser) : undefined),
+    [game, preState],
+  );
+  const postGamePrediction = useMemo(
+    () => (game ? pairingPrediction(postState, game.winner, game.loser) : undefined),
+    [game, postState],
+  );
+
+  // Win % after every point, replayed from the stored point sequences with the
+  // live model. Seeded by the game so the graph is stable across renders.
+  const winPercentHistory = useMemo(() => {
+    if (!game?.score?.pointSequences || !preGamePrediction) return undefined;
+    return replayWinPercentHistory({
+      pointSequences: game.score.pointSequences,
+      preGameWinChance: preGamePrediction.confidence > 0 ? preGamePrediction.fraction : 0.5,
+      preGameConfidence: preGamePrediction.confidence,
+      seed: game.playedAt,
+    });
+  }, [game, preGamePrediction]);
+
+  if (!game) {
+    return <div className="p-8 text-center text-primary-text/60">Game not found</div>;
+  }
+
+  const whatChangedLink =
+    `/what-changed?range=custom` +
+    `&from=${toDatetimeLocalValue(game.playedAt - 1000)}` +
+    `&to=${toDatetimeLocalValue(game.playedAt + 1000)}`;
+
+  return (
+    <div className="w-full px-4 flex flex-col items-center">
+      <div className="w-full max-w-2xl md:max-w-4xl">
+        <div className="bg-primary-background rounded-lg w-full overflow-hidden">
+          <h1 className="text-2xl md:text-4xl text-center mt-2 md:mt-4 text-primary-text">Game details</h1>
+          <p className="text-center text-sm md:text-base text-primary-text/60 mb-2 md:mb-3">
+            {new Date(game.playedAt).toLocaleString()} · <RelativeTime date={new Date(game.playedAt)} variant="auto" />
+          </p>
+
+          {/* Who played, the score, and the Elo the game moved */}
+          <div className="flex justify-center items-center gap-3 xs:gap-6 px-4 text-primary-text">
+            <div
+              className="flex flex-col items-center gap-1 flex-1 min-w-0 cursor-pointer"
+              onClick={() => navigate(`/player/${game.winner}`)}
+            >
+              <ProfilePicture playerId={game.winner} size={64} border={3} />
+              <span className="font-bold text-sm md:text-base truncate max-w-full">
+                🏆 {context.playerName(game.winner)}
+              </span>
+              {eloExchange && (
+                <span className="text-xs md:text-sm text-green-500 font-medium whitespace-nowrap">
+                  +{fmtNum(eloExchange.winner.diff)} Elo → {fmtNum(eloExchange.winner.after)}
+                </span>
+              )}
+            </div>
+
+            <div className="flex flex-col items-center shrink-0">
+              {game.score ? (
+                <>
+                  <div className="text-3xl md:text-4xl font-black whitespace-nowrap">
+                    {game.score.setsWon.gameWinner} - {game.score.setsWon.gameLoser}
+                  </div>
+                  {game.score.setPoints && (
+                    <div className="font-light italic text-xs md:text-sm whitespace-nowrap text-primary-text/70">
+                      {game.score.setPoints.map((set) => `${set.gameWinner}-${set.gameLoser}`).join(", ")}
+                    </div>
+                  )}
+                </>
+              ) : (
+                <div className="text-xl font-bold text-primary-text/60">No score</div>
+              )}
+            </div>
+
+            <div
+              className="flex flex-col items-center gap-1 flex-1 min-w-0 cursor-pointer"
+              onClick={() => navigate(`/player/${game.loser}`)}
+            >
+              <ProfilePicture playerId={game.loser} size={64} border={3} />
+              <span className="font-bold text-sm md:text-base truncate max-w-full">
+                {context.playerName(game.loser)} 💔
+              </span>
+              {eloExchange && (
+                <span className="text-xs md:text-sm text-red-500 font-medium whitespace-nowrap">
+                  {fmtNum(eloExchange.loser.diff)} Elo → {fmtNum(eloExchange.loser.after)}
+                </span>
+              )}
+            </div>
+          </div>
+
+          {/* The pairing prediction before and after the game */}
+          <div className="max-w-md mx-auto mt-3 px-4">
+            <div className="rounded-lg bg-secondary-background text-secondary-text p-3">
+              <h2 className="text-sm font-semibold text-center mb-1">
+                Win % prediction: {context.playerName(game.winner)} beats {context.playerName(game.loser)}
+              </h2>
+              <div className="flex justify-center items-center gap-3 text-center">
+                <PredictionCell label="Before the game" prediction={preGamePrediction} />
+                <span className="text-xl">→</span>
+                <PredictionCell label="After the game" prediction={postGamePrediction} />
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap justify-center gap-2 py-3">
+            <button
+              onClick={() => navigate(`/1v1?player1=${game.winner}&player2=${game.loser}`)}
+              className="px-4 py-1.5 rounded-full text-xs md:text-sm ring-1 ring-secondary-background text-primary-text hover:bg-secondary-background hover:text-secondary-text transition-colors"
+            >
+              Head-to-head stats
+            </button>
+            <button
+              onClick={() => navigate(whatChangedLink)}
+              className="px-4 py-1.5 rounded-full text-xs md:text-sm ring-1 ring-secondary-background text-primary-text hover:bg-secondary-background hover:text-secondary-text transition-colors"
+            >
+              What this game changed →
+            </button>
+          </div>
+
+          {/* Win % over the game, replayed from the point-by-point log */}
+          <div className="px-2 xs:px-4 pb-4">
+            {winPercentHistory && game.score?.setPoints ? (
+              <div className="bg-white rounded-xl shadow-lg p-3 sm:p-4 text-black">
+                <WinPercentGraph
+                  history={winPercentHistory}
+                  winnerIsPlayer1={true}
+                  winnerName={context.playerName(game.winner)}
+                  winnerColor={stringToColor(game.winner)}
+                  completedSets={game.score.setPoints.map((set) => ({
+                    player1: set.gameWinner,
+                    player2: set.gameLoser,
+                  }))}
+                />
+                <p className="text-xs text-gray-500 -mt-4">
+                  Replayed from the recorded points with the live prediction model, using the prediction data as it
+                  stood before the game.
+                </p>
+              </div>
+            ) : (
+              <p className="text-center text-sm text-primary-text/60 py-2">
+                This game has no point-by-point log, so there is no win % graph. Only games tracked live record it.
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const PredictionCell: React.FC<{ label: string; prediction?: Fraction }> = ({ label, prediction }) => (
+  <div className="flex flex-col items-center">
+    <span className="text-xs opacity-70">{label}</span>
+    {prediction && prediction.confidence > 0 ? (
+      <>
+        <span className="text-2xl font-bold">{fmtNum(prediction.fraction * 100)}%</span>
+        <span className="text-xs opacity-70">{fmtNum(prediction.confidence * 100)}% confidence</span>
+      </>
+    ) : (
+      <span className="text-2xl font-bold opacity-60">–</span>
+    )}
+  </div>
+);

--- a/frontend/src/pages/game/game-details-page.tsx
+++ b/frontend/src/pages/game/game-details-page.tsx
@@ -7,8 +7,7 @@ import { fmtNum } from "../../common/number-utils";
 import { RelativeTime, toDatetimeLocalValue } from "../../common/date-utils";
 import { stringToColor } from "../../common/string-to-color";
 import { ProfilePicture } from "../player/profile-picture";
-import { Fraction, Predictions } from "../../client/client-db/predictions";
-import { TennisTable } from "../../client/client-db/tennis-table";
+import { Fraction } from "../../client/client-db/predictions";
 import { WinPercentGraph } from "../add-game/win-percent-graph";
 import { replayWinPercentHistory } from "./game-win-replay";
 
@@ -20,16 +19,6 @@ import { replayWinPercentHistory } from "./game-win-replay";
  * game changed beyond that (leaderboards, achievements) lives on the What
  * changed page, linked with the game's own 2-second window preselected.
  */
-// The overall pairing prediction (direct + indirect, combined by confidence)
-// in a projected state, from the winner's perspective.
-function pairingPrediction(state: TennisTable | undefined, winner: string, loser: string): Fraction | undefined {
-  if (!state) return undefined;
-  const direct = state.predictions.getDirectFraction(winner, loser);
-  const oneLayer = state.predictions.getOneLayerFraction(winner, loser);
-  const twoLayer = state.predictions.getTwoLayerFraction(winner, loser);
-  return Predictions.combinePrioritizedFractions([direct, oneLayer, twoLayer]);
-}
-
 export const GameDetailsPage: React.FC = () => {
   const context = useEventDbContext();
   const navigate = useNavigate();
@@ -40,10 +29,12 @@ export const GameDetailsPage: React.FC = () => {
     [context, playedAt],
   );
 
-  // The app state just before and just at the game. Both drive the pairing
-  // prediction; the pre-game one also seeds the win % replay.
+  // The app state just before and just after the game. Both drive the pairing
+  // prediction; the pre-game one also seeds the win % replay. The game's
+  // GAME_SCORE event is stored at playedAt + 1, so the post state projects
+  // there — at playedAt itself the game would count without its score.
   const preState = useStateAt(game ? game.playedAt - 1 : undefined);
-  const postState = useStateAt(game?.playedAt);
+  const postState = useStateAt(game ? game.playedAt + 1 : undefined);
 
   // Elo moved by this game, from the players' game log entries.
   const eloExchange = useMemo(() => {
@@ -58,26 +49,30 @@ export const GameDetailsPage: React.FC = () => {
     };
   }, [context, game]);
 
+  // The overall pairing prediction, from the winner's perspective, in the two
+  // projected states. Undefined when there is no data to predict from.
   const preGamePrediction = useMemo(
-    () => (game ? pairingPrediction(preState, game.winner, game.loser) : undefined),
+    () => (game ? preState?.predictions.getPredictedFraction(game.winner, game.loser) : undefined),
     [game, preState],
   );
   const postGamePrediction = useMemo(
-    () => (game ? pairingPrediction(postState, game.winner, game.loser) : undefined),
+    () => (game ? postState?.predictions.getPredictedFraction(game.winner, game.loser) : undefined),
     [game, postState],
   );
 
   // Win % after every point, replayed from the stored point sequences with the
-  // live model. Seeded by the game so the graph is stable across renders.
+  // live model. Seeded by the game so the graph is stable across renders. A
+  // pair without prediction data replays from an even coin flip, like the
+  // live trackers do.
   const winPercentHistory = useMemo(() => {
-    if (!game?.score?.pointSequences || !preGamePrediction) return undefined;
+    if (!game?.score?.pointSequences?.length || !preState) return undefined;
     return replayWinPercentHistory({
       pointSequences: game.score.pointSequences,
-      preGameWinChance: preGamePrediction.confidence > 0 ? preGamePrediction.fraction : 0.5,
-      preGameConfidence: preGamePrediction.confidence,
+      preGameWinChance: preGamePrediction?.fraction ?? 0.5,
+      preGameConfidence: preGamePrediction?.confidence ?? 0,
       seed: game.playedAt,
     });
-  }, [game, preGamePrediction]);
+  }, [game, preState, preGamePrediction]);
 
   if (!game) {
     return <div className="p-8 text-center text-primary-text/60">Game not found</div>;
@@ -178,7 +173,7 @@ export const GameDetailsPage: React.FC = () => {
 
           {/* Win % over the game, replayed from the point-by-point log */}
           <div className="px-2 xs:px-4 pb-4">
-            {winPercentHistory && game.score?.setPoints ? (
+            {winPercentHistory && winPercentHistory.length >= 2 && game.score?.setPoints ? (
               <div className="bg-white rounded-xl shadow-lg p-3 sm:p-4 text-black">
                 <WinPercentGraph
                   history={winPercentHistory}
@@ -191,8 +186,8 @@ export const GameDetailsPage: React.FC = () => {
                   }))}
                 />
                 <p className="text-xs text-gray-500 -mt-4">
-                  Replayed from the recorded points with the live prediction model, using the prediction data as it
-                  stood before the game.
+                  Replayed from the recorded points with the live prediction model, using the prediction data from
+                  before the game.
                 </p>
               </div>
             ) : (

--- a/frontend/src/pages/game/game-win-replay.test.ts
+++ b/frontend/src/pages/game/game-win-replay.test.ts
@@ -1,0 +1,52 @@
+import { replayWinPercentHistory, seededRandom } from "./game-win-replay";
+
+// 11-5 and 11-7 to the game winner, winner scoring the last point of each set.
+const SEQUENCES = ["WWLWWLWWLWWLWWLW", "WLWLWLWLWLWLWLWWWW"];
+
+describe("seededRandom", () => {
+  it("is deterministic for a seed and produces values in [0, 1)", () => {
+    const a = seededRandom(42);
+    const b = seededRandom(42);
+    for (let i = 0; i < 100; i++) {
+      const value = a();
+      expect(value).toBe(b());
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThan(1);
+    }
+  });
+
+  it("differs between seeds", () => {
+    expect(seededRandom(1)()).not.toBe(seededRandom(2)());
+  });
+});
+
+describe("replayWinPercentHistory", () => {
+  const input = {
+    pointSequences: SEQUENCES,
+    preGameWinChance: 0.6,
+    preGameConfidence: 0.5,
+    seed: 1234,
+    simulations: 200,
+  };
+
+  it("produces one sample per point, all within [0, 1]", () => {
+    const history = replayWinPercentHistory(input);
+    const totalPoints = SEQUENCES.reduce((sum, sequence) => sum + sequence.length, 0);
+    expect(history).toHaveLength(totalPoints);
+    history.forEach((sample) => {
+      expect(sample).toBeGreaterThanOrEqual(0);
+      expect(sample).toBeLessThanOrEqual(1);
+    });
+  });
+
+  it("ends certain of the winner once the deciding set is decided", () => {
+    const history = replayWinPercentHistory(input);
+    // The final point decides the winner's 2nd set (11-7, 2 clear), so the
+    // normalized score has the match won and every simulation is a win.
+    expect(history.at(-1)).toBe(1);
+  });
+
+  it("is deterministic for the same seed", () => {
+    expect(replayWinPercentHistory(input)).toEqual(replayWinPercentHistory(input));
+  });
+});

--- a/frontend/src/pages/game/game-win-replay.ts
+++ b/frontend/src/pages/game/game-win-replay.ts
@@ -31,7 +31,10 @@ export function replayWinPercentHistory(params: {
   seed: number;
   simulations?: number;
 }): number[] {
-  const { pointSequences, preGameWinChance, preGameConfidence, seed, simulations } = params;
+  const { pointSequences, preGameWinChance, preGameConfidence, seed } = params;
+  // The replay runs the model for every point of the game at once on the main
+  // thread, so trade some Monte-Carlo resolution for render time.
+  const simulations = params.simulations ?? 500;
   const random = seededRandom(seed);
 
   const history: number[] = [];
@@ -52,6 +55,8 @@ export function replayWinPercentHistory(params: {
           completedSets: [...completedSets],
           simulations,
           random,
+          // Only player1WinChance is kept, so skip the confidence-only pass.
+          skipConfidenceSimulation: true,
         }).player1WinChance,
       );
     }

--- a/frontend/src/pages/game/game-win-replay.ts
+++ b/frontend/src/pages/game/game-win-replay.ts
@@ -1,0 +1,64 @@
+import { computeLiveWinPrediction } from "../live-game/live-game-win-probability";
+
+/**
+ * Deterministic RNG (mulberry32). The replayed win % graph re-runs the live
+ * Monte-Carlo model per point; a seed fixed to the game keeps the graph the
+ * same every time the page renders.
+ */
+export function seededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Replays a game's stored point sequences through the live win-prediction
+ * model, as if the game were tracked live: one win-chance sample after every
+ * point, from the game winner's perspective. `preGameWinChance` and
+ * `preGameConfidence` are the pairing prediction as it stood before the game.
+ */
+export function replayWinPercentHistory(params: {
+  /** One string per set, "W"/"L" per point — the GAME_SCORE pointSequences. */
+  pointSequences: string[];
+  /** The game winner's pre-game chance to win the match, [0, 1]. */
+  preGameWinChance: number;
+  preGameConfidence: number;
+  seed: number;
+  simulations?: number;
+}): number[] {
+  const { pointSequences, preGameWinChance, preGameConfidence, seed, simulations } = params;
+  const random = seededRandom(seed);
+
+  const history: number[] = [];
+  const setsWon = { player1: 0, player2: 0 };
+  const completedSets: { player1: number; player2: number }[] = [];
+
+  for (const sequence of pointSequences) {
+    const currentSet = { player1: 0, player2: 0 };
+    for (const point of sequence) {
+      if (point === "W") currentSet.player1++;
+      else currentSet.player2++;
+      history.push(
+        computeLiveWinPrediction({
+          preGameWinChance,
+          preGameConfidence,
+          setsWon: { ...setsWon },
+          currentSet: { ...currentSet },
+          completedSets: [...completedSets],
+          simulations,
+          random,
+        }).player1WinChance,
+      );
+    }
+    completedSets.push(currentSet);
+    if (currentSet.player1 > currentSet.player2) setsWon.player1++;
+    else setsWon.player2++;
+  }
+
+  return history;
+}

--- a/frontend/src/pages/game/point-sequence-marker.tsx
+++ b/frontend/src/pages/game/point-sequence-marker.tsx
@@ -1,0 +1,15 @@
+import { GameScore } from "../../client/client-db/event-store/event-types";
+
+/**
+ * Small marker shown next to a game's score in game lists when the game has a
+ * point-by-point log — the game was tracked live, and its details page can
+ * replay the win % over the game.
+ */
+export const PointSequenceMarker: React.FC<{ score?: GameScore["data"] }> = ({ score }) => {
+  if (!score?.pointSequences?.length) return null;
+  return (
+    <span title="Tracked point by point" className="ml-1 text-[10px] md:text-xs align-middle">
+      📈
+    </span>
+  );
+};

--- a/frontend/src/pages/live-game/live-game-win-probability.ts
+++ b/frontend/src/pages/live-game/live-game-win-probability.ts
@@ -54,6 +54,12 @@ export type LiveWinPredictionInput = {
   simulations?: number;
   /** Injectable RNG for deterministic tests. Defaults to Math.random. */
   random?: () => number;
+  /**
+   * Skip the second full-match simulation pass that only refines `confidence`
+   * (it then stays at the per-point estimate's data confidence). Halves the
+   * cost for callers that ignore the confidence, like the game details replay.
+   */
+  skipConfidenceSimulation?: boolean;
 };
 
 const SETS_TO_WIN_MATCH = 2;
@@ -282,6 +288,10 @@ export function computeLiveWinPrediction(input: LiveWinPredictionInput): LiveWin
     random,
   );
   const player1WinChance = current.winRate;
+
+  if (input.skipConfidenceSimulation) {
+    return { player1WinChance, confidence: perPoint.confidence, perPointWinChance: perPoint.fraction };
+  }
 
   // Confidence rises from the per-point estimate's data confidence toward 100 %
   // as the match nears its end — measured by how few points remain to be played

--- a/frontend/src/pages/other/what-changed-page.tsx
+++ b/frontend/src/pages/other/what-changed-page.tsx
@@ -2,12 +2,13 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useEventDbContext } from "../../wrappers/event-db-context";
 import { TennisTable } from "../../client/client-db/tennis-table";
-import { EventType, EventTypeEnum } from "../../client/client-db/event-store/event-types";
 import { WorkerMessage } from "../../client/client-db/web-worker/web-worker";
 import { createModernWorker } from "../../hooks/use-elo-simulation-worker";
 import { classNames } from "../../common/class-names";
 import { fmtNum } from "../../common/number-utils";
-import { RelativeTime } from "../../common/date-utils";
+import { fromDatetimeLocalValue, RelativeTime, toDatetimeLocalValue } from "../../common/date-utils";
+import { eventsUpTo, useStateAt } from "../../hooks/use-state-at";
+import { PointSequenceMarker } from "../game/point-sequence-marker";
 import { Game } from "../../client/client-db/event-store/projectors/games-projector";
 import { Achievement } from "../../client/client-db/achievements";
 import { getAchievementLabel } from "../player/player-achievements";
@@ -42,25 +43,6 @@ const ROW_GRID =
   "grid grid-cols-[minmax(0,1fr)_2.25rem_2.25rem_2.5rem_3rem_3rem_3.25rem] md:grid-cols-[minmax(0,1fr)_3.5rem_3.5rem_3.5rem_4.5rem_4.5rem_4.5rem] items-center";
 const NUM_CELL = "self-stretch flex items-center justify-end py-1 px-1 md:px-2 whitespace-nowrap";
 
-// Convert a millisecond timestamp into the local "YYYY-MM-DDTHH:mm" string
-// expected by a <input type="datetime-local"> element.
-function toDatetimeLocalValue(ms: number): string {
-  const date = new Date(ms);
-  const pad = (n: number) => n.toString().padStart(2, "0");
-  return (
-    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
-    `T${pad(date.getHours())}:${pad(date.getMinutes())}`
-  );
-}
-
-// A datetime-local string parses as local time. Returns undefined while the
-// input is incomplete (the browser then reports an empty value).
-function fromDatetimeLocalValue(value: string): number | undefined {
-  if (!value) return undefined;
-  const ms = new Date(value).getTime();
-  return isNaN(ms) ? undefined : ms;
-}
-
 type DiffRow = {
   playerId: string;
   startRank?: number;
@@ -70,17 +52,6 @@ type DiffRow = {
 };
 
 type RankedEntry = { id: string; rank: number; score: number };
-
-// Same "state at a point in time" filter as tournament predictions:
-// games count by when they were played, everything else by event time.
-function eventsUpTo(events: EventType[], time: number): EventType[] {
-  return events.filter((event) => {
-    if (event.type === EventTypeEnum.GAME_CREATED) {
-      return event.data.playedAt <= time;
-    }
-    return event.time <= time;
-  });
-}
 
 function useDebounced<T>(value: T, ms: number): T {
   const [debounced, setDebounced] = useState(value);
@@ -103,15 +74,6 @@ function seasonEntriesAt(state: TennisTable | undefined, seasonStart: number): R
     rank: index + 1,
     score: player.seasonScore,
   }));
-}
-
-// The full app state projected at a point in time.
-function useStateAt(time: number | undefined): TennisTable | undefined {
-  const context = useEventDbContext();
-  return useMemo(() => {
-    if (time === undefined) return undefined;
-    return new TennisTable({ events: eventsUpTo(context.events, time), referenceTime: time });
-  }, [context, time]);
 }
 
 function useExpectedLeaderboardAt(time: number | undefined, enabled: boolean) {
@@ -546,6 +508,7 @@ export const WhatChangedPage: React.FC = () => {
                   Start
                   <input
                     type="datetime-local"
+                    step={1}
                     value={fromValue}
                     onChange={(e) => setParams({ from: e.target.value }, true)}
                     className="px-3 py-2 rounded-lg bg-primary-background text-primary-text text-sm normal-case tracking-normal ring-1 ring-secondary-background focus:ring-2 focus:ring-secondary-text focus:outline-none"
@@ -555,6 +518,7 @@ export const WhatChangedPage: React.FC = () => {
                   End
                   <input
                     type="datetime-local"
+                    step={1}
                     value={toValue}
                     onChange={(e) => setParams({ to: e.target.value }, true)}
                     className="px-3 py-2 rounded-lg bg-primary-background text-primary-text text-sm normal-case tracking-normal ring-1 ring-secondary-background focus:ring-2 focus:ring-secondary-text focus:outline-none"
@@ -774,7 +738,7 @@ export const WhatChangedPage: React.FC = () => {
                       return (
                         <tr
                           key={game.id}
-                          onClick={() => navigate(`/1v1?player1=${game.winner}&player2=${game.loser}`)}
+                          onClick={() => navigate(`/game?time=${game.playedAt}`)}
                           className="bg-primary-background hover:bg-secondary-background hover:text-secondary-text cursor-pointer transition-colors"
                         >
                           <td className="py-1 px-1 xs:px-2 md:px-3 w-[35%] max-w-0">
@@ -788,6 +752,7 @@ export const WhatChangedPage: React.FC = () => {
                               <div className="leading-tight -my-1">
                                 <div className="font-medium">
                                   {game.score.setsWon.gameWinner} - {game.score.setsWon.gameLoser}
+                                  <PointSequenceMarker score={game.score} />
                                 </div>
                                 {game.score.setPoints && (
                                   <div className="font-light italic text-[10px] md:text-xs whitespace-nowrap leading-none">

--- a/frontend/src/pages/other/what-changed-page.tsx
+++ b/frontend/src/pages/other/what-changed-page.tsx
@@ -347,9 +347,9 @@ export const WhatChangedPage: React.FC = () => {
   // windows do not drift while the page stays open.
   const [now, setNow] = useState(() => Date.now());
 
-  // Quick select of common periods, all ending now. The inputs have minute
+  // Quick select of common periods, all ending now. The inputs have second
   // resolution, so the last-game window starts 1 ms before the game: the
-  // truncated minute is then strictly before the game and the game itself
+  // truncated second is then strictly before the game and the game itself
   // falls inside the window. "custom" has no start - it reveals the two
   // datetime inputs and keeps their current values.
   const lastGame = context.games.at(-1);

--- a/frontend/src/pages/player/player-page.tsx
+++ b/frontend/src/pages/player/player-page.tsx
@@ -18,6 +18,7 @@ import { PlayerPairings } from "./player-pairings";
 import { ContentCard } from "./content-card";
 import { UnrankedExpectedScore } from "./unranked-expected-score";
 import { usePlayerLinkSearch } from "../../hooks/use-player-link-search";
+import { PointSequenceMarker } from "../game/point-sequence-marker";
 
 type TabType = "overview" | "games" | "statistics" | "achievements" | "predictions" | "season";
 const tabs: { id: TabType; label: string }[] = [
@@ -313,6 +314,7 @@ export const PlayerPage: React.FC = () => {
                             {game.result === "win"
                               ? `${game.score?.setsWon.gameWinner} - ${game.score?.setsWon.gameLoser}`
                               : `${game.score?.setsWon.gameLoser} - ${game.score?.setsWon.gameWinner}`}
+                            <PointSequenceMarker score={game.score} />
                           </div>
                         )}
                         {game.score?.setPoints && (

--- a/frontend/src/pages/pvp-stats.tsx
+++ b/frontend/src/pages/pvp-stats.tsx
@@ -4,6 +4,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { RelativeTime } from "../common/date-utils";
 import { fmtNum } from "../common/number-utils";
 import { useEffect, useState } from "react";
+import { PointSequenceMarker } from "./game/point-sequence-marker";
 
 type Props = {
   player1?: string;
@@ -71,7 +72,7 @@ export const PvPStats: React.FC<Props> = ({ player1, player2 }) => {
                 return (
                   <tr
                     key={`${p1.playerId}-${p2.playerId}-${index}`}
-                    onClick={() => navigate(`/player/${winner.playerId}`)}
+                    onClick={() => navigate(`/game?time=${game.time}`)}
                     className="bg-primary-background hover:bg-secondary-background hover:text-secondary-text cursor-pointer transition-colors text-xs xs:text-sm md:text-base"
                   >
                     {/* Three slots: player 1's trophy | winner name | player 2's trophy.
@@ -108,6 +109,7 @@ export const PvPStats: React.FC<Props> = ({ player1, player2 }) => {
                             {isPlayer1Win
                               ? `${game.score.setsWon.gameWinner} - ${game.score.setsWon.gameLoser}`
                               : `${game.score.setsWon.gameLoser} - ${game.score.setsWon.gameWinner}`}
+                            <PointSequenceMarker score={game.score} />
                           </span>
                         )}
                         {setStrings.length > 0 && (

--- a/frontend/src/pages/recent-games/recent-games-page.tsx
+++ b/frontend/src/pages/recent-games/recent-games-page.tsx
@@ -9,6 +9,7 @@ import { useLocalStorage } from "../../hooks/use-local-storage";
 import { useMediaQuery } from "../../hooks/use-media-query";
 import { session } from "../../services/auth";
 import { ProfilePicture } from "../player/profile-picture";
+import { PointSequenceMarker } from "../game/point-sequence-marker";
 
 type View = "overall" | "season";
 
@@ -94,6 +95,7 @@ export const RecentGamesPage: React.FC = () => {
       <div className="leading-tight -my-1">
         <div className="font-medium">
           {game.score.setsWon.gameWinner} - {game.score.setsWon.gameLoser}
+          <PointSequenceMarker score={game.score} />
         </div>
         {game.score.setPoints && (
           <div className="font-light italic text-[10px] md:text-xs whitespace-nowrap leading-none">
@@ -173,7 +175,7 @@ export const RecentGamesPage: React.FC = () => {
               </thead>
               <tbody className="divide-y divide-primary-text/50 text-xs xs:text-sm md:text-base">
                 {processedGames.map((game, index) => {
-                  const rowClick = () => navigate(`/1v1?player1=${game.winner}&player2=${game.loser}`);
+                  const rowClick = () => navigate(`/game?time=${game.playedAt}`);
 
                   if (view === "season") {
                     return (

--- a/frontend/src/pages/seasons/season-score-log.tsx
+++ b/frontend/src/pages/seasons/season-score-log.tsx
@@ -4,6 +4,7 @@ import { Season } from "../../client/client-db/seasons/season";
 import { ProfilePicture } from "../player/profile-picture";
 import { fmtNum } from "../../common/number-utils";
 import { dateString, RelativeTime } from "../../common/date-utils";
+import { PointSequenceMarker } from "../game/point-sequence-marker";
 import { useMemo } from "react";
 
 type Props = {
@@ -196,6 +197,7 @@ export const SeasonScoreLog = ({ season }: Props) => {
                       {imp.game.winner === imp.playerId
                         ? `${imp.game.score?.setsWon.gameWinner} - ${imp.game.score?.setsWon.gameLoser}`
                         : `${imp.game.score?.setsWon.gameLoser} - ${imp.game.score?.setsWon.gameWinner}`}
+                      <PointSequenceMarker score={imp.game.score} />
                     </span>
                   )}
                   {setStrings.length > 0 && (


### PR DESCRIPTION
## What

A new **game details page** at `/game?time=<playedAt>` — the game's unique played-at timestamp in the `time` url param selects the game. The page shows:

- **Who played and the score**: players with profile pictures, sets and per-set points, played time, and the Elo each player won or lost with their resulting Elo.
- **Win % prediction before and after the game**, each with its confidence — computed from the app state projected at `playedAt − 1` and `playedAt + 1` (the game's `GAME_SCORE` event is stored 1 ms after the game, so the post state includes the score evidence).
- **Win % graph** for games with a point-by-point log: the stored `pointSequences` replay through the live prediction model, driven by the prediction data from before the game, one sample per point with set-boundary lines — the same graph as the tracked-game summary. The Monte-Carlo replay is seeded by the game so it is stable across renders, and skips the confidence-only simulation pass (new `skipConfidenceSimulation` option) to keep render cost down.
- **Two link buttons**: head-to-head stats, and the What changed page with a custom period of 1 second before to 1 second after the game preselected — leaderboard changes and achievements live there instead of being duplicated on this page. The What changed custom range inputs now take second precision (`step={1}`, values include seconds) to support this.

## Entry points and marker

- Game rows in **recent games**, the **What changed games tab**, and the **1v1 match history** now open the game details page (1v1 remains reachable from the button on the page).
- A 📈 marker next to the score in game lists (recent games, What changed, 1v1 history, player page games tab, season score log) shows the game has a point-by-point log.

## Notes

- `eventsUpTo`/`useStateAt` moved from the What changed page into a shared `hooks/use-state-at.tsx`; the datetime-local helpers moved to `common/date-utils.tsx`. No behavior change there beyond second precision.
- New unit tests cover the replay function and the seeded RNG. Full suite green (74 suites, 787 passing), lint and `tsc --noEmit` clean, production build compiles.
- Changelog: a separate `new-feature` post for the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BSRAi9P9rTekYUEoBMSLmL

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSRAi9P9rTekYUEoBMSLmL)_