### PR TITLE
Refactor recently retired players display in Hall of Fame

### DIFF
--- a/frontend/src/pages/hall-of-fame/hall-of-fame-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-page.tsx
@@ -4,6 +4,7 @@ import { useEventDbContext } from "../../wrappers/event-db-context";
 import { ProfilePicture } from "../player/profile-picture";
 import { fmtNum } from "../../common/number-utils";
 import { RelativeTime } from "../../common/date-utils";
+import { isRecentlyRetired } from "./recently-retired";
 
 export const HallOfFamePage: React.FC = () => {
   const context = useEventDbContext();
@@ -44,6 +45,11 @@ export const HallOfFamePage: React.FC = () => {
                       <div className="flex items-center gap-2 min-w-0">
                         <ProfilePicture playerId={entry.playerId} size={28} border={2} />
                         <span className="font-normal truncate">{entry.playerName}</span>
+                        {player && isRecentlyRetired(player) && (
+                          <span className="bg-secondary-background text-secondary-text text-xs px-2 py-0.5 rounded-full font-normal shrink-0">
+                            Recent
+                          </span>
+                        )}
                       </div>
                     </td>
                     <td className="py-1 px-2 text-right w-[1%] whitespace-nowrap">{fmtNum(entry.score.total)}</td>

--- a/frontend/src/pages/hall-of-fame/recently-retired.ts
+++ b/frontend/src/pages/hall-of-fame/recently-retired.ts
@@ -1,0 +1,7 @@
+import { Player } from "../../client/client-db/event-store/projectors/players-projector";
+
+export const RECENTLY_RETIRED_WINDOW = 7 * 24 * 60 * 60 * 1000;
+
+export function isRecentlyRetired(player: Player): boolean {
+  return player.active === false && Date.now() - player.updatedAt < RECENTLY_RETIRED_WINDOW;
+}

--- a/frontend/src/pages/leaderboard/recent-hall-of-fame.tsx
+++ b/frontend/src/pages/leaderboard/recent-hall-of-fame.tsx
@@ -3,59 +3,62 @@ import { Link } from "react-router-dom";
 import { useEventDbContext } from "../../wrappers/event-db-context";
 import { ProfilePicture } from "../player/profile-picture";
 import { fmtNum } from "../../common/number-utils";
-
-const ONE_WEEK = 7 * 24 * 60 * 60 * 1000;
+import { isRecentlyRetired } from "../hall-of-fame/recently-retired";
 
 export const RecentHallOfFame: React.FC = () => {
   const context = useEventDbContext();
 
-  const recentlyRetired = context.eventStore.playersProjector.inactivePlayers.filter(
-    (player) => !player.active && Date.now() - player.updatedAt < ONE_WEEK,
-  );
+  const recentlyRetired = context.eventStore.playersProjector.inactivePlayers
+    .filter(isRecentlyRetired)
+    .sort((a, b) => b.updatedAt - a.updatedAt);
 
   if (recentlyRetired.length === 0) return null;
 
+  const multiple = recentlyRetired.length > 1;
+
   return (
-    <div className="w-full flex flex-col gap-2">
-      {recentlyRetired.map((player) => {
-        const entry = context.hallOfFame.getPlayerScore(player.id);
-        return (
-          <Link
-            key={player.id}
-            to={`/hall-of-fame/${player.id}`}
-            className="w-full rounded-lg p-3 text-white shadow-lg transition-all bg-gradient-to-r from-amber-600 via-yellow-500 to-amber-600 hover:from-amber-500 hover:via-yellow-400 hover:to-amber-500"
-          >
-            <div className="flex items-center justify-between mb-2">
-              <div className="flex items-center gap-2">
-                <span className="text-lg">🏛️</span>
-                <span className="text-xs font-bold uppercase tracking-wider">
-                  Hall of Fame — Newly Retired
-                </span>
-              </div>
-              <span className="text-xs opacity-80">Tap to honor</span>
-            </div>
-            <div className="flex items-center justify-between gap-3">
+    <Link
+      to={multiple ? "/hall-of-fame" : `/hall-of-fame/${recentlyRetired[0].id}`}
+      className="w-full rounded-lg p-3 text-white shadow-lg transition-all bg-gradient-to-r from-amber-600 via-yellow-500 to-amber-600 hover:from-amber-500 hover:via-yellow-400 hover:to-amber-500"
+    >
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <span className="text-lg">🏛️</span>
+          <span className="text-xs font-bold uppercase tracking-wider">Hall of Fame — Newly Retired</span>
+        </div>
+        <span className="text-xs opacity-80">Tap to honor</span>
+      </div>
+      <div className="flex flex-col gap-2">
+        {recentlyRetired.map((player) => {
+          const entry = context.hallOfFame.getPlayerScore(player.id);
+          return (
+            <div key={player.id} className="flex items-center justify-between gap-3">
               <div className="flex items-center gap-3 min-w-0">
-                <ProfilePicture playerId={player.id} size={48} border={2} />
+                <ProfilePicture playerId={player.id} size={multiple ? 36 : 48} border={2} />
                 <div className="flex flex-col min-w-0">
                   <span className="font-bold text-lg truncate">{player.name}</span>
-                  <span className="text-xs uppercase tracking-wider opacity-80">
-                    Thank you for the games ❤️
-                  </span>
+                  {multiple === false && (
+                    <span className="text-xs uppercase tracking-wider opacity-80">Thank you for the games ❤️</span>
+                  )}
                 </div>
               </div>
-              {entry && (
-                <div className="flex flex-col items-center shrink-0">
-                  <span className="text-[10px] font-bold uppercase tracking-wider opacity-70">
-                    HoF Score
-                  </span>
-                  <span className="text-2xl font-black">{fmtNum(entry.score.total)}</span>
-                </div>
-              )}
+              {entry &&
+                (multiple ? (
+                  <div className="flex items-center gap-1.5 shrink-0">
+                    <span className="text-[10px] font-bold uppercase tracking-wider opacity-70">HoF</span>
+                    <span className="text-xl font-black">{fmtNum(entry.score.total)}</span>
+                  </div>
+                ) : (
+                  <div className="flex flex-col items-center shrink-0">
+                    <span className="text-[10px] font-bold uppercase tracking-wider opacity-70">HoF Score</span>
+                    <span className="text-2xl font-black">{fmtNum(entry.score.total)}</span>
+                  </div>
+                ))}
             </div>
-          </Link>
-        );
-      })}
-    </div>
+          );
+        })}
+      </div>
+      {multiple && <div className="text-xs uppercase tracking-wider opacity-80 mt-2">Thank you for the games ❤️</div>}
+    </Link>
   );
 };


### PR DESCRIPTION
## Summary
Consolidates the "recently retired" player detection logic into a reusable utility function and refactors the Recent Hall of Fame component to display multiple recently retired players in a single card, with responsive styling based on the number of players shown.

## Key Changes
- **Extract reusable logic:** Created `recently-retired.ts` with `isRecentlyRetired()` function and `RECENTLY_RETIRED_WINDOW` constant to centralize the 7-day retirement window check
- **Refactor Recent Hall of Fame display:** Changed from rendering individual cards per player to a single consolidated card that adapts based on player count:
  - Single player: Shows full details with larger profile picture (48px) and descriptive message
  - Multiple players: Shows compact list with smaller profile pictures (36px) and abbreviated HoF label
- **Add recent badge:** Hall of Fame page now displays a "Recent" badge next to players who were recently retired
- **Improve sorting:** Recently retired players are now sorted by retirement date (most recent first)

## Implementation Details
- The `isRecentlyRetired()` function is now used consistently across both the Recent Hall of Fame component and the Hall of Fame page
- The consolidated card links to the individual player's Hall of Fame page when a single player is shown, or to the full Hall of Fame page when multiple players are shown
- Responsive layout uses conditional rendering to adjust typography, spacing, and component sizes based on the `multiple` flag

https://claude.ai/code/session_01EamWzNX2DuCzigk97rd3NX