### PR TITLE
Add set-by-set table and point pace graph to game details

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -53,7 +53,10 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
         "The `GAME_SCORE` event stores the start of the match as a full timestamp. Each point after it is the time since the previous point, in tenths of a second. The event also stores who served the first point of each set, which tracker recorded the game, and how many points the person undid.",
       ),
       text(
-        "The game details page shows the duration of the game, the duration of each set, the average time between 2 points, and the longest pause. It also shows the percent of points that each player won on their own serve.",
+        "The game details page shows the duration of the game, the time it started, the average time between 2 points, and the longest pause. For each player it shows the percent of points won on their own serve, and the longest run of points in a row.",
+      ),
+      text(
+        "A table gives every set: the score, who served the first point, the time the set took, and the break before it. A graph below the win % graph shows the time each point took. Each bar has the colour of the player who won the point.",
       ),
       text(
         "The time between 2 points includes everything that happens between the rallies. A player can collect the ball or speak. Read the value as the pace of the game, not as the length of a rally.",

--- a/frontend/src/common/date-utils.tsx
+++ b/frontend/src/common/date-utils.tsx
@@ -102,6 +102,11 @@ export function fullDateTimeString(time: number): string {
   return `${datePart} ${timePart}`;
 }
 
+// Clock time only, e.g. "08:37". For a time whose date is already on screen.
+export function clockTimeString(time: number): string {
+  return new Date(time).toLocaleTimeString("nb-NO", { hour: "2-digit", minute: "2-digit" });
+}
+
 // Month-granularity variant of dateString, for periods that span a whole
 // calendar month (e.g. "januar 2026").
 export function monthString(time: number) {

--- a/frontend/src/common/player-color-styles.ts
+++ b/frontend/src/common/player-color-styles.ts
@@ -14,6 +14,14 @@ export const ROW_SURFACE = "#f9fafb"; // bg-gray-50
 /** How much white is mixed into a player colour for their side of the score display. */
 const PANEL_TINT = 0.85;
 
+/**
+ * The contrast a chart mark must clear against its surface. Far below the 4.5:1
+ * that text needs: a bar or a line is a shape, not something to read, so it
+ * keeps the player's own colour. Only a near-white colour, which would be
+ * invisible on a pale chart surface, moves at all.
+ */
+const MARK_MINIMUM_RATIO = 1.5;
+
 /** How much white is mixed in for the secondary action next to a filled one. */
 const SOFT_FILL_TINT = 0.35;
 
@@ -35,4 +43,13 @@ export function panelTint(color: string): string {
 /** A player's colour as text on a surface, darkened where the raw colour is too pale to read. */
 export function textOn(color: string, surface: string): React.CSSProperties {
   return { color: readableOn(color, surface) };
+}
+
+/**
+ * A player's colour for a chart mark - a bar or a line - on a surface. Keeps the
+ * raw colour, so a player is the same colour in a chart as everywhere else in
+ * the app. Only a colour pale enough to disappear into the surface is darkened.
+ */
+export function markOn(color: string, surface: string): string {
+  return readableOn(color, surface, MARK_MINIMUM_RATIO);
 }

--- a/frontend/src/pages/add-game/track-game.tsx
+++ b/frontend/src/pages/add-game/track-game.tsx
@@ -663,13 +663,15 @@ export const TrackGamePage: React.FC = () => {
             </div>
 
             {/* Winner's win % point by point */}
-            <WinPercentGraph
-              history={winPercentHistory}
-              winnerIsPlayer1={winner === player1}
-              winnerName={context.playerName(winner)}
-              winnerColor={winner === player1 ? player1Color : player2Color}
-              completedSets={matchData.setPoints ?? []}
-            />
+            <div className="mb-6">
+              <WinPercentGraph
+                history={winPercentHistory}
+                winnerIsPlayer1={winner === player1}
+                winnerName={context.playerName(winner)}
+                winnerColor={winner === player1 ? player1Color : player2Color}
+                completedSets={matchData.setPoints ?? []}
+              />
+            </div>
 
             {/* Set Details */}
             {matchData.setPoints && matchData.setPoints.length > 0 && (

--- a/frontend/src/pages/add-game/win-percent-graph.tsx
+++ b/frontend/src/pages/add-game/win-percent-graph.tsx
@@ -53,12 +53,12 @@ export const WinPercentGraph: React.FC<Props> = ({
   const lineColor = readableOn(winnerColor, ROW_SURFACE);
 
   return (
-    <div className="bg-gray-50 rounded-lg p-4 mb-6">
+    <div className="bg-gray-50 rounded-lg p-4">
       <h3 className="text-base font-bold text-gray-800 mb-1">Win % over the game</h3>
       <p className="text-xs text-gray-500 mb-2">{winnerName}'s chance to win, after every point</p>
       <ResponsiveContainer width="100%" height={180}>
         <LineChart data={data} margin={{ top: 12, right: 12, left: 0, bottom: 0 }}>
-          <CartesianGrid strokeDasharray="1 4" vertical={false} stroke="#d1d5db" />
+          <CartesianGrid vertical={false} stroke="#e5e7eb" />
           <XAxis
             dataKey="point"
             type="number"

--- a/frontend/src/pages/add-game/win-percent-graph.tsx
+++ b/frontend/src/pages/add-game/win-percent-graph.tsx
@@ -9,8 +9,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { readableOn } from "../../common/color-utils";
-import { ROW_SURFACE } from "../../common/player-color-styles";
+import { markOn, ROW_SURFACE } from "../../common/player-color-styles";
 import { fmtNum } from "../../common/number-utils";
 
 type Props = {
@@ -48,9 +47,8 @@ export const WinPercentGraph: React.FC<Props> = ({
     return { point: pointsPlayed, label: `Set ${index + 1}` };
   });
 
-  // Player colours run from near-black to near-white, so darken pale ones the
-  // same way the score text does.
-  const lineColor = readableOn(winnerColor, ROW_SURFACE);
+  // The winner's own colour, the one they have everywhere else in the app.
+  const lineColor = markOn(winnerColor, ROW_SURFACE);
 
   return (
     <div className="bg-gray-50 rounded-lg p-4">

--- a/frontend/src/pages/game/game-details-page.tsx
+++ b/frontend/src/pages/game/game-details-page.tsx
@@ -10,8 +10,9 @@ import { ProfilePicture } from "../player/profile-picture";
 import { Fraction } from "../../client/client-db/predictions";
 import { WinPercentGraph } from "../add-game/win-percent-graph";
 import { replayWinPercentHistory } from "./game-win-replay";
-import { durationString, gameTimingStats, gapString, serveStats } from "./game-tracking-stats";
-import { GameTracking } from "../../client/client-db/event-store/event-types";
+import { pointPace } from "./game-tracking-stats";
+import { SetBreakdownTable, TrackingStats } from "./game-tracking-panels";
+import { PointPaceGraph } from "./point-pace-graph";
 
 /**
  * Details about a single game, identified by its played-at timestamp (unique
@@ -173,10 +174,17 @@ export const GameDetailsPage: React.FC = () => {
             </button>
           </div>
 
-          {/* How long the game took, and how each player did on their serve */}
+          {/* Everything the live tracker recorded: the timeline, the serves,
+              the sets one by one, and the pace of the points */}
           {game.score?.tracking && game.score.pointSequences && (
-            <div className="px-2 xs:px-4 pb-3">
+            <div className="px-2 xs:px-4 pb-3 space-y-3">
               <TrackingStats
+                tracking={game.score.tracking}
+                pointSequences={game.score.pointSequences}
+                winnerName={context.playerName(game.winner)}
+                loserName={context.playerName(game.loser)}
+              />
+              <SetBreakdownTable
                 tracking={game.score.tracking}
                 pointSequences={game.score.pointSequences}
                 winnerName={context.playerName(game.winner)}
@@ -185,10 +193,11 @@ export const GameDetailsPage: React.FC = () => {
             </div>
           )}
 
-          {/* Win % over the game, replayed from the point-by-point log */}
+          {/* Win % over the game and the time each point took, both replayed
+              from the point-by-point log and both on the same point scale */}
           <div className="px-2 xs:px-4 pb-4">
             {winPercentHistory && winPercentHistory.length >= 2 && game.score?.setPoints ? (
-              <div className="bg-white rounded-xl shadow-lg p-3 sm:p-4 text-black">
+              <div className="bg-white rounded-xl shadow-lg p-3 sm:p-4 text-black space-y-3">
                 <WinPercentGraph
                   history={winPercentHistory}
                   winnerIsPlayer1={true}
@@ -199,6 +208,15 @@ export const GameDetailsPage: React.FC = () => {
                     player2: set.gameLoser,
                   }))}
                 />
+                {game.score.tracking && game.score.pointSequences && (
+                  <PointPaceGraph
+                    pace={pointPace(game.score.pointSequences, game.score.tracking)}
+                    winnerName={context.playerName(game.winner)}
+                    loserName={context.playerName(game.loser)}
+                    winnerColor={stringToColor(game.winner)}
+                    loserColor={stringToColor(game.loser)}
+                  />
+                )}
               </div>
             ) : (
               <p className="text-center text-sm text-primary-text/60 py-2">
@@ -211,48 +229,6 @@ export const GameDetailsPage: React.FC = () => {
     </div>
   );
 };
-
-/**
- * The timeline and serve data of a tracked game. The gaps are the time between
- * two points being registered, so they include everything that happens between
- * the rallies, not the rally alone.
- */
-const TrackingStats: React.FC<{
-  tracking: GameTracking;
-  pointSequences: string[];
-  winnerName: string;
-  loserName: string;
-}> = ({ tracking, pointSequences, winnerName, loserName }) => {
-  const timing = gameTimingStats(tracking);
-  const serves = serveStats(pointSequences, tracking.firstServers);
-  const servePercent = (side: { served: number; won: number }) =>
-    side.served === 0 ? "–" : `${fmtNum((side.won / side.served) * 100)}%`;
-
-  return (
-    <div className="rounded-lg bg-secondary-background text-secondary-text p-3">
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-y-2 gap-x-3 text-center">
-        <StatCell label="Duration" value={durationString(timing.durationMs)} />
-        <StatCell
-          label="Sets"
-          value={timing.setDurationsMs.map((ms) => durationString(ms)).join(" · ")}
-        />
-        <StatCell label="Between points" value={gapString(timing.averagePointGapMs)} />
-        <StatCell label="Longest pause" value={gapString(timing.longestPointGapMs)} />
-      </div>
-      <div className="mt-3 pt-3 border-t border-secondary-text/20 grid grid-cols-2 gap-x-3 text-center">
-        <StatCell label={`${winnerName} on serve`} value={servePercent(serves.winner)} />
-        <StatCell label={`${loserName} on serve`} value={servePercent(serves.loser)} />
-      </div>
-    </div>
-  );
-};
-
-const StatCell: React.FC<{ label: string; value: string }> = ({ label, value }) => (
-  <div className="flex flex-col items-center min-w-0">
-    <span className="text-xs opacity-70 truncate max-w-full">{label}</span>
-    <span className="text-lg font-bold truncate max-w-full">{value}</span>
-  </div>
-);
 
 const PredictionCell: React.FC<{ label: string; prediction?: Fraction }> = ({ label, prediction }) => (
   <div className="flex flex-col items-center">

--- a/frontend/src/pages/game/game-tracking-panels.tsx
+++ b/frontend/src/pages/game/game-tracking-panels.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { GameTracking } from "../../client/client-db/event-store/event-types";
+import { clockTimeString } from "../../common/date-utils";
+import { fmtNum } from "../../common/number-utils";
+import {
+  durationString,
+  gameTimingStats,
+  gapString,
+  longestStreaks,
+  serveStats,
+  setBreakdown,
+} from "./game-tracking-stats";
+
+/**
+ * The timeline and serve data of a tracked game. The gaps are the time between
+ * two points being registered, so they include everything that happens between
+ * the rallies, not the rally alone.
+ */
+export const TrackingStats: React.FC<{
+  tracking: GameTracking;
+  pointSequences: string[];
+  winnerName: string;
+  loserName: string;
+}> = ({ tracking, pointSequences, winnerName, loserName }) => {
+  const timing = gameTimingStats(tracking);
+  const serves = serveStats(pointSequences, tracking.firstServers);
+  const streaks = longestStreaks(pointSequences);
+  const servePercent = (side: { served: number; won: number }) =>
+    side.served === 0 ? "–" : `${fmtNum((side.won / side.served) * 100)}%`;
+
+  return (
+    <div className="rounded-lg bg-secondary-background text-secondary-text p-3">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-y-2 gap-x-3 text-center">
+        <StatCell label="Duration" value={durationString(timing.durationMs)} />
+        <StatCell label="Started" value={clockTimeString(tracking.startedAt)} />
+        <StatCell label="Between points" value={gapString(timing.averagePointGapMs)} />
+        <StatCell label="Longest pause" value={gapString(timing.longestPointGapMs)} />
+      </div>
+
+      {/* Per player: points won on their own serve, and their longest run */}
+      <div className="mt-3 pt-3 border-t border-secondary-text/20 grid grid-cols-2 gap-y-2 gap-x-3 text-center">
+        <StatCell label={`${winnerName} on serve`} value={servePercent(serves.winner)} />
+        <StatCell label={`${loserName} on serve`} value={servePercent(serves.loser)} />
+        <StatCell label={`${winnerName} best run`} value={`${streaks.winner} points`} />
+        <StatCell label={`${loserName} best run`} value={`${streaks.loser} points`} />
+      </div>
+
+      {tracking.corrections > 0 && (
+        <p className="mt-3 text-xs opacity-70 text-center">
+          {tracking.corrections} {tracking.corrections === 1 ? "point was" : "points were"} undone while tracking, so
+          the times are less exact.
+        </p>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Every set of a tracked game: the score, who served the first point, how long
+ * the set took, and the break before it started.
+ */
+export const SetBreakdownTable: React.FC<{
+  tracking: GameTracking;
+  pointSequences: string[];
+  winnerName: string;
+  loserName: string;
+}> = ({ tracking, pointSequences, winnerName, loserName }) => {
+  const sets = setBreakdown(pointSequences, tracking);
+  if (sets.length === 0) return null;
+
+  return (
+    <div className="rounded-lg bg-secondary-background text-secondary-text p-3 overflow-x-auto">
+      <h2 className="text-sm font-semibold mb-2">Set by set</h2>
+      <table className="w-full text-xs md:text-sm">
+        <thead className="opacity-70">
+          <tr className="text-left">
+            <th className="font-normal pb-1 pr-2">Set</th>
+            <th className="font-normal pb-1 pr-2">Score</th>
+            <th className="font-normal pb-1 pr-2 whitespace-nowrap">First serve</th>
+            <th className="font-normal pb-1 pr-2 text-right">Time</th>
+            <th className="font-normal pb-1 pr-2 text-right">Break</th>
+            {/* The game's longest pause is in the card above, so a narrow
+                screen can drop the per-set one and keep the table unclipped. */}
+            <th className="font-normal pb-1 text-right whitespace-nowrap hidden sm:table-cell">Longest pause</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sets.map((set) => (
+            <tr key={set.set} className="border-t border-secondary-text/20">
+              <td className="py-1.5 pr-2">{set.set}</td>
+              <td className="py-1.5 pr-2 font-semibold whitespace-nowrap">
+                {set.points.winner}-{set.points.loser} {set.wonByGameWinner ? "🏆" : ""}
+              </td>
+              <td className="py-1.5 pr-2 truncate max-w-[8rem]">
+                {set.firstServer === "W" ? winnerName : loserName}
+              </td>
+              <td className="py-1.5 pr-2 text-right whitespace-nowrap">{durationString(set.durationMs)}</td>
+              <td className="py-1.5 pr-2 text-right whitespace-nowrap">{gapString(set.breakBeforeMs)}</td>
+              <td className="py-1.5 text-right whitespace-nowrap hidden sm:table-cell">
+                {gapString(set.longestPointGapMs)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p className="mt-2 text-xs opacity-70">
+        The score is from the game winner's side. The break is the time before the first point of the set — for set 1,
+        the time from the start of tracking.
+      </p>
+    </div>
+  );
+};
+
+const StatCell: React.FC<{ label: string; value: string }> = ({ label, value }) => (
+  <div className="flex flex-col items-center min-w-0">
+    <span className="text-xs opacity-70 truncate max-w-full">{label}</span>
+    <span className="text-lg font-bold truncate max-w-full">{value}</span>
+  </div>
+);

--- a/frontend/src/pages/game/game-tracking-stats.test.ts
+++ b/frontend/src/pages/game/game-tracking-stats.test.ts
@@ -1,5 +1,13 @@
 import { GameTracking } from "../../client/client-db/event-store/event-types";
-import { durationString, gameTimingStats, gapString, serveStats } from "./game-tracking-stats";
+import {
+  durationString,
+  gameTimingStats,
+  gapString,
+  longestStreaks,
+  pointPace,
+  serveStats,
+  setBreakdown,
+} from "./game-tracking-stats";
 
 function tracking(overrides: Partial<GameTracking> = {}): GameTracking {
   return {
@@ -23,12 +31,6 @@ describe("gameTimingStats", () => {
     expect(gameTimingStats(tracking()).durationMs).toBe(118_000);
   });
 
-  it("measures a set from its first point to its last point", () => {
-    // The first delta of a set is the wait before its first point, so it is
-    // not part of the set. Set 1 is 50 + 70 + 60, set 2 is 55 + 200 + 45.
-    expect(gameTimingStats(tracking()).setDurationsMs).toEqual([18_000, 30_000]);
-  });
-
   it("leaves the break between sets out of the gaps between points", () => {
     const stats = gameTimingStats(tracking());
     // The 600 tenth break and the 100 tenth start are both excluded.
@@ -41,6 +43,85 @@ describe("gameTimingStats", () => {
     expect(stats.longestPointGapMs).toBe(0);
     expect(stats.averagePointGapMs).toBe(0);
     expect(stats.durationMs).toBe(30_000);
+  });
+});
+
+describe("setBreakdown", () => {
+  // 4 points in set 1, 4 in set 2, matching the deltas of the tracking above.
+  const pointSequences = ["WWLW", "LWLL"];
+
+  it("reads the score and the winner of each set from the winner's side", () => {
+    const sets = setBreakdown(pointSequences, tracking());
+    expect(sets.map((set) => set.points)).toEqual([
+      { winner: 3, loser: 1 },
+      { winner: 1, loser: 3 },
+    ]);
+    expect(sets.map((set) => set.wonByGameWinner)).toEqual([true, false]);
+  });
+
+  it("splits the first delta of a set off as the break before it", () => {
+    const sets = setBreakdown(pointSequences, tracking());
+    // Set 1 starts 100 tenths in and runs 50 + 70 + 60 tenths.
+    expect(sets[0]).toMatchObject({ breakBeforeMs: 10_000, durationMs: 18_000, longestPointGapMs: 7_000 });
+    // Set 2 starts after a 600 tenth break and runs 55 + 200 + 45 tenths.
+    expect(sets[1]).toMatchObject({ breakBeforeMs: 60_000, durationMs: 30_000, longestPointGapMs: 20_000 });
+  });
+
+  it("reads the first server of each set", () => {
+    expect(setBreakdown(pointSequences, tracking()).map((set) => set.firstServer)).toEqual(["W", "L"]);
+  });
+
+  it("returns no rows for a game with no sets", () => {
+    expect(setBreakdown([], tracking({ pointDeltas: [], firstServers: "" }))).toEqual([]);
+  });
+});
+
+describe("longestStreaks", () => {
+  it("finds the longest run of points in a row for each player", () => {
+    expect(longestStreaks(["WWWLW", "LLWL"])).toEqual({ winner: 3, loser: 2 });
+  });
+
+  it("carries a run across a set boundary, because the points are consecutive", () => {
+    expect(longestStreaks(["LWW", "WWL"])).toEqual({ winner: 4, loser: 1 });
+  });
+
+  it("returns zero for a player who won no point", () => {
+    expect(longestStreaks(["WWW"])).toEqual({ winner: 3, loser: 0 });
+    expect(longestStreaks([])).toEqual({ winner: 0, loser: 0 });
+  });
+});
+
+describe("pointPace", () => {
+  const pointSequences = ["WWLW", "LWLL"];
+
+  it("gives the first point of each set no time, because that gap is the break", () => {
+    const pace = pointPace(pointSequences, tracking());
+    expect(pace[0].seconds).toBeNull();
+    expect(pace[4].seconds).toBeNull();
+  });
+
+  it("converts the other deltas to seconds", () => {
+    const pace = pointPace(pointSequences, tracking());
+    expect(pace.map((point) => point.seconds)).toEqual([null, 5, 7, 6, null, 5.5, 20, 4.5]);
+  });
+
+  it("numbers the points over the whole game and names the set of each", () => {
+    const pace = pointPace(pointSequences, tracking());
+    expect(pace.map((point) => point.point)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(pace.map((point) => point.set)).toEqual([1, 1, 1, 1, 2, 2, 2, 2]);
+  });
+
+  it("keeps who won each point", () => {
+    expect(pointPace(pointSequences, tracking()).map((point) => point.scoredBy)).toEqual([
+      "W",
+      "W",
+      "L",
+      "W",
+      "L",
+      "W",
+      "L",
+      "L",
+    ]);
   });
 });
 

--- a/frontend/src/pages/game/game-tracking-stats.ts
+++ b/frontend/src/pages/game/game-tracking-stats.ts
@@ -14,8 +14,6 @@ const TENTH_MS = 100;
 export type GameTimingStats = {
   /** Ms from the start of tracking to the last point. */
   durationMs: number;
-  /** Ms each set took, from its first point to its last point. */
-  setDurationsMs: number[];
   /** Ms between two points, on average, excluding the breaks between sets. */
   averagePointGapMs: number;
   /** The longest gap between two points, excluding the breaks between sets. */
@@ -39,13 +37,101 @@ export function gameTimingStats(tracking: GameTracking): GameTimingStats {
   );
   return {
     durationMs: totalTenths * TENTH_MS,
-    setDurationsMs: tracking.pointDeltas.map(
-      (deltas) => deltas.slice(1).reduce((sum, delta) => sum + delta, 0) * TENTH_MS,
-    ),
     averagePointGapMs:
       gaps.length === 0 ? 0 : (gaps.reduce((sum, gap) => sum + gap, 0) / gaps.length) * TENTH_MS,
     longestPointGapMs: gaps.length === 0 ? 0 : Math.max(...gaps) * TENTH_MS,
   };
+}
+
+export type SetBreakdown = {
+  /** 1-based number of the set. */
+  set: number;
+  points: { winner: number; loser: number };
+  /** True when the game winner also won this set. */
+  wonByGameWinner: boolean;
+  /** Who served the first point of the set. */
+  firstServer: "W" | "L";
+  /** Ms from the first point of the set to its last point. */
+  durationMs: number;
+  /** Ms between the last point of the previous set and the first of this one. */
+  breakBeforeMs: number;
+  /** The longest gap between two points of this set. */
+  longestPointGapMs: number;
+};
+
+/**
+ * One row per set: the score, who served it first, and how long it took. The
+ * first delta of a set is the break before it, so it is the break time and not
+ * part of the duration of the set.
+ */
+export function setBreakdown(pointSequences: string[], tracking: GameTracking): SetBreakdown[] {
+  return pointSequences.map((sequence, index) => {
+    const deltas = tracking.pointDeltas[index] ?? [];
+    const gaps = deltas.slice(1);
+    const winnerPoints = sequence.split("").filter((point) => point === "W").length;
+    return {
+      set: index + 1,
+      points: { winner: winnerPoints, loser: sequence.length - winnerPoints },
+      wonByGameWinner: winnerPoints > sequence.length - winnerPoints,
+      firstServer: tracking.firstServers[index] === "W" ? "W" : "L",
+      durationMs: gaps.reduce((sum, gap) => sum + gap, 0) * TENTH_MS,
+      breakBeforeMs: (deltas[0] ?? 0) * TENTH_MS,
+      longestPointGapMs: gaps.length === 0 ? 0 : Math.max(...gaps) * TENTH_MS,
+    };
+  });
+}
+
+/** The longest run of points in a row that each player won, over the game. */
+export function longestStreaks(pointSequences: string[]): { winner: number; loser: number } {
+  const longest = { winner: 0, loser: 0 };
+  let current = 0;
+  let currentPoint = "";
+
+  // A streak carries across a set boundary: the points are still consecutive.
+  for (const point of pointSequences.join("")) {
+    current = point === currentPoint ? current + 1 : 1;
+    currentPoint = point;
+    const side = point === "W" ? "winner" : "loser";
+    longest[side] = Math.max(longest[side], current);
+  }
+
+  return longest;
+}
+
+export type PacePoint = {
+  /** 1-based number of the point over the whole game. */
+  point: number;
+  /**
+   * Seconds since the previous point of the same set, or null for the first
+   * point of a set. That first gap is the break before the set, not the pace
+   * of the game.
+   */
+  seconds: number | null;
+  /** Which player won the point. */
+  scoredBy: "W" | "L";
+  /** 1-based number of the set the point belongs to. */
+  set: number;
+};
+
+/** The time each point took, in the order the points were scored. */
+export function pointPace(pointSequences: string[], tracking: GameTracking): PacePoint[] {
+  const pace: PacePoint[] = [];
+  let point = 0;
+
+  pointSequences.forEach((sequence, setIndex) => {
+    const deltas = tracking.pointDeltas[setIndex] ?? [];
+    sequence.split("").forEach((scoredBy, pointIndex) => {
+      point++;
+      pace.push({
+        point,
+        seconds: pointIndex === 0 ? null : (deltas[pointIndex] ?? 0) / 10,
+        scoredBy: scoredBy === "W" ? "W" : "L",
+        set: setIndex + 1,
+      });
+    });
+  });
+
+  return pace;
 }
 
 export type ServeStats = {

--- a/frontend/src/pages/game/point-pace-graph.tsx
+++ b/frontend/src/pages/game/point-pace-graph.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { Bar, BarChart, CartesianGrid, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { readableOn } from "../../common/color-utils";
+import { ROW_SURFACE } from "../../common/player-color-styles";
+import { PacePoint } from "./game-tracking-stats";
+
+type Props = {
+  pace: PacePoint[];
+  winnerName: string;
+  loserName: string;
+  winnerColor: string;
+  loserColor: string;
+};
+
+/**
+ * How long each point took, one bar per point, under the win % graph and on the
+ * same point scale. The bar is coloured by who won the point, so a run of long
+ * points and who took them read together.
+ *
+ * The first point of a set has no bar: the time before it is the break after
+ * the previous set, not the pace of the game. The set table carries that.
+ */
+export const PointPaceGraph: React.FC<Props> = ({ pace, winnerName, loserName, winnerColor, loserColor }) => {
+  const timed = pace.filter((point) => point.seconds !== null);
+  if (timed.length < 2) return null;
+
+  // Player colours run from near-black to near-white, so darken pale ones the
+  // same way the score text and the win % line do.
+  const winnerFill = readableOn(winnerColor, ROW_SURFACE);
+  const loserFill = readableOn(loserColor, ROW_SURFACE);
+
+  const data = pace.map((point) => ({
+    ...point,
+    // Recharts skips a null bar, which keeps the x scale aligned with the win %
+    // graph above: both count every point of the game.
+    winnerSeconds: point.scoredBy === "W" ? point.seconds : null,
+    loserSeconds: point.scoredBy === "L" ? point.seconds : null,
+  }));
+
+  // The last point of each set, so a line can mark where the set ended.
+  const setBoundaries = pace
+    .filter((point, index) => pace[index + 1] && pace[index + 1].set !== point.set)
+    .map((point) => point.point);
+
+  return (
+    <div className="bg-gray-50 rounded-lg p-4">
+      <h3 className="text-base font-bold text-gray-800 mb-1">Time per point</h3>
+      <p className="text-xs text-gray-500 mb-2">Seconds since the previous point, coloured by who won it</p>
+
+      {/* Two series, so identity never rests on colour alone. */}
+      <div className="flex flex-wrap gap-x-4 gap-y-1 mb-2 text-xs text-gray-600">
+        <LegendKey color={winnerFill} name={winnerName} />
+        <LegendKey color={loserFill} name={loserName} />
+      </div>
+
+      <ResponsiveContainer width="100%" height={140}>
+        <BarChart data={data} margin={{ top: 8, right: 12, left: 0, bottom: 0 }} barCategoryGap={2}>
+          <CartesianGrid vertical={false} stroke="#e5e7eb" />
+          <XAxis dataKey="point" type="category" tick={false} axisLine={{ stroke: "#d1d5db" }} height={4} />
+          <YAxis
+            tickFormatter={(value) => `${value}s`}
+            tick={{ fontSize: 10, fill: "#6b7280" }}
+            axisLine={false}
+            tickLine={false}
+            width={34}
+          />
+          <Tooltip
+            animationDuration={0}
+            cursor={{ fill: "#00000010" }}
+            content={({ active, payload }) => {
+              if (!active || !payload || payload.length === 0) return null;
+              const point = payload[0].payload as PacePoint;
+              if (point.seconds === null) return null;
+              return (
+                <div className="rounded-lg bg-white p-2 text-xs text-gray-700 shadow ring-1 ring-gray-300">
+                  <p className="font-semibold">
+                    Point {point.point} · Set {point.set}
+                  </p>
+                  <p>
+                    {point.seconds.toFixed(1)}s to {point.scoredBy === "W" ? winnerName : loserName}
+                  </p>
+                </div>
+              );
+            }}
+          />
+          {/* The win % graph above marks the same boundaries with a label, so
+              these lines only have to line up with it. A second set of labels
+              collides with a tall bar and says nothing new. */}
+          {setBoundaries.map((boundary) => (
+            <ReferenceLine key={boundary} x={boundary} stroke="#9ca3af" strokeDasharray="4 4" />
+          ))}
+          {/* One stack, so the 2 series share a slot and every bar sits on the
+              same baseline. Only 1 of them has a value for a given point. */}
+          <Bar dataKey="winnerSeconds" stackId="point" fill={winnerFill} radius={[2, 2, 0, 0]} maxBarSize={24} />
+          <Bar dataKey="loserSeconds" stackId="point" fill={loserFill} radius={[2, 2, 0, 0]} maxBarSize={24} />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+const LegendKey: React.FC<{ color: string; name: string }> = ({ color, name }) => (
+  <span className="flex items-center gap-1.5 min-w-0">
+    <span className="w-2.5 h-2.5 rounded-sm shrink-0" style={{ backgroundColor: color }} />
+    <span className="truncate">{name}</span>
+  </span>
+);

--- a/frontend/src/pages/game/point-pace-graph.tsx
+++ b/frontend/src/pages/game/point-pace-graph.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Bar, BarChart, CartesianGrid, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
-import { readableOn } from "../../common/color-utils";
-import { ROW_SURFACE } from "../../common/player-color-styles";
+import { markOn, ROW_SURFACE } from "../../common/player-color-styles";
 import { PacePoint } from "./game-tracking-stats";
 
 type Props = {
@@ -24,10 +23,9 @@ export const PointPaceGraph: React.FC<Props> = ({ pace, winnerName, loserName, w
   const timed = pace.filter((point) => point.seconds !== null);
   if (timed.length < 2) return null;
 
-  // Player colours run from near-black to near-white, so darken pale ones the
-  // same way the score text and the win % line do.
-  const winnerFill = readableOn(winnerColor, ROW_SURFACE);
-  const loserFill = readableOn(loserColor, ROW_SURFACE);
+  // Each player's own colour, the one they have everywhere else in the app.
+  const winnerFill = markOn(winnerColor, ROW_SURFACE);
+  const loserFill = markOn(loserColor, ROW_SURFACE);
 
   const data = pace.map((point) => ({
     ...point,


### PR DESCRIPTION
Builds on the timing and serve data from #172, which was recorded but only partly shown.

## What the game details page gains

**A "Set by set" table** — one row per set: the score, who served the first point, how long the set took, and the break before it started. The per-set longest pause is hidden below the `sm` breakpoint so the table never clips on a phone.

**A "Time per point" graph** — a bar per point, under the win % graph and on the same point scale, coloured by the player who won the point. The first point of a set has no bar: that gap is the break after the previous set, and at ~60s it would dwarf every real point. The set table carries it instead.

**More in the stats card** — the time the match started (from `tracking.startedAt`, the real start, not the submit time), and each player's longest run of points in a row. It also warns when points were undone while tracking, so a hand-corrected log is not read as exact. The per-set durations move out to the table, which says more in the same space.

## Notes

- Two panels move out of `game-details-page.tsx` into `game-tracking-panels.tsx`, so the page reads as composition.
- The win % graph's grid becomes solid instead of dashed, so it matches the graph now sitting directly under it, and its bottom margin moves out to the call sites — the track game summary keeps the spacing it had.
- The changelog edits the post from #172 rather than adding a new one: this extends a feature that shipped a day ago, and that post is what people will read.

## Verification

- 836 tests pass, 10 new ones covering `setBreakdown`, `longestStreaks` and `pointPace`.
- `tsc --noEmit`, eslint and the production build are clean.
- Both panels and the graph were rendered in the running app and screenshotted at 760px and 380px. The mobile pass is what caught the clipped table column and a set label colliding with a tall bar; both are fixed, and neither width scrolls sideways.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmSeinhGxwaEpcuAs37NMi)_