### PR TITLE
Record point times and serves on tracked games

### DIFF
--- a/DenoServer/db/database.ts
+++ b/DenoServer/db/database.ts
@@ -21,11 +21,21 @@ export type LiveGameState = {
    * "1" = point to player 1, "2" = point to player 2.
    */
   currentSetSequence: string;
+  /** Epoch ms of each point of the current set, parallel to currentSetSequence. */
+  currentSetPointTimes: number[];
   /** Point sequence of each completed set, same encoding as currentSetSequence. */
   completedSetSequences: string[];
+  /** Point times of each completed set, same encoding as currentSetPointTimes. */
+  completedSetPointTimes: number[][];
+  /** Which player (1 or 2) served the first point of each completed set. */
+  completedSetFirstServers: (1 | 2)[];
   /** Which player (1 or 2) served the first point of the current set. */
   firstServer: 1 | 2;
+  /** How many points were undone while tracking this match. */
+  corrections: number;
   startedAt: number | null;
+  /** Epoch ms the match was ended for review. Null while it is still played. */
+  endedAt: number | null;
   finishedAt: number | null;
   updatedAt: number;
 };

--- a/DenoServer/event-store/event-types.ts
+++ b/DenoServer/event-store/event-types.ts
@@ -38,6 +38,31 @@ export type PlayerNameUpdated = GenericEvent<EventTypeEnum.PLAYER_NAME_UPDATED, 
 
 export type GameCreated = GenericEvent<EventTypeEnum.GAME_CREATED, { playedAt: number; winner: string; loser: string }>;
 export type GameDeleted = GenericEvent<EventTypeEnum.GAME_DELETED, null>;
+/**
+ * What the live trackers recorded while the points were logged: when each point
+ * was scored, who served, and how much the log was corrected. Always stored
+ * together with `pointSequences`.
+ */
+export type GameTracking = {
+  /** Schema version of this object, so the format can change later. */
+  version: 1;
+  /** Which tracker logged the points. */
+  source: "track-game" | "live-game";
+  /** Epoch ms when tracking started. The only absolute time in the object. */
+  startedAt: number;
+  /**
+   * One array per set, parallel to `pointSequences`. Each number is the tenths
+   * of a second since the previous point of the game, across set boundaries.
+   */
+  pointDeltas: number[][];
+  /** Tenths of a second from the last point to the end of the match. */
+  endedAfter: number;
+  /** Who served the first point of each set: "W" = game winner, "L" = game loser. */
+  firstServers: string;
+  /** How many points were undone while tracking. */
+  corrections: number;
+};
+
 export type GameScore = GenericEvent<
   EventTypeEnum.GAME_SCORE,
   {
@@ -50,6 +75,8 @@ export type GameScore = GenericEvent<
      * marked won — the last char is not necessarily the set winner's point.
      */
     pointSequences?: string[];
+    /** Timing and serve data of the same points. Requires pointSequences. */
+    tracking?: GameTracking;
   }
 >;
 

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -65,14 +65,14 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
   },
   {
     slug: "on-the-record-achievement",
-    title: "New achievement: On the Record 👀",
+    title: "New achievement: On the Record 🔴",
     date: "2026-08-16",
     tags: ["feature-update"],
     summary:
-      "On the Record 👀 is a new achievement. Play 5 games that are tracked point by point.",
+      "On the Record 🔴 is a new achievement. Play 5 games that are tracked point by point.",
     body: [
       text(
-        "A game is tracked when a person records each point on the track game page or the broadcasted live game. The game lists show a 👀 mark next to the score of a tracked game.",
+        "A game is tracked when a person records each point on the track game page or the broadcasted live game. The game lists show a 🔴 mark next to the score of a tracked game.",
       ),
       text(
         "Both players of a tracked game get the credit, and the result of the game does not matter. The count is for your career, and you earn the achievement 1 time.",
@@ -98,7 +98,7 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
         "The page shows the win % prediction between the 2 players before and after the game, each with its confidence.",
       ),
       text(
-        "A game with a point-by-point log gets a win % graph. The app replays the recorded points through the live prediction model, with the prediction data from before the game. A 👀 mark next to a score in the game lists shows that the game has the log.",
+        "A game with a point-by-point log gets a win % graph. The app replays the recorded points through the live prediction model, with the prediction data from before the game. A 🔴 mark next to a score in the game lists shows that the game has the log.",
       ),
       text(
         "2 buttons open related pages: the head-to-head page for the 2 players, and the What changed page with the period of this game preselected.",

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -42,6 +42,28 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "point-times-and-serves-on-tracked-games",
+    title: "Tracked games record point times and serves",
+    date: "2026-08-16",
+    tags: ["feature-update", "technical"],
+    summary:
+      "A game tracked live now records when each point was scored and who served each set. The game details page shows the duration and the serve statistics.",
+    body: [
+      text(
+        "The `GAME_SCORE` event stores the start of the match as a full timestamp. Each point after it is the time since the previous point, in tenths of a second. The event also stores who served the first point of each set, which tracker recorded the game, and how many points the person undid.",
+      ),
+      text(
+        "The game details page shows the duration of the game, the duration of each set, the average time between 2 points, and the longest pause. It also shows the percent of points that each player won on their own serve.",
+      ),
+      text(
+        "The time between 2 points includes everything that happens between the rallies. A player can collect the ball or speak. Read the value as the pace of the game, not as the length of a rally.",
+      ),
+      text(
+        "Only games tracked live record the data. An edited score removes it, together with the point log.",
+      ),
+    ],
+  },
+  {
     slug: "on-the-record-achievement",
     title: "New achievement: On the Record 👀",
     date: "2026-08-16",
@@ -126,8 +148,7 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
     title: "Tracked games record every point",
     date: "2026-08-13",
     tags: ["technical"],
-    summary:
-      "A game tracked live now saves the order of every point, not only the set scores. The app does not show the data yet.",
+    summary: "A game tracked live saves the order of every point, not only the set scores.",
     body: [
       text(
         "The track game page and the broadcasted live game record each point. When you save the game, the `GAME_SCORE` event stores one string per set. Each character is one point, in scoring order. `W` is a point to the game winner. `L` is a point to the game loser.",

--- a/frontend/src/client/client-db/__tests__/event-store/games-projector.test.ts
+++ b/frontend/src/client/client-db/__tests__/event-store/games-projector.test.ts
@@ -1,6 +1,23 @@
 import { expectInvalid } from "../../event-store/projectors/validator-test-utils";
 import { GamesProjector } from "../../event-store/projectors/games-projector";
-import { EventTypeEnum, GameCreated, GameDeleted, GameScore } from "../../event-store/event-types";
+import { EventTypeEnum, GameCreated, GameDeleted, GameScore, GameTracking } from "../../event-store/event-types";
+
+/**
+ * Valid tracking data for a point log. A point log is never stored without it,
+ * so the sequence tests below supply it and stay about the sequences.
+ */
+function tracking(pointSequences: string[], overrides: Partial<GameTracking> = {}): GameTracking {
+  return {
+    version: 1,
+    source: "track-game",
+    startedAt: 1_700_000_000_000,
+    pointDeltas: pointSequences.map((sequence) => sequence.split("").map(() => 50)),
+    endedAfter: 30,
+    firstServers: pointSequences.map(() => "W").join(""),
+    corrections: 0,
+    ...overrides,
+  };
+}
 
 function createEvent(stream: string, playedAt: number, winner: string, loser: string): GameCreated {
   return { time: playedAt, stream, type: EventTypeEnum.GAME_CREATED, data: { playedAt, winner, loser } };
@@ -233,6 +250,7 @@ describe("validateScoreGame", () => {
           { gameWinner: 2, gameLoser: 0 },
         ],
         pointSequences: ["WLWW", "LWL", "WW"],
+        tracking: tracking(["WLWW", "LWL", "WW"]),
       }),
     );
     expect(result).toEqual({ valid: true });
@@ -243,6 +261,7 @@ describe("validateScoreGame", () => {
       scoreEvent("game-1", {
         setsWon: { gameWinner: 2, gameLoser: 0 },
         pointSequences: ["WW", "WW"],
+        tracking: tracking(["WW", "WW"]),
       }),
     );
     expectInvalid(result);
@@ -258,6 +277,7 @@ describe("validateScoreGame", () => {
           { gameWinner: 2, gameLoser: 1 },
         ],
         pointSequences: ["WW"],
+        tracking: tracking(["WW"]),
       }),
     );
     expectInvalid(result);
@@ -270,6 +290,7 @@ describe("validateScoreGame", () => {
         setsWon: { gameWinner: 1, gameLoser: 0 },
         setPoints: [{ gameWinner: 2, gameLoser: 0 }],
         pointSequences: ["W1"],
+        tracking: tracking(["W1"]),
       }),
     );
     expectInvalid(result);
@@ -285,10 +306,111 @@ describe("validateScoreGame", () => {
           { gameWinner: 2, gameLoser: 1 },
         ],
         pointSequences: ["WW", "WLL"],
+        tracking: tracking(["WW", "WLL"]),
       }),
     );
     expectInvalid(result);
     expect(result.message).toBe("Point sequences are invalid. Sequence for set 2 does not match the set points");
