### PR TITLE
Improve game details page formatting and point log indicator

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -56,7 +56,7 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
         "The page shows the win % prediction between the 2 players before and after the game, each with its confidence.",
       ),
       text(
-        "A game with a point-by-point log gets a win % graph. The app replays the recorded points through the live prediction model, with the prediction data from before the game. A 📈 mark next to a score in the game lists shows that the game has the log.",
+        "A game with a point-by-point log gets a win % graph. The app replays the recorded points through the live prediction model, with the prediction data from before the game. A 👀 mark next to a score in the game lists shows that the game has the log.",
       ),
       text(
         "2 buttons open related pages: the head-to-head page for the 2 players, and the What changed page with the period of this game preselected.",

--- a/frontend/src/common/date-utils.tsx
+++ b/frontend/src/common/date-utils.tsx
@@ -85,6 +85,23 @@ export function dateString(time: number) {
   });
 }
 
+// Full date and time with the weekday, e.g. "Mandag 1. April 2026 08:37".
+// Norwegian locale writes weekdays and months in lowercase; capitalize them
+// so the line reads as a heading.
+export function fullDateTimeString(time: number): string {
+  const date = new Date(time);
+  const datePart = date
+    .toLocaleDateString("nb-NO", {
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    })
+    .replace(/\p{L}+/gu, (word) => word[0].toUpperCase() + word.slice(1));
+  const timePart = date.toLocaleTimeString("nb-NO", { hour: "2-digit", minute: "2-digit" });
+  return `${datePart} ${timePart}`;
+}
+
 // Month-granularity variant of dateString, for periods that span a whole
 // calendar month (e.g. "januar 2026").
 export function monthString(time: number) {

--- a/frontend/src/pages/game/game-details-page.tsx
+++ b/frontend/src/pages/game/game-details-page.tsx
@@ -4,7 +4,7 @@ import { useEventDbContext } from "../../wrappers/event-db-context";
 import { useTennisParams } from "../../hooks/use-tennis-params";
 import { useStateAt } from "../../hooks/use-state-at";
 import { fmtNum } from "../../common/number-utils";
-import { RelativeTime, toDatetimeLocalValue } from "../../common/date-utils";
+import { RelativeTime, fullDateTimeString, toDatetimeLocalValue } from "../../common/date-utils";
 import { stringToColor } from "../../common/string-to-color";
 import { ProfilePicture } from "../player/profile-picture";
 import { Fraction } from "../../client/client-db/predictions";
@@ -89,7 +89,7 @@ export const GameDetailsPage: React.FC = () => {
         <div className="bg-primary-background rounded-lg w-full overflow-hidden">
           <h1 className="text-2xl md:text-4xl text-center mt-2 md:mt-4 text-primary-text">Game details</h1>
           <p className="text-center text-sm md:text-base text-primary-text/60 mb-2 md:mb-3">
-            {new Date(game.playedAt).toLocaleString()} · <RelativeTime date={new Date(game.playedAt)} variant="auto" />
+            {fullDateTimeString(game.playedAt)} - <RelativeTime date={new Date(game.playedAt)} variant="auto" />
           </p>
 
           {/* Who played, the score, and the Elo the game moved */}
@@ -185,10 +185,6 @@ export const GameDetailsPage: React.FC = () => {
                     player2: set.gameLoser,
                   }))}
                 />
-                <p className="text-xs text-gray-500 -mt-4">
-                  Replayed from the recorded points with the live prediction model, using the prediction data from
-                  before the game.
-                </p>
               </div>
             ) : (
               <p className="text-center text-sm text-primary-text/60 py-2">

--- a/frontend/src/pages/game/point-sequence-marker.tsx
+++ b/frontend/src/pages/game/point-sequence-marker.tsx
@@ -9,7 +9,7 @@ export const PointSequenceMarker: React.FC<{ score?: GameScore["data"] }> = ({ s
   if (!score?.pointSequences?.length) return null;
   return (
     <span title="Tracked point by point" className="ml-1 text-[10px] md:text-xs align-middle">
-      📈
+      👀
     </span>
   );
 };


### PR DESCRIPTION
## Summary
Refactors the game details page to use a new utility function for consistent date-time formatting, updates the point sequence indicator emoji, and removes redundant explanatory text.

## Changes
- **New utility function:** Added `fullDateTimeString()` to `date-utils.tsx` that formats dates with weekday, date, and time in Norwegian locale with proper capitalization (e.g., "Mandag 1. April 2026 08:37")
- **Game details page:** Replaced `toLocaleString()` with the new `fullDateTimeString()` function for consistent formatting and changed the separator from `·` to `-`
- **Point sequence indicator:** Changed emoji from 📈 (chart) to 👀 (eyes) to better represent "tracked/watched" games
- **Removed explanatory text:** Deleted the small gray text below the win % graph that explained the replay functionality, as this is now documented in the changelog
- **Changelog update:** Updated the changelog post to reference the new 👀 emoji instead of 📈

## Implementation Details
The new `fullDateTimeString()` function uses Unicode regex (`\p{L}+/gu`) to capitalize the first letter of each word in the date string, accounting for Norwegian locale's lowercase weekday and month names. This ensures the date-time string reads as a proper heading.

https://claude.ai/code/session_01E7jpvUtuKqbL4DHz8VKHPU