### PR TITLE
Add player game count analysis tool to admin stats

### DIFF
--- a/frontend/src/pages/admin/admin-page.tsx
+++ b/frontend/src/pages/admin/admin-page.tsx
@@ -27,6 +27,7 @@ import { Events } from "./events";
 import { classNames } from "../../common/class-names";
 import { PlayersTab } from "./players";
 import { PlayerDiversityChart } from "./player-diversity-chart";
+import { PlayerGameCount } from "./player-game-count";
 
 type TabType = "stats" | "games" | "players" | "users" | "events" | "local";
 const tabs: { id: TabType; label: string }[] = [
@@ -208,6 +209,7 @@ export const AdminPage: React.FC = () => {
           <TopGamingDays />
           <TopPlayers />
           <TopPlayerPairings />
+          <PlayerGameCount />
           <PlayerDiversityChart />
           <h2>Total distribution of games played</h2>
           <AllPlayerGamesDistrubution />

--- a/frontend/src/pages/admin/player-game-count.tsx
+++ b/frontend/src/pages/admin/player-game-count.tsx
@@ -1,0 +1,143 @@
+import React, { useMemo, useState } from "react";
+import { useEventDbContext } from "../../wrappers/event-db-context";
+import { fmtNum } from "../../common/number-utils";
+
+export const PlayerGameCount: React.FC = () => {
+  const context = useEventDbContext();
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [filter, setFilter] = useState("");
+
+  const players = useMemo(
+    () =>
+      [...context.allPlayers].sort((a, b) => {
+        if (a.active !== b.active) {
+          return a.active ? -1 : 1;
+        }
+        return a.name.localeCompare(b.name);
+      }),
+    [context],
+  );
+
+  const visiblePlayers = useMemo(() => {
+    const query = filter.trim().toLowerCase();
+    if (!query) {
+      return players;
+    }
+    return players.filter((player) => player.name.toLowerCase().includes(query));
+  }, [players, filter]);
+
+  const totalGames = context.games.length;
+
+  const { anyCount, bothCount } = useMemo(() => {
+    if (selectedIds.size === 0) {
+      return { anyCount: 0, bothCount: 0 };
+    }
+    let anyCount = 0;
+    let bothCount = 0;
+    context.games.forEach(({ winner, loser }) => {
+      const winnerSelected = selectedIds.has(winner);
+      const loserSelected = selectedIds.has(loser);
+      if (winnerSelected || loserSelected) {
+        anyCount++;
+      }
+      if (winnerSelected && loserSelected) {
+        bothCount++;
+      }
+    });
+    return { anyCount, bothCount };
+  }, [context.games, selectedIds]);
+
+  const togglePlayer = (playerId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(playerId)) {
+        next.delete(playerId);
+      } else {
+        next.add(playerId);
+      }
+      return next;
+    });
+  };
+
+  const anyPercent = totalGames > 0 ? ((anyCount / totalGames) * 100).toFixed(1) : "0.0";
+
+  return (
+    <div className="bg-primary-background text-primary-text rounded-lg p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
+        <h2 className="text-lg font-semibold">Player Game Count</h2>
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            type="text"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Filter players..."
+            aria-label="Filter players"
+            className="px-2 py-1 text-xs border rounded border-primary-text/20 bg-primary-background"
+          />
+          <button
+            type="button"
+            onClick={() => setSelectedIds(new Set(players.map((player) => player.id)))}
+            className="px-3 py-1 text-xs rounded border border-primary-text/20 bg-primary-background hover:bg-secondary-background/50 transition-colors"
+          >
+            Select all
+          </button>
+          <button
+            type="button"
+            onClick={() => setSelectedIds(new Set())}
+            disabled={selectedIds.size === 0}
+            className="px-3 py-1 text-xs rounded border border-primary-text/20 bg-primary-background hover:bg-secondary-background/50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Clear
+          </button>
+        </div>
+      </div>
+      <p className="text-xs text-primary-text/70 mb-2">
+        Select players to count the games where at least one of them played.
+      </p>
+      <div className="flex flex-wrap gap-1 mb-4 max-h-48 overflow-y-auto">
+        {visiblePlayers.length === 0 ? (
+          <span className="text-xs text-primary-text/70 p-1">No players match the filter</span>
+        ) : (
+          visiblePlayers.map((player) => {
+            const isSelected = selectedIds.has(player.id);
+            return (
+              <button
+                key={player.id}
+                type="button"
+                aria-pressed={isSelected}
+                onClick={() => togglePlayer(player.id)}
+                className={`px-3 py-1 text-xs rounded border border-primary-text/20 transition-colors whitespace-nowrap ${
+                  isSelected
+                    ? "bg-secondary-background text-secondary-text font-semibold"
+                    : "bg-primary-background hover:bg-secondary-background/50"
+                }`}
+              >
+                {player.name}
+                {!player.active && <span className="opacity-50"> 🪦</span>}
+              </button>
+            );
+          })
+        )}
+      </div>
+      {selectedIds.size === 0 ? (
+        <div className="text-center text-primary-text p-4 bg-secondary-background rounded-lg text-xs">
+          No players selected
+        </div>
+      ) : (
+        <div className="flex flex-wrap gap-4">
+          <div className="bg-secondary-background text-secondary-text rounded-lg p-4 flex-1 min-w-48">
+            <div className="text-3xl font-bold">{fmtNum(anyCount)}</div>
+            <div className="text-xs mt-1">
+              Games with at least 1 of the {fmtNum(selectedIds.size)} selected players ({anyPercent}% of{" "}
+              {fmtNum(totalGames)} games)
+            </div>
+          </div>
+          <div className="bg-secondary-background text-secondary-text rounded-lg p-4 flex-1 min-w-48">
+            <div className="text-3xl font-bold">{fmtNum(bothCount)}</div>
+            <div className="text-xs mt-1">Games where both players are among the selected</div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
Adds a new "Player Game Count" component to the admin stats page that allows filtering and analyzing games involving selected players.

## Changes
- **New component:** `PlayerGameCount` in `frontend/src/pages/admin/player-game-count.tsx`
  - Displays all players sorted by active status and name
  - Includes a search filter to find players by name
  - Shows game counts for selected players:
    - Games where at least one selected player participated
    - Games where both players are among the selected
  - Displays percentages relative to total games in the database
  - Provides "Select all" and "Clear" buttons for bulk operations
  - Marks inactive players with a 🪦 indicator

- **Integration:** Added `PlayerGameCount` component to the admin stats tab in `AdminPage`

## Implementation Details
- Uses `useMemo` to optimize player sorting, filtering, and game count calculations
- Maintains selection state with a `Set<string>` for efficient lookups
- Calculates both "any" (at least one player) and "both" (both players selected) game counts in a single pass through games
- Responsive layout with flex wrapping and scrollable player list
- Accessible with proper ARIA labels and button semantics
- Styled consistently with existing admin UI theme

https://claude.ai/code/session_01TRxb9DXAfvvcPRTYNpKuJs