+  });
+
+  it("rejects point sequences without tracking data", () => {
+    const result = projector.validateScoreGame(
+      scoreEvent("game-1", {
+        setsWon: { gameWinner: 1, gameLoser: 0 },
+        setPoints: [{ gameWinner: 2, gameLoser: 0 }],
+        pointSequences: ["WW"],
+      }),
+    );
+    expectInvalid(result);
+    expect(result.message).toBe("Point sequences require tracking data");
+  });
+
+  it("rejects tracking data without point sequences", () => {
+    const result = projector.validateScoreGame(
+      scoreEvent("game-1", {
+        setsWon: { gameWinner: 1, gameLoser: 0 },
+        setPoints: [{ gameWinner: 2, gameLoser: 0 }],
+        tracking: tracking(["WW"]),
+      }),
+    );
+    expectInvalid(result);
+    expect(result.message).toBe("Tracking data requires point sequences");
+  });
+
+  /** A one-set game whose tracking data can be broken one field at a time. */
+  function trackedScoreEvent(overrides: Partial<GameTracking>) {
+    return scoreEvent("game-1", {
+      setsWon: { gameWinner: 1, gameLoser: 0 },
+      setPoints: [{ gameWinner: 2, gameLoser: 0 }],
+      pointSequences: ["WW"],
+      tracking: tracking(["WW"], overrides),
+    });
+  }
+
+  it("accepts tracking data that matches the point sequences", () => {
+    expect(projector.validateScoreGame(trackedScoreEvent({}))).toEqual({ valid: true });
+  });
+
+  it("rejects an unknown tracking version", () => {
+    const result = projector.validateScoreGame(trackedScoreEvent({ version: 2 as 1 }));
+    expectInvalid(result);
+    expect(result.message).toBe("Tracking data is invalid. Unknown version 2");
+  });
+
+  it("rejects an unknown tracking source", () => {
+    const result = projector.validateScoreGame(
+      trackedScoreEvent({ source: "guesswork" as GameTracking["source"] }),
+    );
+    expectInvalid(result);
+    expect(result.message).toBe("Tracking data is invalid. Unknown source");
+  });
+
+  it("rejects a missing start time", () => {
+    const result = projector.validateScoreGame(trackedScoreEvent({ startedAt: 0 }));
+    expectInvalid(result);
+    expect(result.message).toBe("Tracking data is invalid. Started at must be an epoch timestamp");
+  });
+
+  it("rejects point deltas that do not cover every set", () => {
+    const result = projector.validateScoreGame(trackedScoreEvent({ pointDeltas: [] }));
+    expectInvalid(result);
+    expect(result.message).toBe("Tracking data is invalid. There must be one point delta list per set");
+  });
+
+  it("rejects a set whose point deltas do not cover every point", () => {
+    const result = projector.validateScoreGame(trackedScoreEvent({ pointDeltas: [[50]] }));
+    expectInvalid(result);
+    expect(result.message).toBe("Tracking data is invalid. Set 1 has 1 point deltas for 2 points");
+  });
+
+  it("rejects a negative point delta", () => {
+    const result = projector.validateScoreGame(trackedScoreEvent({ pointDeltas: [[50, -1]] }));
+    expectInvalid(result);
+    expect(result.message).toBe(
+      "Tracking data is invalid. Set 1 has a point delta that is not a positive whole number",
+    );
+  });
+
+  it("rejects a first server list that does not cover every set", () => {
+    const result = projector.validateScoreGame(trackedScoreEvent({ firstServers: "" }));
+    expectInvalid(result);
+    expect(result.message).toBe("Tracking data is invalid. There must be one first server per set");
+  });
+
+  it("rejects a first server that is not W or L", () => {
+    const result = projector.validateScoreGame(trackedScoreEvent({ firstServers: "1" }));
+    expectInvalid(result);
+    expect(result.message).toBe("Tracking data is invalid. Only 'W' and 'L' first servers are allowed");
+  });
+
+  it("rejects a negative end delta and a negative correction count", () => {
+    const endedAfter = projector.validateScoreGame(trackedScoreEvent({ endedAfter: -1 }));
+    expectInvalid(endedAfter);
+    expect(endedAfter.message).toBe("Tracking data is invalid. Ended after must be a positive whole number");
+
+    const corrections = projector.validateScoreGame(trackedScoreEvent({ corrections: -1 }));
+    expectInvalid(corrections);
+    expect(corrections.message).toBe("Tracking data is invalid. Corrections must be a positive whole number");
   });
 
   it("currently accepts a score for a game that does not exist (documented gap)", () => {

--- a/frontend/src/client/client-db/event-store/event-types.ts
+++ b/frontend/src/client/client-db/event-store/event-types.ts
@@ -36,6 +36,41 @@ export type PlayerNameUpdated = GenericEvent<EventTypeEnum.PLAYER_NAME_UPDATED, 
 
 export type GameCreated = GenericEvent<EventTypeEnum.GAME_CREATED, { playedAt: number; winner: string; loser: string }>;
 export type GameDeleted = GenericEvent<EventTypeEnum.GAME_DELETED, null>;
+/**
+ * What the live trackers recorded while the points were logged: when each point
+ * was scored, who served, and how much the log was corrected. Always stored
+ * together with `pointSequences` — validation rejects one without the other.
+ */
+export type GameTracking = {
+  /** Schema version of this object, so the format can change later. */
+  version: 1;
+  /** Which tracker logged the points. */
+  source: "track-game" | "live-game";
+  /** Epoch ms when tracking started. The only absolute time in the object. */
+  startedAt: number;
+  /**
+   * One array per set, parallel to `pointSequences`. Each number is the tenths
+   * of a second since the previous point of the game, across set boundaries —
+   * so the first number of a set is the break after the previous set, and the
+   * first number of the game is the delay before the first point. A point was
+   * scored at `startedAt + 100 * (sum of every delta up to and including it)`.
+   */
+  pointDeltas: number[][];
+  /** Tenths of a second from the last point to the end of the match. */
+  endedAfter: number;
+  /**
+   * Who served the first point of each set, one char per set: "W" = the game
+   * winner, "L" = the game loser. The server of every later point follows from
+   * the set score, see `getServeInfo`.
+   */
+  firstServers: string;
+  /**
+   * How many points were undone while tracking. A high count means the log was
+   * corrected by hand, so its times are less trustworthy.
+   */
+  corrections: number;
+};
+
 export type GameScore = GenericEvent<
   EventTypeEnum.GAME_SCORE,
   {
@@ -50,6 +85,8 @@ export type GameScore = GenericEvent<
      * set's points.
      */
     pointSequences?: string[];
+    /** Timing and serve data of the same points. Requires pointSequences. */
+    tracking?: GameTracking;
   }
 >;
 

--- a/frontend/src/client/client-db/event-store/projectors/games-projector.ts
+++ b/frontend/src/client/client-db/event-store/projectors/games-projector.ts
@@ -1,5 +1,50 @@
-import { GameCreated, GameDeleted, GameScore } from "../event-types";
+import { GameCreated, GameDeleted, GameScore, GameTracking } from "../event-types";
 import { ValidatorResponse } from "./validator-types";
+
+const isCount = (value: number) => Number.isInteger(value) && value >= 0;
+
+/**
+ * Checks the timing and serve data against the point log it describes. Returns
+ * the error message, or undefined when the tracking data is valid.
+ */
+function validateTracking(tracking: GameTracking, pointSequences: string[]): string | undefined {
+  if (tracking.version !== 1) {
+    return `Tracking data is invalid. Unknown version ${tracking.version}`;
+  }
+  if (tracking.source !== "track-game" && tracking.source !== "live-game") {
+    return "Tracking data is invalid. Unknown source";
+  }
+  if (isCount(tracking.startedAt) === false || tracking.startedAt === 0) {
+    return "Tracking data is invalid. Started at must be an epoch timestamp";
+  }
+  if (tracking.pointDeltas.length !== pointSequences.length) {
+    return "Tracking data is invalid. There must be one point delta list per set";
+  }
+  for (let setIndex = 0; setIndex < tracking.pointDeltas.length; setIndex++) {
+    const deltas = tracking.pointDeltas[setIndex];
+    if (deltas.length !== pointSequences[setIndex].length) {
+      return `Tracking data is invalid. Set ${setIndex + 1} has ${deltas.length} point deltas for ${
+        pointSequences[setIndex].length
+      } points`;
+    }
+    if (deltas.some((delta) => isCount(delta) === false)) {
+      return `Tracking data is invalid. Set ${setIndex + 1} has a point delta that is not a positive whole number`;
+    }
+  }
+  if (tracking.firstServers.length !== pointSequences.length) {
+    return "Tracking data is invalid. There must be one first server per set";
+  }
+  if (/^[WL]*$/.test(tracking.firstServers) === false) {
+    return "Tracking data is invalid. Only 'W' and 'L' first servers are allowed";
+  }
+  if (isCount(tracking.endedAfter) === false) {
+    return "Tracking data is invalid. Ended after must be a positive whole number";
+  }
+  if (isCount(tracking.corrections) === false) {
+    return "Tracking data is invalid. Corrections must be a positive whole number";
+  }
+  return undefined;
+}
 
 export type Game = { id: string; playedAt: number; winner: string; loser: string; score?: GameScore["data"] };
 
@@ -94,6 +139,13 @@ export class GamesProjector {
       }
     }
 
+    if (event.data.pointSequences && !event.data.tracking) {
+      return { valid: false, message: "Point sequences require tracking data" };
+    }
+    if (event.data.tracking && !event.data.pointSequences) {
+      return { valid: false, message: "Tracking data requires point sequences" };
+    }
+
     if (event.data.pointSequences) {
       if (!event.data.setPoints) {
         return { valid: false, message: "Point sequences require set points" };
@@ -115,6 +167,13 @@ export class GamesProjector {
             message: `Point sequences are invalid. Sequence for set ${setIndex + 1} does not match the set points`,
           };
         }
+      }
+    }
+
+    if (event.data.tracking && event.data.pointSequences) {
+      const trackingError = validateTracking(event.data.tracking, event.data.pointSequences);
+      if (trackingError) {
+        return { valid: false, message: trackingError };
       }
     }
 

