### PR TITLE
Score players who join or leave a leaderboard on What changed

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -208,7 +208,7 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
         "The new What changed page shows what changed in a period that you select. Buttons select common periods: the last game, today, or the last 7, 30 or 365 days. The Custom button shows two inputs for a start time and an end time.",
       ),
       text(
-        "The Leaderboards tab compares the overall leaderboard, the season leaderboard or the Hall of Fame score at the two times. A table shows each player with the rank and the score at the start, at the end, and the change in both. A toggle sorts the table by the rank at the start, the rank at the end, or the change in score.",
+        "The Leaderboards tab compares the overall leaderboard, the season leaderboard or the Hall of Fame score at the two times. A table shows each player with the rank and the score at the start, at the end, and the change in both. A toggle sorts the table by the rank at the start, the rank at the end, or the change in score. A player who joins or leaves a leaderboard in the period also gets a score change. The season score and the Hall of Fame score start at 0, and the overall leaderboard uses the elo of the player.",
       ),
       text(
         "On the overall leaderboard, a second toggle changes the data source between the actual leaderboard and the expected leaderboard. The expected leaderboard is the average of 5 000 simulations at each of the two times.",

--- a/frontend/src/pages/admin/admin-page.tsx
+++ b/frontend/src/pages/admin/admin-page.tsx
@@ -29,6 +29,7 @@ import { PlayersTab } from "./players";
 import { PlayerDiversityChart } from "./player-diversity-chart";
 import { PlayerGameCount } from "./player-game-count";
 import { HallOfFameCategoryBalance } from "./hall-of-fame-category-balance";
+import { PointSequenceMarker } from "../game/point-sequence-marker";
 
 type TabType = "stats" | "games" | "players" | "users" | "events" | "local";
 const tabs: { id: TabType; label: string }[] = [
@@ -336,11 +337,16 @@ export const AdminPage: React.FC = () => {
                         })}
                       </p>
                     </td>
