### PR TITLE
Rebalance hall of fame career score factors

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -42,6 +42,31 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "hall-of-fame-scoring-weights",
+    title: "New weights in the career score",
+    date: "2026-08-17",
+    tags: ["feature-update"],
+    summary:
+      "Time at the top of the leaderboard now counts the top 5 places. Each Elo point above the start rating now gives 2 points.",
+    body: [
+      text(
+        "The Time at the Top factor gives points for each day you spent near the top of the leaderboard. A day counts once, at the best place you held that day:",
+      ),
+      list(
+        "A day at place 1 gives 1.5 points.",
+        "A day at place 2 or 3 gives 1 point.",
+        "A day at place 4 or 5 gives 0.5 points.",
+      ),
+      text(
+        "The factor counted only the top 3 before this change. It gave 1 point for a day at place 1, and 0.5 points for a day at place 2 or 3.",
+      ),
+      text(
+        "The All-Time High factor also changed. Each Elo point above the start rating of 1 000 now gives 2 points, not 1 point.",
+      ),
+      text("Both changes move the ranks on the Hall of Fame page."),
+    ],
+  },
+  {
     slug: "point-times-and-serves-on-tracked-games",
     title: "Tracked games record point times and serves",
     date: "2026-08-16",
@@ -707,7 +732,7 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
       text("The career score now uses 3 more values:"),
       list(
         "The highest Elo of your career, not your final rating. A bad final year no longer removes a good year.",
-        "Podium time - the time you spent in the top 3, not the number of times.",
+        "The time you spent at the top of the leaderboard, not the number of times you got there.",
         "Experience as games won and games lost, so a game counts even after a loss.",
       ),
       text(

--- a/frontend/src/client/client-db/__tests__/hall-of-fame/podium-time.test.ts
+++ b/frontend/src/client/client-db/__tests__/hall-of-fame/podium-time.test.ts
@@ -48,16 +48,17 @@ describe("Hall of Fame podium time", () => {
     const a = tt.hallOfFame.getScoreForAnyPlayer("a")?.score.podiumTime;
     expect(a?.score).toBe(0);
     expect(a?.rank1Days).toBe(0);
-    expect(a?.rank2Days).toBe(0);
-    expect(a?.rank3Days).toBe(0);
+    expect(a?.rank2to3Days).toBe(0);
+    expect(a?.rank4to5Days).toBe(0);
   });
 
-  it("scores 1 pt per day at #1, 0.5 pt per day at #2 and #3", () => {
+  it("scores 1.5 pt per day at #1, 1 pt per day at #2-3 and 0.5 pt per day at #4-5", () => {
     const setup = fivePlayerSetup();
     const lastSetupTime = 119; // last game time in the round-robin
     const futureTime = lastSetupTime + 10 * ONE_DAY;
     // A pings-the-clock game between D and E far in the future. This
-    // doesn't change the top 3 (A, B, C) but advances time by 10 days.
+    // doesn't change the top 5 order (A, B, C, D, E) but advances time by
+    // 10 days.
     const events = [...setup, game("ping", futureTime, "d", "e")];
 
     const tt = new TennisTable({ events });
@@ -70,13 +71,15 @@ describe("Hall of Fame podium time", () => {
     // The podium activates at t=113 (when E becomes ranked, all in day 0)
     // and runs until the ping at day 10 + tiny offset, so days [0..10] = 11.
     expect(a?.rank1Days).toBe(11);
-    expect(a?.score).toBe(11);
-    expect(b?.rank2Days).toBe(11);
-    expect(b?.score).toBe(5.5);
-    expect(c?.rank3Days).toBe(11);
-    expect(c?.score).toBe(5.5);
-    expect(d?.score).toBe(0);
-    expect(e?.score).toBe(0);
+    expect(a?.score).toBe(16.5);
+    expect(b?.rank2to3Days).toBe(11);
+    expect(b?.score).toBe(11);
+    expect(c?.rank2to3Days).toBe(11);
+    expect(c?.score).toBe(11);
+    expect(d?.rank4to5Days).toBe(11);
+    expect(d?.score).toBe(5.5);
+    expect(e?.rank4to5Days).toBe(11);
+    expect(e?.score).toBe(5.5);
   });
 
   it("freezes the podium clock when a deactivation drops the ranked count below 5", () => {
@@ -102,14 +105,15 @@ describe("Hall of Fame podium time", () => {
     // Podium runs from t=113 (day 0) until C's retirement at day 5 + tiny,
     // so days [0..5] = 6 calendar days each at their respective ranks.
     expect(a?.rank1Days).toBe(6);
-    expect(a?.score).toBe(6);
-    expect(b?.rank2Days).toBe(6);
-    expect(b?.score).toBe(3);
-    expect(c?.rank3Days).toBe(6);
-    expect(c?.score).toBe(3);
-    // D never earns podium time — the ranked count drops to 4 the moment
-    // C retires.
-    expect(d?.score).toBe(0);
+    expect(a?.score).toBe(9);
+    expect(b?.rank2to3Days).toBe(6);
+    expect(b?.score).toBe(6);
+    expect(c?.rank2to3Days).toBe(6);
+    expect(c?.score).toBe(6);
+    // D earns only the 6 days at #4 before C retires — the ranked count
+    // drops to 4 the moment C retires, which stops the clock.
+    expect(d?.rank4to5Days).toBe(6);
+    expect(d?.score).toBe(3);
   });
 
   it("does not accumulate podium time until 5 players are ranked", () => {
@@ -198,6 +202,6 @@ describe("Hall of Fame podium time", () => {
     expect(a?.rank1Days).toBe(12);
     // C is back at #3 across days [10..15] after reactivation = 6 days,
     // plus the 6 days [0..5] before retirement = 12 unique days.
-    expect(c?.rank3Days).toBe(12);
+    expect(c?.rank2to3Days).toBe(12);
   });
 });

--- a/frontend/src/client/client-db/hall-of-fame.ts
+++ b/frontend/src/client/client-db/hall-of-fame.ts
@@ -3,6 +3,8 @@ import { EventTypeEnum } from "./event-store/event-types";
 import { TennisTable } from "./tennis-table";
 import { TournamentBracket } from "./tournaments/bracket";
 
+type PodiumRank = 1 | 2 | 3 | 4 | 5;
+
 export type SeasonDetail = { rank: number; points: number };
 export type TournamentDetail = { name: string; placement: string; points: number };
 
@@ -15,7 +17,7 @@ export type HallOfFameScoreBreakdown = {
   experience: { score: number; gamesWon: number; gamesLost: number };
   dataVolume: { score: number; gamesWithSets: number; gamesWithPoints: number; liveTrackedGames: number };
   peakElo: { score: number; peakElo: number };
-  podiumTime: { score: number; rank1Days: number; rank2Days: number; rank3Days: number };
+  podiumTime: { score: number; rank1Days: number; rank2to3Days: number; rank4to5Days: number };
   total: number;
 };
 
@@ -58,7 +60,7 @@ export class HallOfFame {
   private sectionRanks: Record<HallOfFameFactorKey, Map<string, number>> | undefined;
   private totalRanks: Map<string, number> | undefined;
   private peakEloCache: Map<string, number> | undefined;
-  private podiumMsCache: Map<string, { rank1Days: number; rank2Days: number; rank3Days: number }> | undefined;
+  private podiumMsCache: Map<string, { rank1Days: number; rank2to3Days: number; rank4to5Days: number }> | undefined;
 
   constructor(parent: TennisTable) {
     this.parent = parent;
@@ -443,7 +445,7 @@ export class HallOfFame {
       return { score: 0, peakElo: 0 };
     }
     const peakElo = this.#getPeakElos().get(playerId) ?? Elo.INITIAL_ELO;
-    const score = Math.max(0, peakElo - Elo.INITIAL_ELO);
+    const score = Math.max(0, peakElo - Elo.INITIAL_ELO) * 2;
     return { score, peakElo };
   }
 
@@ -467,17 +469,18 @@ export class HallOfFame {
   #calcPodiumTime(playerId: string): HallOfFameScoreBreakdown["podiumTime"] {
     const days = this.#getPodiumDaysByPlayer().get(playerId);
     const rank1Days = days?.rank1Days ?? 0;
-    const rank2Days = days?.rank2Days ?? 0;
-    const rank3Days = days?.rank3Days ?? 0;
-    const score = rank1Days + rank2Days * 0.5 + rank3Days * 0.5;
-    return { score, rank1Days, rank2Days, rank3Days };
+    const rank2to3Days = days?.rank2to3Days ?? 0;
+    const rank4to5Days = days?.rank4to5Days ?? 0;
+    const score = rank1Days * 1.5 + rank2to3Days * 1 + rank4to5Days * 0.5;
+    return { score, rank1Days, rank2to3Days, rank4to5Days };
   }
 
-  #getPodiumDaysByPlayer(): Map<string, { rank1Days: number; rank2Days: number; rank3Days: number }> {
+  #getPodiumDaysByPlayer(): Map<string, { rank1Days: number; rank2to3Days: number; rank4to5Days: number }> {
     if (this.podiumMsCache) return this.podiumMsCache;
     const ONE_DAY = 24 * 60 * 60 * 1000;
     const gameLimitForRanked = this.parent.client.gameLimitForRanked;
     const MIN_RANKED_FOR_PODIUM = 5;
+    const PODIUM_SIZE = 5;
 
     type Timeline = { kind: "game"; time: number; winner: string; loser: string }
       | { kind: "activity"; time: number; playerId: string; active: boolean };
@@ -503,23 +506,23 @@ export class HallOfFame {
 
     type State = { elo: number; totalGames: number; active: boolean };
     const playerState = new Map<string, State>();
-    let currentTop3: string[] = [];
+    let currentPodium: string[] = [];
     let lastTime: number | undefined;
 
-    const recomputeTop3 = (): string[] => {
+    const recomputePodium = (): string[] => {
       const ranked = Array.from(playerState.entries())
         .filter(([, s]) => s.active && s.totalGames >= gameLimitForRanked);
       if (ranked.length < MIN_RANKED_FOR_PODIUM) return [];
       return ranked
         .sort((a, b) => b[1].elo - a[1].elo)
-        .slice(0, 3)
+        .slice(0, PODIUM_SIZE)
         .map(([id]) => id);
     };
 
     // Per player: day index -> best (lowest) rank held on that day.
-    const dayBestRank = new Map<string, Map<number, 1 | 2 | 3>>();
+    const dayBestRank = new Map<string, Map<number, PodiumRank>>();
 
-    const recordInterval = (playerId: string, rank: 1 | 2 | 3, tStart: number, tEnd: number) => {
+    const recordInterval = (playerId: string, rank: PodiumRank, tStart: number, tEnd: number) => {
       if (tEnd <= tStart) return;
       const dStart = Math.floor(tStart / ONE_DAY);
       const dEnd = Math.ceil(tEnd / ONE_DAY) - 1;
@@ -535,10 +538,10 @@ export class HallOfFame {
     };
 
     for (const entry of timeline) {
-      if (lastTime !== undefined && currentTop3.length > 0) {
-        for (let i = 0; i < currentTop3.length; i++) {
-          const rank = (i + 1) as 1 | 2 | 3;
-          recordInterval(currentTop3[i], rank, lastTime, entry.time);
+      if (lastTime !== undefined && currentPodium.length > 0) {
+        for (let i = 0; i < currentPodium.length; i++) {
+          const rank = (i + 1) as PodiumRank;
+          recordInterval(currentPodium[i], rank, lastTime, entry.time);
         }
       }
 
@@ -561,21 +564,21 @@ export class HallOfFame {
         }
       }
 
-      currentTop3 = recomputeTop3();
+      currentPodium = recomputePodium();
       lastTime = entry.time;
     }
 
-    const result = new Map<string, { rank1Days: number; rank2Days: number; rank3Days: number }>();
+    const result = new Map<string, { rank1Days: number; rank2to3Days: number; rank4to5Days: number }>();
     for (const [playerId, dayMap] of dayBestRank) {
       let rank1Days = 0;
-      let rank2Days = 0;
-      let rank3Days = 0;
+      let rank2to3Days = 0;
+      let rank4to5Days = 0;
       for (const rank of dayMap.values()) {
         if (rank === 1) rank1Days++;
-        else if (rank === 2) rank2Days++;
-        else rank3Days++;
+        else if (rank <= 3) rank2to3Days++;
+        else rank4to5Days++;
       }
-      result.set(playerId, { rank1Days, rank2Days, rank3Days });
+      result.set(playerId, { rank1Days, rank2to3Days, rank4to5Days });
     }
 
     this.podiumMsCache = result;

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
@@ -181,6 +181,7 @@ function renderDetails(breakdown: HallOfFameScoreBreakdown, key: FactorKey): Rea
       const d = data as HallOfFameScoreBreakdown["peakElo"];
       return (
         <div className="text-primary-text text-xs space-y-1.5">
+          <p className="italic">2 pts for each Elo point above the start rating of 1 000.</p>
           <div className="flex flex-wrap gap-1.5">
             <span className="bg-secondary-background text-secondary-text px-2 py-0.5 rounded text-xs inline-flex items-center gap-1.5">
               Peak ELO
@@ -195,13 +196,16 @@ function renderDetails(breakdown: HallOfFameScoreBreakdown, key: FactorKey): Rea
     case "podiumTime": {
       const d = data as HallOfFameScoreBreakdown["podiumTime"];
       const podiumTiers = [
-        { label: "🥇 Day at #1", pts: 1, count: d.rank1Days },
-        { label: "🥈 Day at #2", pts: 0.5, count: d.rank2Days },
-        { label: "🥉 Day at #3", pts: 0.5, count: d.rank3Days },
+        { label: "🥇 Day at #1", pts: 1.5, count: d.rank1Days },
+        { label: "🥈 Day at #2-3", pts: 1, count: d.rank2to3Days },
+        { label: "🥉 Day at #4-5", pts: 0.5, count: d.rank4to5Days },
       ];
       return (
         <div className="text-primary-text text-xs space-y-1.5">
-          <p className="italic">Days spent in the top 3 of the ranked leaderboard. Only counts while at least 5 players are ranked.</p>
+          <p className="italic">
+            Days spent at the top of the ranked leaderboard. A higher place gives more points per day. Each day counts
+            once, at the best place held that day. Only counts while at least 5 players are ranked.
+          </p>
           <div className="flex flex-wrap gap-1.5">
             {podiumTiers.map((tier) => (
               <span
@@ -234,14 +238,14 @@ function renderDetails(breakdown: HallOfFameScoreBreakdown, key: FactorKey): Rea
 
 export const FACTORS: { key: FactorKey; emoji: string; name: string }[] = [
   { key: "peakElo", emoji: "🔥", name: "All-Time High" },
-  { key: "podiumTime", emoji: "🥉", name: "Podium Time" },
+  { key: "podiumTime", emoji: "🥉", name: "Time at the Top" },
   { key: "experience", emoji: "🏓", name: "Experience" },
   { key: "dataVolume", emoji: "📊", name: "Data Volume" },
   { key: "longevity", emoji: "📅", name: "Activity" },
-  { key: "seasonPerformance", emoji: "🍁", name: "Season Performance" },
-  { key: "tournamentProgression", emoji: "🏆", name: "Tournament Performance" },
+  { key: "seasonPerformance", emoji: "🍁", name: "Seasons" },
+  { key: "tournamentProgression", emoji: "🏆", name: "Tournaments" },
   { key: "socialDiversity", emoji: "👥", name: "Social Diversity" },
-  { key: "achievementsEarned", emoji: "🎖️", name: "Achievements Earned" },
+  { key: "achievementsEarned", emoji: "🎖️", name: "Achievements" },
 ];
 
 export const HallOfFamePlayerPage: React.FC = () => {


### PR DESCRIPTION
Revises two factors of the Hall of Fame career score.

## Podium time

Now covers the top 5 places instead of the top 3. Each day still counts once, at the best place held that day:

| Segment | Points per day | Before |
| --- | --- | --- |
| Day at #1 | 1.5 | 1 |
| Day at #2-3 | 1 | 0.5 |
| Day at #4-5 | 0.5 | not counted |

The breakdown fields are renamed `rank1Days` / `rank2to3Days` / `rank4to5Days`. The "at least 5 ranked players" gate is unchanged, so the clock still stops when the league drops below 5 ranked players. With exactly 5 ranked players every player on the leaderboard now earns points, which follows from a top-5 rule and that gate.

## All-Time High

`score = (peakElo - 1000) * 2` — 2 points per rating point above the start rating, up from 1.

## UI

- The factor is shown as "Time at the Top" instead of "Podium Time", since the rule no longer describes a podium. The internal key stays `podiumTime`.
- Its description now reads: "Days spent at the top of the ranked leaderboard. A higher place gives more points per day. Each day counts once, at the best place held that day. Only counts while at least 5 players are ranked."
- All-Time High gained a line stating the 2 points per Elo point above 1 000.
- Factor names shortened: Season Performance → Seasons, Tournament Performance → Tournaments, Achievements Earned → Achievements.

## Changelog

One post, "New weights in the career score". The June "Update to hall of fame scoring" post had a line that still described podium time as the top 3, so that line is corrected in place.

## Testing

`npx tsc --noEmit`, `npm run lint` and the full Jest suite (844 passed, 1 skipped) are clean. The podium time tests are updated for the new segments, including a case where the #4 player now earns points where they earned none before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rfkz4XuKiEMU4CoDhpyDwm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rfkz4XuKiEMU4CoDhpyDwm)_