--- a/frontend/src/common/point-sequences.test.ts
+++ b/frontend/src/common/point-sequences.test.ts
@@ -1,55 +1,126 @@
-import { appendPointToSequence, removeLastPointFromSequence, toEventPointSequences } from "./point-sequences";
+import { appendPoint, removeLastPoint, toEventTrackingData, TrackedSet } from "./point-sequences";
 
-describe("appendPointToSequence", () => {
-  it("appends the player's digit to the sequence", () => {
-    expect(appendPointToSequence("", 1)).toBe("1");
-    expect(appendPointToSequence("112", 2)).toBe("1122");
+describe("appendPoint", () => {
+  it("appends the player's digit and the time of the point", () => {
+    expect(appendPoint({ sequence: "", pointTimes: [] }, 1, 500)).toEqual({ sequence: "1", pointTimes: [500] });
+    expect(appendPoint({ sequence: "112", pointTimes: [1, 2, 3] }, 2, 4)).toEqual({
+      sequence: "1122",
+      pointTimes: [1, 2, 3, 4],
+    });
   });
 });
 
-describe("removeLastPointFromSequence", () => {
-  it("removes the player's last point and keeps later points", () => {
-    expect(removeLastPointFromSequence("1121", 2)).toBe("111");
-    expect(removeLastPointFromSequence("1121", 1)).toBe("112");
+describe("removeLastPoint", () => {
+  it("removes the player's last point and keeps later points with their times", () => {
+    const set: TrackedSet = { sequence: "1121", pointTimes: [10, 20, 30, 40] };
+    expect(removeLastPoint(set, 2)).toEqual({ sequence: "111", pointTimes: [10, 20, 40] });
+    expect(removeLastPoint(set, 1)).toEqual({ sequence: "112", pointTimes: [10, 20, 30] });
   });
 
-  it("returns the sequence unchanged when the player has no points", () => {
-    expect(removeLastPointFromSequence("111", 2)).toBe("111");
-    expect(removeLastPointFromSequence("", 1)).toBe("");
+  it("returns the set unchanged when the player has no points", () => {
+    const set: TrackedSet = { sequence: "111", pointTimes: [1, 2, 3] };
+    expect(removeLastPoint(set, 2)).toBe(set);
+    expect(removeLastPoint({ sequence: "", pointTimes: [] }, 1)).toEqual({ sequence: "", pointTimes: [] });
   });
 });
 
-describe("toEventPointSequences", () => {
+describe("toEventTrackingData", () => {
   const completedSets = [
     { player1: 3, player2: 1 },
     { player1: 1, player2: 2 },
   ];
-  const setSequences = ["1211", "212"];
+  const startedAt = 1_000_000;
+  // Set 1 runs 10s, 20s, 30s and 40s in. Set 2 starts after a 60s break.
+  const trackedSets: TrackedSet[] = [
+    { sequence: "1211", pointTimes: [10_000, 20_000, 30_000, 40_000].map((ms) => startedAt + ms) },
+    { sequence: "212", pointTimes: [100_000, 105_500, 111_000].map((ms) => startedAt + ms) },
+  ];
+  const params = {
+    completedSets,
+    trackedSets,
+    firstServers: [1, 2] as (1 | 2)[],
+    source: "track-game" as const,
+    startedAt,
+    endedAt: startedAt + 120_000,
+    corrections: 2,
+  };
 
   it("encodes sequences as W/L from the game winner's perspective", () => {
-    expect(toEventPointSequences({ setSequences, completedSets, player1IsGameWinner: true })).toEqual([
-      "WLWW",
-      "LWL",
+    expect(toEventTrackingData({ ...params, player1IsGameWinner: true })?.pointSequences).toEqual(["WLWW", "LWL"]);
+    expect(toEventTrackingData({ ...params, player1IsGameWinner: false })?.pointSequences).toEqual(["LWLL", "WLW"]);
+  });
+
+  it("stores each point as tenths of a second since the previous point", () => {
+    const tracking = toEventTrackingData({ ...params, player1IsGameWinner: true })?.tracking;
+    // The first delta of set 2 is the break since the last point of set 1.
+    expect(tracking?.pointDeltas).toEqual([
+      [100, 100, 100, 100],
+      [600, 55, 55],
     ]);
-    expect(toEventPointSequences({ setSequences, completedSets, player1IsGameWinner: false })).toEqual([
-      "LWLL",
-      "WLW",
-    ]);
+    expect(tracking?.endedAfter).toBe(90);
+    expect(tracking?.startedAt).toBe(startedAt);
+  });
+
+  it("keeps the deltas in step with the total instead of drifting", () => {
+    // Each gap rounds down on its own, but the sum must still reach 3.0s.
+    const drifting: TrackedSet[] = [
+      { sequence: "1211", pointTimes: [749, 1_499, 2_249, 2_999].map((ms) => startedAt + ms) },
+      trackedSets[1],
+    ];
+    const tracking = toEventTrackingData({ ...params, trackedSets: drifting, player1IsGameWinner: true })?.tracking;
+    expect(tracking?.pointDeltas[0]).toEqual([7, 8, 7, 8]);
+    expect(tracking?.pointDeltas[0].reduce((sum, delta) => sum + delta, 0)).toBe(30);
+  });
+
+  it("never produces a negative delta when a point time goes backwards", () => {
+    const backwards: TrackedSet[] = [
+      { sequence: "1211", pointTimes: [10_000, 9_000, 30_000, 40_000].map((ms) => startedAt + ms) },
+      trackedSets[1],
+    ];
+    const tracking = toEventTrackingData({ ...params, trackedSets: backwards, player1IsGameWinner: true })?.tracking;
+    expect(tracking?.pointDeltas[0]).toEqual([100, 0, 200, 100]);
+  });
+
+  it("encodes the first server of each set from the game winner's perspective", () => {
+    expect(toEventTrackingData({ ...params, player1IsGameWinner: true })?.tracking.firstServers).toBe("WL");
+    expect(toEventTrackingData({ ...params, player1IsGameWinner: false })?.tracking.firstServers).toBe("LW");
+  });
+
+  it("keeps the source and the correction count", () => {
+    const tracking = toEventTrackingData({ ...params, player1IsGameWinner: true })?.tracking;
+    expect(tracking?.version).toBe(1);
+    expect(tracking?.source).toBe("track-game");
+    expect(tracking?.corrections).toBe(2);
   });
 
   it("returns undefined when there are no completed sets", () => {
-    expect(toEventPointSequences({ setSequences: [], completedSets: [], player1IsGameWinner: true })).toBeUndefined();
+    expect(
+      toEventTrackingData({ ...params, completedSets: [], trackedSets: [], firstServers: [], player1IsGameWinner: true }),
+    ).toBeUndefined();
   });
 
   it("returns undefined when a set has no sequence", () => {
     expect(
-      toEventPointSequences({ setSequences: ["1211"], completedSets, player1IsGameWinner: true }),
+      toEventTrackingData({ ...params, trackedSets: [trackedSets[0]], player1IsGameWinner: true }),
     ).toBeUndefined();
   });
 
   it("returns undefined when a sequence does not match its set's points", () => {
-    expect(
-      toEventPointSequences({ setSequences: ["1211", "211"], completedSets, player1IsGameWinner: true }),
-    ).toBeUndefined();
+    const wrong: TrackedSet[] = [trackedSets[0], { sequence: "211", pointTimes: trackedSets[1].pointTimes }];
+    expect(toEventTrackingData({ ...params, trackedSets: wrong, player1IsGameWinner: true })).toBeUndefined();
+  });
+
+  it("returns undefined when a set has no time for every point", () => {
+    const missing: TrackedSet[] = [{ sequence: "1211", pointTimes: [1, 2, 3] }, trackedSets[1]];
+    expect(toEventTrackingData({ ...params, trackedSets: missing, player1IsGameWinner: true })).toBeUndefined();
+  });
+
+  it("returns undefined when a set has no first server", () => {
+    expect(toEventTrackingData({ ...params, firstServers: [1], player1IsGameWinner: true })).toBeUndefined();
+  });
+
+  it("returns undefined when the match was never started or ended", () => {
+    expect(toEventTrackingData({ ...params, startedAt: null, player1IsGameWinner: true })).toBeUndefined();
+    expect(toEventTrackingData({ ...params, endedAt: null, player1IsGameWinner: true })).toBeUndefined();
   });
 });

--- a/frontend/src/common/point-sequences.ts
+++ b/frontend/src/common/point-sequences.ts
@@ -3,25 +3,55 @@
  *
  * While a game is tracked the winner is unknown, so points are collected per
  * set as a string of "1"/"2" chars — one char per point, in the order the
- * points were scored, naming the player slot that won the point. When the game
- * is saved the sequences are re-encoded from the game winner's perspective
- * ("W"/"L") to match how a GAME_SCORE event stores its setPoints.
+ * points were scored, naming the player slot that won the point. Next to each
+ * sequence the tracker keeps the time of every point, and per set who served
+ * first. When the game is saved all of it is re-encoded from the game winner's
+ * perspective ("W"/"L") to match how a GAME_SCORE event stores its setPoints.
  */
+
+import { GameTracking } from "../client/client-db/event-store/event-types";
+import { Server } from "./serve-tracker";
 
 export type TrackedSetPoints = { player1: number; player2: number };
 
-export function appendPointToSequence(sequence: string, player: 1 | 2): string {
-  return sequence + String(player);
+/** A tracked set: the points in scoring order, and when each one was scored. */
+export type TrackedSet = {
+  sequence: string;
+  /** Epoch ms of each point, parallel to `sequence`. */
+  pointTimes: number[];
+};
+
+export const emptyTrackedSet: TrackedSet = { sequence: "", pointTimes: [] };
+
+/**
+ * Epoch ms from a clock that cannot jump backwards inside one page load. A
+ * system clock correction while a game is tracked would otherwise shift the
+ * point times, or make them run backwards. Across a page reload this
+ * re-anchors on the system clock, which is the best available.
+ */
+export function trackingNow(): number {
+  if (typeof performance !== "undefined" && typeof performance.timeOrigin === "number") {
+    return Math.round(performance.timeOrigin + performance.now());
+  }
+  return Date.now();
+}
+
+export function appendPoint(set: TrackedSet, player: 1 | 2, at: number): TrackedSet {
+  return { sequence: set.sequence + String(player), pointTimes: [...set.pointTimes, at] };
 }
 
 /**
- * Undo one point for a player: drops that player's last point from the
- * sequence, keeping the points scored after it.
+ * Undo one point for a player: drops that player's last point from the set,
+ * keeping the points scored after it and their times. The surviving points
+ * keep the time they were scored at, so the timeline stays true.
  */
-export function removeLastPointFromSequence(sequence: string, player: 1 | 2): string {
-  const index = sequence.lastIndexOf(String(player));
-  if (index === -1) return sequence;
-  return sequence.slice(0, index) + sequence.slice(index + 1);
+export function removeLastPoint(set: TrackedSet, player: 1 | 2): TrackedSet {
+  const index = set.sequence.lastIndexOf(String(player));
+  if (index === -1) return set;
+  return {
+    sequence: set.sequence.slice(0, index) + set.sequence.slice(index + 1),
+    pointTimes: [...set.pointTimes.slice(0, index), ...set.pointTimes.slice(index + 1)],
+  };
 }
 
 function sequenceMatchesSet(sequence: string, set: TrackedSetPoints): boolean {
@@ -31,28 +61,69 @@ function sequenceMatchesSet(sequence: string, set: TrackedSetPoints): boolean {
 }
 
 /**
- * Re-encodes tracked "1"/"2" sequences to the "W"/"L" sequences stored on a
- * GAME_SCORE event. Returns undefined when the sequences do not align with the
- * completed sets — e.g. a live game that started before point tracking existed —
- * so the game is saved without point-level data instead of failing validation.
+ * Re-encodes what a tracker collected into the `pointSequences` and `tracking`
+ * of a GAME_SCORE event. The two always travel together, so this builds both
+ * or neither.
+ *
+ * Returns undefined when the tracked data does not line up with the completed
+ * sets — e.g. a broadcasted live game that started before this tracking
+ * existed — so the game is saved without point-level data instead of failing
+ * validation.
  */
-export function toEventPointSequences(params: {
-  setSequences: string[];
+export function toEventTrackingData(params: {
   completedSets: TrackedSetPoints[];
+  trackedSets: TrackedSet[];
+  /** Who served the first point of each completed set. */
+  firstServers: Server[];
   player1IsGameWinner: boolean;
-}): string[] | undefined {
-  const { setSequences, completedSets, player1IsGameWinner } = params;
+  source: GameTracking["source"];
+  /** Epoch ms tracking started, and when the match was ended. */
+  startedAt: number | null;
+  endedAt: number | null;
+  corrections: number;
+}): { pointSequences: string[]; tracking: GameTracking } | undefined {
+  const { completedSets, trackedSets, firstServers, player1IsGameWinner, startedAt, endedAt } = params;
+  if (startedAt === null || endedAt === null) return undefined;
   if (completedSets.length === 0) return undefined;
-  if (setSequences.length !== completedSets.length) return undefined;
-  if (setSequences.some((sequence, index) => sequenceMatchesSet(sequence, completedSets[index]) === false)) {
+  if (trackedSets.length !== completedSets.length) return undefined;
+  if (firstServers.length !== completedSets.length) return undefined;
+  if (trackedSets.some((set, index) => sequenceMatchesSet(set.sequence, completedSets[index]) === false)) {
     return undefined;
   }
+  if (trackedSets.some((set) => set.sequence.length !== set.pointTimes.length)) return undefined;
 
-  const gameWinnerDigit = player1IsGameWinner ? "1" : "2";
-  return setSequences.map((sequence) =>
-    sequence
+  const gameWinnerSlot: Server = player1IsGameWinner ? 1 : 2;
+  const pointSequences = trackedSets.map((set) =>
+    set.sequence
       .split("")
-      .map((point) => (point === gameWinnerDigit ? "W" : "L"))
+      .map((point) => (Number(point) === gameWinnerSlot ? "W" : "L"))
       .join(""),
   );
+
+  // Each delta is the difference of two rounded offsets from the start, not the
+  // rounding of one gap. That keeps the deltas in step with the total instead
+  // of drifting away from it point by point. The clamp keeps them positive
+  // even if a point time went backwards.
+  let previousTenths = 0;
+  const pointDeltas = trackedSets.map((set) =>
+    set.pointTimes.map((time) => {
+      const tenths = Math.max(previousTenths, Math.round((time - startedAt) / 100));
+      const delta = tenths - previousTenths;
+      previousTenths = tenths;
+      return delta;
+    }),
+  );
+
+  return {
+    pointSequences,
+    tracking: {
+      version: 1,
+      source: params.source,
+      startedAt,
+      pointDeltas,
+      endedAfter: Math.max(0, Math.round((endedAt - startedAt) / 100) - previousTenths),
+      firstServers: firstServers.map((server) => (server === gameWinnerSlot ? "W" : "L")).join(""),
+      corrections: params.corrections,
+    },
+  };
 }

--- a/frontend/src/pages/add-game/track-game.tsx
+++ b/frontend/src/pages/add-game/track-game.tsx
@@ -22,9 +22,12 @@ import { WinPercentGraph } from "./win-percent-graph";
 import { session } from "../../services/auth";
 import { useLiveGameQuery, useUpdateLiveGameMutation } from "../live-game/use-live-game";
 import {
-  appendPointToSequence,
-  removeLastPointFromSequence,
-  toEventPointSequences,
+  appendPoint,
+  emptyTrackedSet,
+  removeLastPoint,
+  toEventTrackingData,
+  TrackedSet,
+  trackingNow,
 } from "../../common/point-sequences";
 
 interface SetPoint {
@@ -38,8 +41,10 @@ interface MatchData {
     player2: number;
   };
   setPoints?: SetPoint[];
-  /** Point sequence of each completed set: "1"/"2" chars in the order the points were scored. */
-  setSequences: string[];
+  /** Points of each completed set, in scoring order, and when each was scored. */
+  trackedSets: TrackedSet[];
+  /** Who served the first point of each completed set. */
+  firstServers: Server[];
 }
 
 type Stage = "player-selection" | "scoring" | "summary";
@@ -56,15 +61,21 @@ export const TrackGamePage: React.FC = () => {
   const [matchData, setMatchData] = useState<MatchData>({
     setsWon: { player1: 0, player2: 0 },
     setPoints: [],
-    setSequences: [],
+    trackedSets: [],
+    firstServers: [],
   });
   const [currentSetScore, setCurrentSetScore] = useState<SetPoint>({
     player1: 0,
     player2: 0,
   });
-  // "1"/"2" per point of the current set, in the order the points were scored.
-  const [currentSetSequence, setCurrentSetSequence] = useState<string>("");
+  // The points of the current set, in the order they were scored.
+  const [currentTrackedSet, setCurrentTrackedSet] = useState<TrackedSet>(emptyTrackedSet);
   const [firstServer, setFirstServer] = useState<Server>(1);
+  // Epoch ms the match started, when it was ended, and how many points were
+  // undone. Saved with the game so its timeline can be replayed.
+  const [startedAt, setStartedAt] = useState<number | null>(null);
+  const [endedAt, setEndedAt] = useState<number | null>(null);
+  const [corrections, setCorrections] = useState(0);
   // Player 1's live win chance sampled after every point, for the summary graph.
   const [winPercentHistory, setWinPercentHistory] = useState<number[]>([]);
   const [validationError, setValidationError] = useState<string>("");
@@ -100,7 +111,8 @@ export const TrackGamePage: React.FC = () => {
     const key = `player${player}` as keyof SetPoint;
     const next: SetPoint = { ...currentSetScore, [key]: currentSetScore[key] + 1 };
     setCurrentSetScore(next);
-    setCurrentSetSequence((prev) => appendPointToSequence(prev, player as 1 | 2));
+    const at = trackingNow();
+    setCurrentTrackedSet((prev) => appendPoint(prev, player as 1 | 2, at));
     setWinPercentHistory((prev) => [...prev, computeWinPercent(next)]);
   };
 
@@ -109,7 +121,8 @@ export const TrackGamePage: React.FC = () => {
     if (currentSetScore[key] === 0) return;
     const next: SetPoint = { ...currentSetScore, [key]: currentSetScore[key] - 1 };
     setCurrentSetScore(next);
-    setCurrentSetSequence((prev) => removeLastPointFromSequence(prev, player as 1 | 2));
+    setCurrentTrackedSet((prev) => removeLastPoint(prev, player as 1 | 2));
+    setCorrections((prev) => prev + 1);
     // Undoing a point drops the last 2 samples and appends one for the restored
     // score, so the history keeps one sample per point. Undoing the only point
     // of the match just empties the history.
@@ -128,20 +141,23 @@ export const TrackGamePage: React.FC = () => {
         player2: prev.setsWon.player2 + (player === 2 ? 1 : 0),
       },
       setPoints: [...(prev.setPoints || []), newSetPoint],
-      setSequences: [...prev.setSequences, currentSetSequence],
+      trackedSets: [...prev.trackedSets, currentTrackedSet],
+      firstServers: [...prev.firstServers, firstServer],
     }));
 
     setCurrentSetScore({ player1: 0, player2: 0 });
-    setCurrentSetSequence("");
+    setCurrentTrackedSet(emptyTrackedSet);
     // Alternate who serves first in the next set, per table tennis convention.
     setFirstServer((prev) => (prev === 1 ? 2 : 1));
   };
 
   const startMatch = () => {
+    setStartedAt(trackingNow());
     setStage("scoring");
   };
 
   const endMatch = () => {
+    setEndedAt(trackingNow());
     setStage("summary");
   };
 
@@ -166,6 +182,19 @@ export const TrackGamePage: React.FC = () => {
     // We only send setPoints if we actually recorded them (which we always do in this flow)
     const setPointsForValidation = matchData.setPoints || [];
 
+    // Both are undefined when the tracked points do not line up with the
+    // completed sets. They are always saved together.
+    const trackingData = toEventTrackingData({
+      completedSets: setPointsForValidation,
+      trackedSets: matchData.trackedSets,
+      firstServers: matchData.firstServers,
+      player1IsGameWinner: player1 === winner,
+      source: "track-game",
+      startedAt,
+      endedAt,
+      corrections,
+    });
+
     const gameScoreEvent: GameScore = {
       type: EventTypeEnum.GAME_SCORE,
       time: gameCreatedEvent.time + 1,
@@ -182,11 +211,8 @@ export const TrackGamePage: React.FC = () => {
                 gameLoser: player1 === winner ? set.player2 : set.player1,
               }))
             : undefined,
-        pointSequences: toEventPointSequences({
-          setSequences: matchData.setSequences,
-          completedSets: setPointsForValidation,
-          player1IsGameWinner: player1 === winner,
-        }),
+        pointSequences: trackingData?.pointSequences,
+        tracking: trackingData?.tracking,
       },
     };
 
@@ -260,7 +286,7 @@ export const TrackGamePage: React.FC = () => {
       return;
     }
 
-    const now = Date.now();
+    const now = trackingNow();
     try {
       await updateLiveGame.mutateAsync({
         player1Id: player1,
@@ -268,10 +294,17 @@ export const TrackGamePage: React.FC = () => {
         setsWon: { ...matchData.setsWon },
         currentSet: { ...currentSetScore },
         completedSets: matchData.setPoints ?? [],
-        currentSetSequence,
-        completedSetSequences: [...matchData.setSequences],
+        currentSetSequence: currentTrackedSet.sequence,
+        currentSetPointTimes: [...currentTrackedSet.pointTimes],
+        completedSetSequences: matchData.trackedSets.map((set) => set.sequence),
+        completedSetPointTimes: matchData.trackedSets.map((set) => [...set.pointTimes]),
+        completedSetFirstServers: [...matchData.firstServers],
         firstServer,
-        startedAt: now,
+        corrections,
+        // Keep the original start so the timeline stays continuous across the
+        // handover. Only a match that skipped the scoring screen starts now.
+        startedAt: startedAt ?? now,
+        endedAt: null,
         finishedAt: null,
         updatedAt: now,
       });
@@ -289,11 +322,15 @@ export const TrackGamePage: React.FC = () => {
     setMatchData({
       setsWon: { player1: 0, player2: 0 },
       setPoints: [],
-      setSequences: [],
+      trackedSets: [],
+      firstServers: [],
     });
     setCurrentSetScore({ player1: 0, player2: 0 });
-    setCurrentSetSequence("");
+    setCurrentTrackedSet(emptyTrackedSet);
     setFirstServer(1);
+    setStartedAt(null);
+    setEndedAt(null);
+    setCorrections(0);
     setWinPercentHistory([]);
     setValidationError("");
   };

--- a/frontend/src/pages/game/game-details-page.tsx
+++ b/frontend/src/pages/game/game-details-page.tsx
@@ -10,6 +10,8 @@ import { ProfilePicture } from "../player/profile-picture";
 import { Fraction } from "../../client/client-db/predictions";
 import { WinPercentGraph } from "../add-game/win-percent-graph";
 import { replayWinPercentHistory } from "./game-win-replay";
+import { durationString, gameTimingStats, gapString, serveStats } from "./game-tracking-stats";
+import { GameTracking } from "../../client/client-db/event-store/event-types";
 
 /**
  * Details about a single game, identified by its played-at timestamp (unique
@@ -171,6 +173,18 @@ export const GameDetailsPage: React.FC = () => {
             </button>
           </div>
 
+          {/* How long the game took, and how each player did on their serve */}
+          {game.score?.tracking && game.score.pointSequences && (
+            <div className="px-2 xs:px-4 pb-3">
+              <TrackingStats
+                tracking={game.score.tracking}
+                pointSequences={game.score.pointSequences}
+                winnerName={context.playerName(game.winner)}
+                loserName={context.playerName(game.loser)}
+              />
+            </div>
+          )}
+
           {/* Win % over the game, replayed from the point-by-point log */}
           <div className="px-2 xs:px-4 pb-4">
             {winPercentHistory && winPercentHistory.length >= 2 && game.score?.setPoints ? (
@@ -197,6 +211,48 @@ export const GameDetailsPage: React.FC = () => {
     </div>
   );
 };
+
+/**
+ * The timeline and serve data of a tracked game. The gaps are the time between
+ * two points being registered, so they include everything that happens between
+ * the rallies, not the rally alone.
+ */
+const TrackingStats: React.FC<{
+  tracking: GameTracking;
+  pointSequences: string[];
+  winnerName: string;
+  loserName: string;
+}> = ({ tracking, pointSequences, winnerName, loserName }) => {
+  const timing = gameTimingStats(tracking);
+  const serves = serveStats(pointSequences, tracking.firstServers);
+  const servePercent = (side: { served: number; won: number }) =>
+    side.served === 0 ? "–" : `${fmtNum((side.won / side.served) * 100)}%`;
+
+  return (
+    <div className="rounded-lg bg-secondary-background text-secondary-text p-3">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-y-2 gap-x-3 text-center">
+        <StatCell label="Duration" value={durationString(timing.durationMs)} />
+        <StatCell
+          label="Sets"
+          value={timing.setDurationsMs.map((ms) => durationString(ms)).join(" · ")}
+        />
+        <StatCell label="Between points" value={gapString(timing.averagePointGapMs)} />
+        <StatCell label="Longest pause" value={gapString(timing.longestPointGapMs)} />
+      </div>
+      <div className="mt-3 pt-3 border-t border-secondary-text/20 grid grid-cols-2 gap-x-3 text-center">
+        <StatCell label={`${winnerName} on serve`} value={servePercent(serves.winner)} />
+        <StatCell label={`${loserName} on serve`} value={servePercent(serves.loser)} />
+      </div>
+    </div>
+  );
+};
+
+const StatCell: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <div className="flex flex-col items-center min-w-0">
+    <span className="text-xs opacity-70 truncate max-w-full">{label}</span>
+    <span className="text-lg font-bold truncate max-w-full">{value}</span>
+  </div>
+);
 
 const PredictionCell: React.FC<{ label: string; prediction?: Fraction }> = ({ label, prediction }) => (
   <div className="flex flex-col items-center">

--- a/frontend/src/pages/game/game-tracking-stats.test.ts
+++ b/frontend/src/pages/game/game-tracking-stats.test.ts
@@ -1,0 +1,93 @@
+import { GameTracking } from "../../client/client-db/event-store/event-types";
+import { durationString, gameTimingStats, gapString, serveStats } from "./game-tracking-stats";
+
+function tracking(overrides: Partial<GameTracking> = {}): GameTracking {
+  return {
+    version: 1,
+    source: "track-game",
+    startedAt: 1_700_000_000_000,
+    pointDeltas: [
+      [100, 50, 70, 60],
+      [600, 55, 200, 45],
+    ],
+    endedAfter: 90,
+    firstServers: "WL",
+    corrections: 0,
+    ...overrides,
+  };
+}
+
+describe("gameTimingStats", () => {
+  it("sums every delta into the duration of the game", () => {
+    // 100 + 50 + 70 + 60 + 600 + 55 + 200 + 45 tenths = 118 seconds.
+    expect(gameTimingStats(tracking()).durationMs).toBe(118_000);
+  });
+
+  it("measures a set from its first point to its last point", () => {
+    // The first delta of a set is the wait before its first point, so it is
+    // not part of the set. Set 1 is 50 + 70 + 60, set 2 is 55 + 200 + 45.
+    expect(gameTimingStats(tracking()).setDurationsMs).toEqual([18_000, 30_000]);
+  });
+
+  it("leaves the break between sets out of the gaps between points", () => {
+    const stats = gameTimingStats(tracking());
+    // The 600 tenth break and the 100 tenth start are both excluded.
+    expect(stats.longestPointGapMs).toBe(20_000);
+    expect(stats.averagePointGapMs).toBe(((50 + 70 + 60 + 55 + 200 + 45) / 6) * 100);
+  });
+
+  it("reports zero gaps for a game of single-point sets", () => {
+    const stats = gameTimingStats(tracking({ pointDeltas: [[100], [200]] }));
+    expect(stats.longestPointGapMs).toBe(0);
+    expect(stats.averagePointGapMs).toBe(0);
+    expect(stats.durationMs).toBe(30_000);
+  });
+});
+
+describe("serveStats", () => {
+  it("counts the points each player played on their own serve", () => {
+    // One set, the game winner serves first. Serve changes every 2 points, so
+    // the winner serves points 1, 2, 5, 6 and the loser serves points 3, 4.
+    const stats = serveStats(["WLLWWL"], "W");
+    expect(stats.winner.served).toBe(4);
+    expect(stats.loser.served).toBe(2);
+  });
+
+  it("counts the points won on serve for each player", () => {
+    // The winner serves points 1, 2, 5 and 6, and wins points 1 and 5 of them.
+    // The loser serves points 3 and 4, and wins point 3 only.
+    const stats = serveStats(["WLLWWL"], "W");
+    expect(stats.winner.won).toBe(2);
+    expect(stats.loser.won).toBe(1);
+  });
+
+  it("reads the first server of each set separately", () => {
+    // Same 2 points in both sets, but the server of the set swaps.
+    const stats = serveStats(["WW", "WW"], "WL");
+    expect(stats.winner).toEqual({ served: 2, won: 2 });
+    expect(stats.loser).toEqual({ served: 2, won: 0 });
+  });
+
+  it("returns empty counts for an empty log", () => {
+    expect(serveStats([], "")).toEqual({ winner: { served: 0, won: 0 }, loser: { served: 0, won: 0 } });
+  });
+});
+
+describe("durationString", () => {
+  it("formats seconds, minutes and hours", () => {
+    expect(durationString(38_000)).toBe("38s");
+    expect(durationString(252_000)).toBe("4m 12s");
+    expect(durationString(3_840_000)).toBe("1h 04m");
+  });
+});
+
+describe("gapString", () => {
+  it("keeps the tenth of a second for a short gap", () => {
+    expect(gapString(7_400)).toBe("7.4s");
+    expect(gapString(0)).toBe("0.0s");
+  });
+
+  it("switches to minutes for a gap of a minute or more", () => {
+    expect(gapString(90_000)).toBe("1m 30s");
+  });
+});

--- a/frontend/src/pages/game/game-tracking-stats.ts
+++ b/frontend/src/pages/game/game-tracking-stats.ts
@@ -1,0 +1,100 @@
+/**
+ * Reads the timing and serve data a tracked game stores, and turns it into the
+ * numbers the game details page shows.
+ *
+ * Every time in `GameTracking` is a delta in tenths of a second from the
+ * previous point, so anything absolute is rebuilt by summing them.
+ */
+
+import { GameTracking } from "../../client/client-db/event-store/event-types";
+import { getServeInfo, Server } from "../../common/serve-tracker";
+
+const TENTH_MS = 100;
+
+export type GameTimingStats = {
+  /** Ms from the start of tracking to the last point. */
+  durationMs: number;
+  /** Ms each set took, from its first point to its last point. */
+  setDurationsMs: number[];
+  /** Ms between two points, on average, excluding the breaks between sets. */
+  averagePointGapMs: number;
+  /** The longest gap between two points, excluding the breaks between sets. */
+  longestPointGapMs: number;
+};
+
+/**
+ * The gaps between points inside a set. The first delta of a set is the break
+ * since the previous point of the game, so it is not a gap between two points
+ * of the same set and is left out.
+ */
+function withinSetGaps(tracking: GameTracking): number[] {
+  return tracking.pointDeltas.flatMap((deltas) => deltas.slice(1));
+}
+
+export function gameTimingStats(tracking: GameTracking): GameTimingStats {
+  const gaps = withinSetGaps(tracking);
+  const totalTenths = tracking.pointDeltas.reduce(
+    (total, deltas) => total + deltas.reduce((sum, delta) => sum + delta, 0),
+    0,
+  );
+  return {
+    durationMs: totalTenths * TENTH_MS,
+    setDurationsMs: tracking.pointDeltas.map(
+      (deltas) => deltas.slice(1).reduce((sum, delta) => sum + delta, 0) * TENTH_MS,
+    ),
+    averagePointGapMs:
+      gaps.length === 0 ? 0 : (gaps.reduce((sum, gap) => sum + gap, 0) / gaps.length) * TENTH_MS,
+    longestPointGapMs: gaps.length === 0 ? 0 : Math.max(...gaps) * TENTH_MS,
+  };
+}
+
+export type ServeStats = {
+  /** Points played on this player's serve, and how many of them the player won. */
+  winner: { served: number; won: number };
+  loser: { served: number; won: number };
+};
+
+/**
+ * Counts how each player did on their own serve. The server of a point follows
+ * from who served first in the set and the score at that point, the same rule
+ * the live serve tracker shows.
+ */
+export function serveStats(pointSequences: string[], firstServers: string): ServeStats {
+  const stats: ServeStats = { winner: { served: 0, won: 0 }, loser: { served: 0, won: 0 } };
+
+  pointSequences.forEach((sequence, setIndex) => {
+    // The game winner is slot 1 here, so the set score is counted their way.
+    const firstServer: Server = firstServers[setIndex] === "W" ? 1 : 2;
+    let winnerPoints = 0;
+    let loserPoints = 0;
+
+    for (const point of sequence) {
+      const { server } = getServeInfo({ player1: winnerPoints, player2: loserPoints }, firstServer);
+      const winnerScored = point === "W";
+      const side = server === 1 ? stats.winner : stats.loser;
+      side.served++;
+      if (winnerScored === (server === 1)) side.won++;
+      if (winnerScored) winnerPoints++;
+      else loserPoints++;
+    }
+  });
+
+  return stats;
+}
+
+/** A duration as "1h 04m", "4m 12s" or "38s". */
+export function durationString(ms: number): string {
+  const totalSeconds = Math.round(ms / 1_000);
+  const hours = Math.floor(totalSeconds / 3_600);
+  const minutes = Math.floor((totalSeconds % 3_600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours > 0) return `${hours}h ${String(minutes).padStart(2, "0")}m`;
+  if (minutes > 0) return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
+  return `${seconds}s`;
+}
+
+/** A short gap as "7.4s". Point gaps are short enough to keep the tenth. */
+export function gapString(ms: number): string {
+  if (ms >= 60_000) return durationString(ms);
+  return `${(ms / 1_000).toFixed(1)}s`;
+}

--- a/frontend/src/pages/game/point-sequence-marker.tsx
+++ b/frontend/src/pages/game/point-sequence-marker.tsx
@@ -9,7 +9,7 @@ export const PointSequenceMarker: React.FC<{ score?: GameScore["data"] }> = ({ s
   if (!score?.pointSequences?.length) return null;
   return (
     <span title="Tracked point by point" className="ml-1 text-[10px] md:text-xs align-middle">
-      👀
+      🔴
     </span>
   );
 };

--- a/frontend/src/pages/live-game/live-game-admin-page.tsx
+++ b/frontend/src/pages/live-game/live-game-admin-page.tsx
@@ -26,11 +26,7 @@ import { LiveGamePredictionCard } from "./live-game-prediction-card";
 import ConfettiExplosion from "react-confetti-explosion";
 import { Server } from "../../common/serve-tracker";
 import { ServeTrackerDisplay } from "../../common/serve-tracker-display";
-import {
-  appendPointToSequence,
-  removeLastPointFromSequence,
-  toEventPointSequences,
-} from "../../common/point-sequences";
+import { appendPoint, removeLastPoint, toEventTrackingData, trackingNow } from "../../common/point-sequences";
 
 type Stage = "scoring" | "confirm";
 
@@ -102,9 +98,14 @@ export const LiveGameAdminPage: React.FC = () => {
       currentSet: { player1: 0, player2: 0 },
       completedSets: [],
       currentSetSequence: "",
+      currentSetPointTimes: [],
       completedSetSequences: [],
+      completedSetPointTimes: [],
+      completedSetFirstServers: [],
       firstServer: localState!.firstServer,
-      startedAt: Date.now(),
+      corrections: 0,
+      startedAt: trackingNow(),
+      endedAt: null,
       finishedAt: null,
       updatedAt: Date.now(),
     });
@@ -116,25 +117,37 @@ export const LiveGameAdminPage: React.FC = () => {
 
   function addPoint(player: 1 | 2) {
     const key: keyof LiveGameSetPoint = player === 1 ? "player1" : "player2";
+    const trackedSet = appendPoint(
+      { sequence: localState!.currentSetSequence, pointTimes: localState!.currentSetPointTimes },
+      player,
+      trackingNow(),
+    );
     pushState({
       ...localState!,
       currentSet: {
         ...localState!.currentSet,
         [key]: localState!.currentSet[key] + 1,
       },
-      currentSetSequence: appendPointToSequence(localState!.currentSetSequence, player),
+      currentSetSequence: trackedSet.sequence,
+      currentSetPointTimes: trackedSet.pointTimes,
     });
   }
 
   function removePoint(player: 1 | 2) {
     const key: keyof LiveGameSetPoint = player === 1 ? "player1" : "player2";
+    const trackedSet = removeLastPoint(
+      { sequence: localState!.currentSetSequence, pointTimes: localState!.currentSetPointTimes },
+      player,
+    );
     pushState({
       ...localState!,
       currentSet: {
         ...localState!.currentSet,
         [key]: Math.max(0, localState!.currentSet[key] - 1),
       },
-      currentSetSequence: removeLastPointFromSequence(localState!.currentSetSequence, player),
+      currentSetSequence: trackedSet.sequence,
+      currentSetPointTimes: trackedSet.pointTimes,
+      corrections: localState!.corrections + 1,
     });
   }
 
@@ -148,7 +161,10 @@ export const LiveGameAdminPage: React.FC = () => {
       completedSets: [...localState!.completedSets, { ...localState!.currentSet }],
       currentSet: { player1: 0, player2: 0 },
       completedSetSequences: [...localState!.completedSetSequences, localState!.currentSetSequence],
+      completedSetPointTimes: [...localState!.completedSetPointTimes, localState!.currentSetPointTimes],
+      completedSetFirstServers: [...localState!.completedSetFirstServers, localState!.firstServer],
       currentSetSequence: "",
+      currentSetPointTimes: [],
       // Alternate who serves first in the next set, per table tennis convention.
       firstServer: localState!.firstServer === 1 ? 2 : 1,
     });
@@ -162,8 +178,15 @@ export const LiveGameAdminPage: React.FC = () => {
       currentSet: { player1: 0, player2: 0 },
       completedSets: [],
       currentSetSequence: "",
+      currentSetPointTimes: [],
       completedSetSequences: [],
+      completedSetPointTimes: [],
+      completedSetFirstServers: [],
       firstServer: 1,
+      corrections: 0,
+      // The match restarts, so its timeline restarts with it.
+      startedAt: trackingNow(),
+      endedAt: null,
       updatedAt: Date.now(),
     });
   }
@@ -184,6 +207,7 @@ export const LiveGameAdminPage: React.FC = () => {
       setValidationError("Match is tied — complete another set before saving.");
       return;
     }
+    pushState({ ...localState!, endedAt: trackingNow() });
     setStage("confirm");
   }
 
@@ -209,6 +233,23 @@ export const LiveGameAdminPage: React.FC = () => {
       return;
     }
 
+    // Both are undefined when the tracked points do not line up with the
+    // completed sets, e.g. a live game that started before this tracking
+    // existed. They are always saved together.
+    const trackingData = toEventTrackingData({
+      completedSets: localState!.completedSets,
+      trackedSets: localState!.completedSetSequences.map((sequence, index) => ({
+        sequence,
+        pointTimes: localState!.completedSetPointTimes[index] ?? [],
+      })),
+      firstServers: localState!.completedSetFirstServers,
+      player1IsGameWinner: player1Won,
+      source: "live-game",
+      startedAt: localState!.startedAt,
+      endedAt: localState!.endedAt,
+      corrections: localState!.corrections,
+    });
+
     const gameScoreEvent: GameScore = {
       type: EventTypeEnum.GAME_SCORE,
       time: gameCreatedEvent.time + 1,
@@ -222,13 +263,8 @@ export const LiveGameAdminPage: React.FC = () => {
                 gameLoser: player1Won ? set.player2 : set.player1,
               }))
             : undefined,
-        // undefined when the sequences do not align with the completed sets,
-        // e.g. a live game that started before point tracking existed.
-        pointSequences: toEventPointSequences({
-          setSequences: localState!.completedSetSequences,
-          completedSets: localState!.completedSets,
-          player1IsGameWinner: player1Won,
-        }),
+        pointSequences: trackingData?.pointSequences,
+        tracking: trackingData?.tracking,
       },
     };
 

--- a/frontend/src/pages/live-game/live-game-types.ts
+++ b/frontend/src/pages/live-game/live-game-types.ts
@@ -17,11 +17,21 @@ export type LiveGameState = {
    * "1" = point to player 1, "2" = point to player 2.
    */
   currentSetSequence: string;
+  /** Epoch ms of each point of the current set, parallel to currentSetSequence. */
+  currentSetPointTimes: number[];
   /** Point sequence of each completed set, same encoding as currentSetSequence. */
   completedSetSequences: string[];
+  /** Point times of each completed set, same encoding as currentSetPointTimes. */
+  completedSetPointTimes: number[][];
+  /** Which player (1 or 2) served the first point of each completed set. */
+  completedSetFirstServers: (1 | 2)[];
   /** Which player (1 or 2) served the first point of the current set. */
   firstServer: 1 | 2;
+  /** How many points were undone while tracking this match. */
+  corrections: number;
   startedAt: number | null;
+  /** Epoch ms the match was ended for review. Null while it is still played. */
+  endedAt: number | null;
   finishedAt: number | null;
   updatedAt: number;
 };
@@ -33,9 +43,14 @@ export const emptyLiveGame: LiveGameState = {
   currentSet: { player1: 0, player2: 0 },
   completedSets: [],
   currentSetSequence: "",
+  currentSetPointTimes: [],
   completedSetSequences: [],
+  completedSetPointTimes: [],
+  completedSetFirstServers: [],
   firstServer: 1,
+  corrections: 0,
   startedAt: null,
+  endedAt: null,
   finishedAt: null,
   updatedAt: 0,
 };

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -360,8 +360,8 @@ export const ACHIEVEMENT_LABELS: Record<AchievementType, { title: string; descri
   },
   "on-the-record": {
     title: "On the Record",
-    description: "Play 5 games tracked point by point — the games marked 👀",
-    icon: "👀",
+    description: "Play 5 games tracked point by point — the games marked 🔴",
+    icon: "🔴",
   },
   "giant-hunting": {
     title: "Giant Hunting",


### PR DESCRIPTION
A tracked game now saves a timeline and serve data next to its point log,
in a new `tracking` object on the GAME_SCORE event.

- `startedAt` is the only absolute time. Each point is a delta from the
  previous point in tenths of a second, across set boundaries, so the
  first delta of a set is the break after the previous set.
- `firstServers` stores who served the first point of each set. The
  trackers already knew this and threw it away on save. The server of any
  later point follows from the set score via getServeInfo.
- `source` and `corrections` record which tracker logged the game and how
  many points were undone, so timing stats can exclude a corrected log.

Point times come from `performance.timeOrigin + performance.now()`, which
does not jump when the system clock is corrected mid-match. The trackers
keep the absolute time of each point and convert to deltas on save, so
undoing a point in the middle of a set leaves the later points at the
time they were scored. Deltas are the difference of two rounded offsets
from the start, so they cannot drift away from the total.

`pointSequences` and `tracking` are now built together and validated as a
pair - neither can be stored without the other.

The game details page shows the duration of the game and of each set, the
average time between points, the longest pause, and the percent of points
each player won on their own serve.