-                    <td className="border border-gray-300 px-1 md:px-4 py-0.5 md:py-1">
-                      {game.score && (
+                    <td
+                      className="border border-gray-300 px-1 md:px-4 py-0.5 md:py-1 cursor-pointer hover:bg-blue-500/20"
+                      title="Game details"
+                      onClick={() => navigate(`/game?time=${game.playedAt}`)}
+                    >
+                      {game.score ? (
                         <div className="flex flex-col">
                           <span className="text-xs md:text-base font-bold whitespace-nowrap">
                             {game.score.setsWon.gameWinner}-{game.score.setsWon.gameLoser}
+                            <PointSequenceMarker score={game.score} />
                           </span>
                           {game.score.setPoints && (
                             <span className="text-[10px] md:text-xs whitespace-nowrap">
@@ -350,6 +356,9 @@ export const AdminPage: React.FC = () => {
                             </span>
                           )}
                         </div>
+                      ) : (
+                        // A game with no score still opens its details page.
+                        <span className="opacity-40">-</span>
                       )}
                     </td>
                     <td className="border border-gray-300 px-1 md:px-4 py-0.5 md:py-1 text-center">

--- a/frontend/src/pages/admin/hall-of-fame-category-balance.tsx
+++ b/frontend/src/pages/admin/hall-of-fame-category-balance.tsx
@@ -35,7 +35,7 @@ export const HallOfFameCategoryBalance: React.FC = () => {
   return (
     <div className="bg-primary-background text-primary-text rounded-lg my-6">
       <h2 className="text-xl font-semibold text-center mb-1">Hall of Fame score per category</h2>
-      <p className="text-sm text-center opacity-75 mb-4">
+      <p className="text-sm text-center mb-4">
         Sum over all players, active and retired. An even spread means the categories are balanced.
       </p>
 
@@ -48,21 +48,25 @@ export const HallOfFameCategoryBalance: React.FC = () => {
               <div className="truncate">
                 {row.emoji} {row.name}
               </div>
-              <div className="h-5 rounded bg-secondary-background/40">
+              {/* Only full theme colors, in the pairs the themes define: the
+                  track is the secondary background and the bar is the secondary
+                  text. A tertiary color on a faded secondary background has
+                  almost no contrast in some themes. */}
+              <div className="h-5 rounded ring-1 ring-secondary-background bg-secondary-background">
                 <div
-                  className="h-5 rounded bg-tertiary-background"
+                  className="h-5 rounded bg-secondary-text"
                   style={{ width: `${Math.max(barWidth, row.total > 0 ? 1 : 0)}%` }}
                 />
               </div>
               <div className="text-right tabular-nums whitespace-nowrap">
-                {fmtNum(Math.round(row.total))} <span className="opacity-60">({share.toFixed(1)}%)</span>
+                {fmtNum(Math.round(row.total))} ({share.toFixed(1)}%)
               </div>
             </div>
           );
         })}
       </div>
 
-      <div className="mt-4 text-sm text-center opacity-75">
+      <div className="mt-4 text-sm text-center">
         Players: {fmtNum(playerCount)} | Total points: {fmtNum(Math.round(grandTotal))}
       </div>
     </div>

--- a/frontend/src/pages/other/what-changed-diff.test.ts
+++ b/frontend/src/pages/other/what-changed-diff.test.ts
@@ -1,0 +1,66 @@
+import { absentScoreZero, buildDiffRows, RankedEntry, scoreDelta } from "./what-changed-diff";
+
+const entry = (id: string, rank: number, score: number): RankedEntry => ({ id, rank, score });
+
+describe("what changed diff rows", () => {
+  const start = [entry("a", 1, 1_100), entry("b", 2, 1_000)];
+
+  it("sorts by the rank at the start and at the end", () => {
+    const end = [entry("b", 1, 1_050), entry("a", 2, 1_050)];
+
+    expect(buildDiffRows(start, end, "start").map((row) => row.playerId)).toEqual(["a", "b"]);
+    expect(buildDiffRows(start, end, "end").map((row) => row.playerId)).toEqual(["b", "a"]);
+  });
+
+  it("puts a player who is absent from the sorted leaderboard last", () => {
+    const end = [entry("c", 1, 1_200), ...start];
+    const rows = buildDiffRows(start, end, "start");
+    expect(rows.map((row) => row.playerId)).toEqual(["a", "b", "c"]);
+  });
+
+  it("sorts by the score delta, biggest gain first", () => {
+    const end = [entry("b", 1, 1_200), entry("a", 2, 1_000)];
+    const rows = buildDiffRows(start, end, "delta");
+    expect(rows.map((row) => row.playerId)).toEqual(["b", "a"]);
+  });
+
+  describe("a player who joins the leaderboard", () => {
+    // The Hall of Fame score and the season score of a new player start at 0.
+    const end = [entry("c", 1, 1_200), entry("a", 2, 1_100), entry("b", 3, 1_000)];
+
+    it("gains the full score when the score starts at 0", () => {
+      const rows = buildDiffRows(start, end, "delta", absentScoreZero);
+      expect(rows.map((row) => row.playerId)).toEqual(["c", "a", "b"]);
+      expect(scoreDelta(rows[0], absentScoreZero)).toBe(1_200);
+    });
+
+    it("gains the change of the score that it had while absent", () => {
+      // The overall leaderboard reads the elo of an unranked player instead.
+      const eloWhileAbsent = () => 1_150;
+      const rows = buildDiffRows(start, end, "delta", eloWhileAbsent);
+      expect(rows.map((row) => row.playerId)).toEqual(["c", "a", "b"]);
+      expect(scoreDelta(rows[0], eloWhileAbsent)).toBe(50);
+    });
+
+    it("sorts last with no delta when no absent score exists", () => {
+      const rows = buildDiffRows(start, end, "delta");
+      expect(rows.map((row) => row.playerId)).toEqual(["a", "b", "c"]);
+      expect(scoreDelta(rows[2])).toBeUndefined();
+    });
+  });
+
+  it("scores a player who leaves the leaderboard as a loss", () => {
+    const end = [entry("a", 1, 1_100)];
+    const rows = buildDiffRows(start, end, "delta", absentScoreZero);
+    expect(rows.map((row) => row.playerId)).toEqual(["a", "b"]);
+    expect(scoreDelta(rows[1], absentScoreZero)).toBe(-1_000);
+  });
+
+  it("uses the absent score of the side that the player is absent from", () => {
+    const absent = (playerId: string, side: "start" | "end") => (side === "start" ? 10 : 20);
+
+    expect(scoreDelta({ playerId: "a", endScore: 100 }, absent)).toBe(90);
+    expect(scoreDelta({ playerId: "a", startScore: 100 }, absent)).toBe(-80);
+    expect(scoreDelta({ playerId: "a", startScore: 100, endScore: 120 }, absent)).toBe(20);
+  });
+});

--- a/frontend/src/pages/other/what-changed-diff.ts
+++ b/frontend/src/pages/other/what-changed-diff.ts
@@ -1,0 +1,89 @@
+// Row and sort logic of the What changed leaderboard diff tables.
+
+/** One entry of a leaderboard: the player, the rank and the score. */
+export type RankedEntry = { id: string; rank: number; score: number };
+
+/**
+ * The rank and the score of one player at the two selected times. A missing
+ * rank or score means the player was not on the leaderboard at that time.
+ */
+export type DiffRow = {
+  playerId: string;
+  startRank?: number;
+  endRank?: number;
+  startScore?: number;
+  endScore?: number;
+};
+
+export type SortBy = "start" | "end" | "delta";
+
+/**
+ * The score of a player who is absent from one of the two leaderboards. It
+ * makes the score delta of a player who joins or leaves the leaderboard
+ * comparable to the delta of a player who is on both leaderboards.
+ *
+ * A Hall of Fame score and a season score start at 0, so a player who joins
+ * gains the full score. An elo has no such start point, so the overall
+ * leaderboard reads the elo that the player had at that time instead. A
+ * function that returns undefined leaves the delta unknown.
+ */
+export type AbsentScore = (playerId: string, side: "start" | "end") => number | undefined;
+
+/** For a leaderboard whose score starts at 0. */
+export const absentScoreZero: AbsentScore = () => 0;
+
+/** The score change between the two times, or undefined when it is unknown. */
+export function scoreDelta(row: DiffRow, absentScore?: AbsentScore): number | undefined {
+  const start = row.startScore ?? absentScore?.(row.playerId, "start");
+  const end = row.endScore ?? absentScore?.(row.playerId, "end");
+  if (start === undefined || end === undefined) return undefined;
+  return end - start;
+}
+
+// Ascending rank order. A missing rank sorts last.
+function compareRank(a: number | undefined, b: number | undefined): number {
+  if (a === b) return 0;
+  if (a === undefined) return 1;
+  if (b === undefined) return -1;
+  return a - b;
+}
+
+// Biggest score gain first. A row with an unknown delta sorts last.
+function compareDelta(a: number | undefined, b: number | undefined): number {
+  if (a === b) return 0;
+  if (a === undefined) return 1;
+  if (b === undefined) return -1;
+  return b - a;
+}
+
+/** One row per player on either leaderboard, in the selected sort order. */
+export function buildDiffRows(
+  startEntries: RankedEntry[] | undefined,
+  endEntries: RankedEntry[] | undefined,
+  sortBy: SortBy,
+  absentScore?: AbsentScore,
+): DiffRow[] {
+  const rowMap = new Map<string, DiffRow>();
+  startEntries?.forEach((player) => {
+    rowMap.set(player.id, { playerId: player.id, startRank: player.rank, startScore: player.score });
+  });
+  endEntries?.forEach((player) => {
+    const row = rowMap.get(player.id) ?? { playerId: player.id };
+    row.endRank = player.rank;
+    row.endScore = player.score;
+    rowMap.set(player.id, row);
+  });
+
+  const list = Array.from(rowMap.values());
+
+  if (sortBy === "delta") {
+    return list.sort(
+      (a, b) =>
+        compareDelta(scoreDelta(a, absentScore), scoreDelta(b, absentScore)) || compareRank(a.endRank, b.endRank),
+    );
+  }
+
+  const sortRank = (row: DiffRow) => (sortBy === "start" ? row.startRank : row.endRank);
+  const fallbackRank = (row: DiffRow) => (sortBy === "start" ? row.endRank : row.startRank);
+  return list.sort((a, b) => compareRank(sortRank(a), sortRank(b)) || compareRank(fallbackRank(a), fallbackRank(b)));
+}

--- a/frontend/src/pages/other/what-changed-page.tsx
+++ b/frontend/src/pages/other/what-changed-page.tsx
@@ -13,8 +13,9 @@ import { Game } from "../../client/client-db/event-store/projectors/games-projec
 import { Achievement } from "../../client/client-db/achievements";
 import { getAchievementLabel } from "../player/player-achievements";
 import { ProfilePicture } from "../player/profile-picture";
+import { Elo } from "../../client/client-db/elo";
+import { AbsentScore, absentScoreZero, buildDiffRows, RankedEntry, scoreDelta, SortBy } from "./what-changed-diff";
 
-type SortBy = "start" | "end" | "delta";
 type Source = "actual" | "expected";
 
 type Tab = "leaderboards" | "games" | "achievements";
@@ -42,16 +43,6 @@ const ACHIEVEMENTS_PAGE_SIZE = 50;
 const ROW_GRID =
   "grid grid-cols-[minmax(0,1fr)_2.25rem_2.25rem_2.5rem_3rem_3rem_3.25rem] md:grid-cols-[minmax(0,1fr)_3.5rem_3.5rem_3.5rem_4.5rem_4.5rem_4.5rem] items-center";
 const NUM_CELL = "self-stretch flex items-center justify-end py-1 px-1 md:px-2 whitespace-nowrap";
-
-type DiffRow = {
-  playerId: string;
-  startRank?: number;
-  endRank?: number;
-  startScore?: number;
-  endScore?: number;
-};
-
-type RankedEntry = { id: string; rank: number; score: number };
 
 function useDebounced<T>(value: T, ms: number): T {
   const [debounced, setDebounced] = useState(value);
@@ -205,35 +196,22 @@ const DiffTable: React.FC<{
   sortBy: SortBy;
   emptyText: string;
   scoreDigits?: number;
+  // The score of a player who is on only one of the two leaderboards, so the
+  // score delta of a player who joins or leaves stays comparable.
+  absentScore?: AbsentScore;
   onRowClick: (playerId: string) => void;
-}> = ({ startEntries, endEntries, sortBy, emptyText, scoreDigits = 0, onRowClick }) => {
+}> = ({ startEntries, endEntries, sortBy, emptyText, scoreDigits = 0, absentScore, onRowClick }) => {
   const context = useEventDbContext();
 
-  const rows = useMemo(() => {
-    const rowMap = new Map<string, DiffRow>();
-    startEntries?.forEach((player) => {
-      rowMap.set(player.id, { playerId: player.id, startRank: player.rank, startScore: player.score });
-    });
-    endEntries?.forEach((player) => {
-      const row = rowMap.get(player.id) ?? { playerId: player.id };
-      row.endRank = player.rank;
-      row.endScore = player.score;
-      rowMap.set(player.id, row);
-    });
+  // A missing entry list means the leaderboard at that time is not known. The
+  // absent score then does not apply - it scores a player who is not on a
+  // leaderboard that the table has.
+  const knownAbsentScore = startEntries !== undefined && endEntries !== undefined ? absentScore : undefined;
 
-    const list = Array.from(rowMap.values());
-
-    if (sortBy === "delta") {
-      // Biggest score gain first; rows without a delta go to the bottom.
-      const scoreDelta = (row: DiffRow) =>
-        row.startScore !== undefined && row.endScore !== undefined ? row.endScore - row.startScore : -Infinity;
-      return list.sort((a, b) => scoreDelta(b) - scoreDelta(a) || (a.endRank ?? Infinity) - (b.endRank ?? Infinity));
-    }
-
-    const sortRank = (row: DiffRow) => (sortBy === "start" ? row.startRank : row.endRank) ?? Infinity;
-    const fallbackRank = (row: DiffRow) => (sortBy === "start" ? row.endRank : row.startRank) ?? Infinity;
-    return list.sort((a, b) => sortRank(a) - sortRank(b) || fallbackRank(a) - fallbackRank(b));
-  }, [startEntries, endEntries, sortBy]);
+  const rows = useMemo(
+    () => buildDiffRows(startEntries, endEntries, sortBy, knownAbsentScore),
+    [startEntries, endEntries, sortBy, knownAbsentScore],
+  );
 
   const stableRows = useMemo(() => [...rows].sort((a, b) => a.playerId.localeCompare(b.playerId)), [rows]);
   const visualOrder = new Map(rows.map((row, index) => [row.playerId, index + 1]));
@@ -265,8 +243,7 @@ const DiffTable: React.FC<{
       {stableRows.map((row) => {
         const deltaRank =
           row.startRank !== undefined && row.endRank !== undefined ? row.startRank - row.endRank : undefined;
-        const deltaScore =
-          row.startScore !== undefined && row.endScore !== undefined ? row.endScore - row.startScore : undefined;
+        const deltaScore = scoreDelta(row, knownAbsentScore);
         return (
           <div
             key={row.playerId}
@@ -406,6 +383,18 @@ export const WhatChangedPage: React.FC = () => {
     () => endState?.leaderboard.getLeaderboard().rankedPlayers.map(({ id, rank, elo }) => ({ id, rank, score: elo })),
     [endState],
   );
+  // A player who is not on the overall leaderboard is unranked or retired, but
+  // still has an elo. The score delta of a player who becomes ranked or retires
+  // in the period is the change of that elo.
+  const actualAbsentScore = useMemo<AbsentScore>(
+    () => (playerId, side) => {
+      const state = side === "start" ? startState : endState;
+      if (!state) return undefined;
+      return state.leaderboard.getCachedLeaderboardMap().get(playerId)?.elo ?? Elo.INITIAL_ELO;
+    },
+    [startState, endState],
+  );
+
   // The expected leaderboard is only shown on the overall leaderboard tab, so
   // only simulate there.
   const simulationNeeded = source === "expected" && activeTab === "leaderboards" && leaderboardTab === "overall";
@@ -616,6 +605,10 @@ export const WhatChangedPage: React.FC = () => {
                     endEntries={source === "actual" ? endActual : endExpected.entries}
                     sortBy={sortBy}
                     emptyText="No ranked players at either time"
+                    // The simulation only covers the players who are ranked at
+                    // that time, so the expected leaderboard has no score for a
+                    // player who is absent.
+                    absentScore={source === "actual" ? actualAbsentScore : undefined}
                     onRowClick={(playerId) => navigate(`/player/${playerId}`)}
                   />
                 ))}
@@ -633,6 +626,9 @@ export const WhatChangedPage: React.FC = () => {
                       sortBy={sortBy}
                       emptyText="No season games at either time"
                       scoreDigits={1}
+                      // A player with no game in the season has a season score
+                      // of 0.
+                      absentScore={absentScoreZero}
                       onRowClick={(playerId) =>
                         navigate(`/season/player?seasonStart=${singleSeason.start}&playerId=${playerId}`)
                       }
@@ -660,6 +656,9 @@ export const WhatChangedPage: React.FC = () => {
                     endEntries={endHallOfFame}
                     sortBy={sortBy}
                     emptyText="No players at either time"
+                    // A player who is not registered yet has a Hall of Fame
+                    // score of 0.
+                    absentScore={absentScoreZero}
                     onRowClick={(playerId) => navigate(`/hall-of-fame/${playerId}`)}
                   />
                 </>


### PR DESCRIPTION
## What changed

On the What changed page, a player who was on only one of the two leaderboards had no score delta: the `Score Δ` column showed `–` and the `Score Δ` sort put the player last. A player who registers inside the period and reaches a Hall of Fame score of 54 belongs at the top with `+54`, not at the bottom.

Each diff table now takes an **absent score** — the score of a player who is not on one of the two leaderboards. The value differs per leaderboard, because the leaderboards do not share a zero point:

| Leaderboard | Absent score | Why |
| --- | --- | --- |
| Hall of Fame | `0` | A player who is not registered yet has no Hall of Fame score, so joining gains the full score. |
| Season | `0` | A player with no game in the season has a season score of 0. |
| Overall (actual) | The elo the player had at that time | An elo has no zero point. Scoring an absent player at 0 would put every newly ranked player on top with a fake `+1100`. A player who becomes ranked or retires in the period now shows the elo they really gained. |
| Overall (expected) | none — stays `–` | The simulation only covers the players who are ranked at that time, so no expected score exists for an absent player. Inventing one would mix simulated and actual elo. |

The absent score only applies when both leaderboards are known. While a datetime input is invalid there is no leaderboard to be absent from, so the delta stays `–` as before.

The row building and sorting move from the component into `what-changed-diff.ts` with 8 unit tests. The rank comparisons no longer return `NaN` when both ranks are missing.

## Admin games tab

The score column of the Games tab on the admin page now shows the 🔴 marker for a game tracked point by point, like the other game lists in the app. A click on the score column opens the game details page, also for a game with no score.

## Changelog

The sorting rule is an edit to the existing `what-changed-page` post, not a new post. The admin page change is admin-only and gets no post.

## Testing

- `npm run lint` — clean
- `npx tsc --noEmit` — clean
- `npm test` — 844 passed, 1 skipped, 77 suites


---
_Generated by [Claude Code](https://claude.ai/code/session_01AoPAFDs2wT4wPv6bmZpgHm)_