### PR TITLE
Add skill rating over time page using Whole History Rating

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,6 +32,7 @@ import { IndividualPointsOverview } from "./pages/simulations/individual-points/
 import { IndividualPointsPlayer } from "./pages/simulations/individual-points/individual-points-player";
 import { PlayerPage } from "./pages/player/player-page";
 import { SimulatedLeaderboard } from "./pages/simulations/expected-leaderboard/expected-leaderboard-page";
+import { SkillRatingPage } from "./pages/simulations/skill-rating/skill-rating-page";
 import { OptioPongPage } from "./pages/simulations/optio-pong";
 import { PlayerNetwork } from "./pages/player-network/player-network";
 import { TrackGamePage } from "./pages/add-game/track-game";
@@ -144,6 +145,7 @@ function App() {
                           <Route index element={<SimulationsPage />} />
                           <Route path="win-loss" element={<WinLoss />} />
                           <Route path="expected-leaderboard" element={<SimulatedLeaderboard />} />
+                          <Route path="skill-rating" element={<SkillRatingPage />} />
                           <Route path="individual-points" element={<IndividualPointsOverview />} />
                           <Route path="individual-points/player" element={<IndividualPointsPlayer />} />
                           <Route path="optio-pong" element={<OptioPongPage />} />

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -50,7 +50,7 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
       "A new page under Simulations shows a skill curve for each player. A win by a large margin counts for more, and the rating does not change when a player retires.",
     body: [
       text(
-        "The page is at Simulations, Skill rating over time. Select up to 8 players to compare their curves. Select one player to also see the uncertainty of the rating.",
+        "The page is at Simulations, Skill rating over time. Select any number of players to compare their curves. Select one player to also see the uncertainty of the rating. A filter adds the unranked and the retired players to the list.",
       ),
       text(
         "The method is Whole History Rating. It fits every game in the history at once, and it gives each player one rating per day they played. A rating of 1 000 is the skill of a new player. This anchor keeps the numbers comparable between 2024 and today.",

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -42,6 +42,31 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "skill-rating-over-time",
+    title: "Skill rating over time",
+    date: "2026-08-18",
+    tags: ["new-feature", "technical"],
+    summary:
+      "A new page under Simulations shows a skill curve for each player. The rating stays comparable back in time, and it does not change when a player retires.",
+    body: [
+      text(
+        "The page is at Simulations, Skill rating over time. Select up to 8 players to compare their curves. Select one player to also see the uncertainty of the rating.",
+      ),
+      text(
+        "The method is Whole History Rating. It fits every game in the history at once, and it gives each player one rating per day they played. A rating of 1 000 is the skill of a new player. This anchor keeps the numbers comparable between 2024 and today.",
+      ),
+      text("The rating differs from the expected score simulation on the player page:"),
+      list(
+        "It uses played games only. A retirement today does not change the history of any player.",
+        "It does not depend on who is on the leaderboard today.",
+        "A result from today also sharpens the estimate of a player months back, so a curve can change when new games arrive.",
+      ),
+      text(
+        "The expected score simulation answers a different question: your place in the field of active players. Both numbers stay, and they are not the same measure.",
+      ),
+    ],
+  },
+  {
     slug: "statistics-page",
     title: "Statistics page",
     date: "2026-08-18",

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -47,7 +47,7 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
     date: "2026-08-18",
     tags: ["new-feature", "technical"],
     summary:
-      "A new page under Simulations shows a skill curve for each player. The rating stays comparable back in time, and it does not change when a player retires.",
+      "A new page under Simulations shows a skill curve for each player. A win by a large margin counts for more, and the rating does not change when a player retires.",
     body: [
       text(
         "The page is at Simulations, Skill rating over time. Select up to 8 players to compare their curves. Select one player to also see the uncertainty of the rating.",
@@ -55,14 +55,15 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
       text(
         "The method is Whole History Rating. It fits every game in the history at once, and it gives each player one rating per day they played. A rating of 1 000 is the skill of a new player. This anchor keeps the numbers comparable between 2024 and today.",
       ),
-      text("The rating differs from the expected score simulation on the player page:"),
+      text("The score of a game changes how much a result moves a rating:"),
       list(
-        "It uses played games only. A retirement today does not change the history of any player.",
-        "It does not depend on who is on the leaderboard today.",
-        "A result from today also sharpens the estimate of a player months back, so a curve can change when new games arrive.",
+        "A win by 11-2 moves a rating more than a win by 11-9.",
+        "A win where you drop a set moves a rating less than a win in straight sets.",
+        "The game result decides the direction. The sets and the points then refine it.",
+        "Set scores are newer than the league, so a rating is more exact over the recent period. A game with no score still counts in full.",
       ),
       text(
-        "The expected score simulation answers a different question: your place in the field of active players. Both numbers stay, and they are not the same measure.",
+        "The rating uses played games only. A retirement today does not change the history of any player, and the rating does not depend on who is on the leaderboard. A result from today also sharpens the estimate of a player months back, so a curve can change when new games arrive. The expected score simulation on the player page answers a different question: your place in the field of active players. Both numbers stay.",
       ),
     ],
   },

--- a/frontend/src/client/client-db/__tests__/whr.test.ts
+++ b/frontend/src/client/client-db/__tests__/whr.test.ts
@@ -1,0 +1,262 @@
+import { TennisTable } from "../tennis-table";
+import { EventType, EventTypeEnum } from "../event-store/event-types";
+import { WhrConfig, WhrResult } from "../whr";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+let sequence = 0;
+const nextSequence = () => ++sequence;
+
+function player(id: string): EventType {
+  return { time: nextSequence(), stream: id, type: EventTypeEnum.PLAYER_CREATED, data: { name: id } };
+}
+
+function deactivate(id: string): EventType {
+  return { time: nextSequence(), stream: id, type: EventTypeEnum.PLAYER_DEACTIVATED, data: null };
+}
+
+/** One game on a given day. The day decides which rating point the game lands on. */
+function game(winner: string, loser: string, day = 0): EventType {
+  const playedAt = day * DAY_MS + nextSequence();
+  return {
+    time: playedAt,
+    stream: `game-${winner}-${loser}-${playedAt}`,
+    type: EventTypeEnum.GAME_CREATED,
+    data: { playedAt, winner, loser },
+  };
+}
+
+function games(winner: string, loser: string, count: number, day = 0): EventType[] {
+  return Array.from({ length: count }, () => game(winner, loser, day));
+}
+
+/** mulberry32, so a generated set of results is the same on every run. */
+function makeRandom(seed: number): () => number {
+  let state = seed;
+  return () => {
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function compute(events: EventType[], options?: Partial<WhrConfig>): WhrResult {
+  return new TennisTable({ events }).whr.compute(options);
+}
+
+function curve(result: WhrResult, playerId: string) {
+  const found = result.curves.find((c) => c.playerId === playerId);
+  if (!found) throw new Error(`No curve for ${playerId}`);
+  return found;
+}
+
+function lastRating(result: WhrResult, playerId: string): number {
+  const points = curve(result, playerId).points;
+  return points[points.length - 1].rating;
+}
+
+describe("Whr", () => {
+  beforeEach(() => {
+    sequence = 0;
+  });
+
+  it("rates an even record at the rating of a new player", () => {
+    const result = compute([player("a"), player("b"), ...games("a", "b", 5), ...games("b", "a", 5)]);
+
+    expect(lastRating(result, "a")).toBeCloseTo(1000, 3);
+    expect(lastRating(result, "b")).toBeCloseTo(1000, 3);
+    expect(result.converged).toBe(true);
+  });
+
+  it("rates the player who wins more above the other", () => {
+    const result = compute([player("a"), player("b"), ...games("a", "b", 8), ...games("b", "a", 2)]);
+
+    const a = lastRating(result, "a");
+    const b = lastRating(result, "b");
+
+    expect(a).toBeGreaterThan(b);
+    // With one pairing and a symmetric prior the two ratings sit either side of the
+    // anchor. The fit stops at a tolerance, so allow a fraction of a point.
+    expect(Math.abs(a + b - 2000)).toBeLessThan(0.5);
+  });
+
+  it("does not change any curve when a player retires", () => {
+    const history = [
+      player("a"),
+      player("b"),
+      player("c"),
+      ...games("a", "b", 4, 0),
+      ...games("b", "c", 3, 1),
+      ...games("c", "a", 2, 2),
+      ...games("a", "c", 3, 3),
+    ];
+
+    const before = compute(history);
+    const after = compute([...history, deactivate("b")]);
+
+    expect(after.curves.length).toBe(before.curves.length);
+    for (const playerId of ["a", "b", "c"]) {
+      const pointsBefore = curve(before, playerId).points;
+      const pointsAfter = curve(after, playerId).points;
+      expect(pointsAfter.length).toBe(pointsBefore.length);
+      pointsBefore.forEach((point, index) => {
+        expect(pointsAfter[index].time).toBe(point.time);
+        expect(pointsAfter[index].rating).toBeCloseTo(point.rating, 10);
+        expect(pointsAfter[index].uncertainty).toBeCloseTo(point.uncertainty, 10);
+      });
+    }
+  });
+
+  it("still rates a retired player", () => {
+    const result = compute([
+      player("a"),
+      player("b"),
+      ...games("a", "b", 5),
+      ...games("b", "a", 1),
+      deactivate("b"),
+    ]);
+
+    expect(result.curves.map((c) => c.playerId).sort()).toEqual(["a", "b"]);
+    expect(lastRating(result, "a")).toBeGreaterThan(lastRating(result, "b"));
+  });
+
+  it("orders players through a chain of opponents they never played", () => {
+    // 'a' and 'c' never meet. Only the games against 'b' connect them.
+    const result = compute([
+      player("a"),
+      player("b"),
+      player("c"),
+      ...games("a", "b", 8),
+      ...games("b", "a", 2),
+      ...games("b", "c", 8),
+      ...games("c", "b", 2),
+    ]);
+
+    expect(lastRating(result, "a")).toBeGreaterThan(lastRating(result, "b"));
+    expect(lastRating(result, "b")).toBeGreaterThan(lastRating(result, "c"));
+  });
+
+  it("gives one rating point per day a player played", () => {
+    const result = compute([
+      player("a"),
+      player("b"),
+      ...games("a", "b", 2, 0),
+      ...games("b", "a", 1, 1),
+      ...games("a", "b", 1, 5),
+    ]);
+
+    const points = curve(result, "a").points;
+    expect(points.map((p) => p.time)).toEqual([0, DAY_MS, 5 * DAY_MS]);
+    expect(points.map((p) => p.games)).toEqual([2, 1, 1]);
+    expect(curve(result, "a").totalGames).toBe(4);
+  });
+
+  it("narrows the uncertainty as a player plays more games", () => {
+    const few = compute([player("a"), player("b"), ...games("a", "b", 1), ...games("b", "a", 1)]);
+    const many = compute([player("a"), player("b"), ...games("a", "b", 20), ...games("b", "a", 20)]);
+
+    const fewUncertainty = curve(few, "a").points[0].uncertainty;
+    const manyUncertainty = curve(many, "a").points[0].uncertainty;
+
+    expect(manyUncertainty).toBeLessThan(fewUncertainty);
+    expect(manyUncertainty).toBeGreaterThan(0);
+  });
+
+  it("follows a player whose results improve over time", () => {
+    const events: EventType[] = [player("a"), player("b")];
+    for (let day = 0; day < 10; day++) {
+      events.push(...games("b", "a", 2, day));
+    }
+    for (let day = 90; day < 100; day++) {
+      events.push(...games("a", "b", 2, day));
+    }
+
+    const result = compute(events, { driftPerDay: 25 });
+    const points = curve(result, "a").points;
+    const first = points[0].rating;
+    const last = points[points.length - 1].rating;
+
+    expect(last).toBeGreaterThan(first + 100);
+    // The same games, so the two curves mirror each other around the anchor
+    const opponent = curve(result, "b").points;
+    expect(Math.abs(last + opponent[opponent.length - 1].rating - 2000)).toBeLessThan(0.5);
+  });
+
+  it("keeps a rating flat when the results stay the same over time", () => {
+    const events: EventType[] = [player("a"), player("b")];
+    for (let day = 0; day < 20; day += 2) {
+      events.push(...games("a", "b", 3, day), ...games("b", "a", 1, day));
+    }
+
+    const points = curve(compute(events), "a").points;
+    const ratings = points.map((p) => p.rating);
+    const spread = Math.max(...ratings) - Math.min(...ratings);
+
+    expect(spread).toBeLessThan(15);
+    expect(ratings[0]).toBeGreaterThan(1000);
+  });
+
+  it("rates a player who has only played one game", () => {
+    const result = compute([player("a"), player("b"), game("a", "b")]);
+
+    expect(curve(result, "a").totalGames).toBe(1);
+    expect(lastRating(result, "a")).toBeGreaterThan(1000);
+    expect(lastRating(result, "b")).toBeLessThan(1000);
+  });
+
+  it("returns no curves when there are no games", () => {
+    const result = compute([player("a"), player("b")]);
+
+    expect(result.curves).toEqual([]);
+    expect(result.converged).toBe(true);
+  });
+
+  it("moves a rating further from the anchor when the prior is weaker", () => {
+    const events = [player("a"), player("b"), ...games("a", "b", 6), ...games("b", "a", 1)];
+
+    const tight = compute(events, { newPlayerUncertainty: 50 });
+    const loose = compute(events, { newPlayerUncertainty: 600 });
+
+    expect(lastRating(loose, "a")).toBeGreaterThan(lastRating(tight, "a"));
+  });
+
+  it("recovers the order of players with known strengths", () => {
+    // Every pair plays 60 games, drawn from the Elo win chance of their true
+    // ratings. All games are on one day, so only the ranking is under test.
+    const trueRating: Record<string, number> = { e: 700, d: 820, c: 940, b: 1060, a: 1180, s: 1300 };
+    const ids = Object.keys(trueRating);
+    const random = makeRandom(7);
+
+    const events: EventType[] = ids.map((id) => player(id));
+    for (let i = 0; i < ids.length; i++) {
+      for (let j = i + 1; j < ids.length; j++) {
+        const [one, two] = [ids[i], ids[j]];
+        const chance = 1 / (1 + Math.pow(10, (trueRating[two] - trueRating[one]) / 400));
+        for (let round = 0; round < 60; round++) {
+          const oneWins = random() < chance;
+          events.push(game(oneWins ? one : two, oneWins ? two : one));
+        }
+      }
+    }
+
+    const result = compute(events);
+    const fitted = result.curves
+      .map((curve) => ({ id: curve.playerId, rating: curve.points[curve.points.length - 1].rating }))
+      .sort((a, b) => b.rating - a.rating);
+
+    const trueOrder = ids.slice().sort((one, two) => trueRating[two] - trueRating[one]);
+    expect(fitted.map((entry) => entry.id)).toEqual(trueOrder);
+    expect(result.converged).toBe(true);
+    expect(fitted[0].rating).toBeGreaterThan(1000);
+    expect(fitted[fitted.length - 1].rating).toBeLessThan(1000);
+  });
+
+  it("reports the configuration it used", () => {
+    const result = compute([player("a"), player("b"), game("a", "b")], { driftPerDay: 12 });
+
+    expect(result.config.driftPerDay).toBe(12);
+    expect(result.config.anchorRating).toBe(1000);
+    expect(result.iterations).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/client/client-db/__tests__/whr.test.ts
+++ b/frontend/src/client/client-db/__tests__/whr.test.ts
@@ -431,6 +431,60 @@ describe("Whr", () => {
     });
   });
 
+  it("agrees with the 1v1 win chance predictor", () => {
+    // The rating scale must mean the same thing as the predictor on the player
+    // pages: a gap of 400 points is a 10 to 1 win ratio. If the scale or a level
+    // slope drifts, the two stop lining up.
+    const trueRating: Record<string, number> = { s: 1350, a: 1230, b: 1120, c: 1000, d: 890, e: 760 };
+    const ids = Object.keys(trueRating);
+    const random = makeRandom(23);
+
+    // The predictor weights a game by its age, with a half life of 120 days, so
+    // the games need a realistic date. A fixed one keeps the test repeatable.
+    const firstDay = Math.floor(Date.UTC(2026, 6, 1) / DAY_MS);
+    const referenceTime = Date.UTC(2026, 6, 10);
+
+    const events: EventType[] = ids.map((id) => player(id));
+    for (let i = 0; i < ids.length; i++) {
+      for (let j = i + 1; j < ids.length; j++) {
+        const [one, two] = [ids[i], ids[j]];
+        const chance = 1 / (1 + Math.pow(10, (trueRating[two] - trueRating[one]) / 400));
+        for (let round = 0; round < 40; round++) {
+          const oneWins = random() < chance;
+          events.push(game(oneWins ? one : two, oneWins ? two : one, firstDay + (round % 5)));
+        }
+      }
+    }
+
+    const table = new TennisTable({ events, referenceTime });
+    const result = table.whr.compute();
+    const ratings = new Map(
+      result.curves.map((curve) => [curve.playerId, curve.points[curve.points.length - 1].rating]),
+    );
+
+    let compared = 0;
+    let sameFavourite = 0;
+    let totalGap = 0;
+    for (let i = 0; i < ids.length; i++) {
+      for (let j = i + 1; j < ids.length; j++) {
+        const predicted = table.predictions.getPredictedFraction(ids[i], ids[j]);
+        const one = ratings.get(ids[i])!;
+        const two = ratings.get(ids[j])!;
+        if (!predicted || predicted.confidence < 0.1) continue;
+
+        const fromRating = 1 / (1 + Math.pow(10, (two - one) / 400));
+        if ((fromRating > 0.5) === (predicted.fraction > 0.5)) sameFavourite++;
+        totalGap += Math.abs(fromRating - predicted.fraction);
+        compared++;
+      }
+    }
+
+    expect(compared).toBeGreaterThan(10);
+    expect(sameFavourite / compared).toBeGreaterThan(0.85);
+    // On the real league the average difference is 6 to 9 percentage points
+    expect(totalGap / compared).toBeLessThan(0.15);
+  });
+
   it("reports the configuration it used", () => {
     const result = compute([player("a"), player("b"), game("a", "b")], { driftPerDay: 12 });
 

--- a/frontend/src/client/client-db/__tests__/whr.test.ts
+++ b/frontend/src/client/client-db/__tests__/whr.test.ts
@@ -1,6 +1,6 @@
 import { TennisTable } from "../tennis-table";
 import { EventType, EventTypeEnum } from "../event-store/event-types";
-import { WhrConfig, WhrResult } from "../whr";
+import { GAME_LEVEL_ONLY, POINT_SLOPE, SET_SLOPE, WhrConfig, WhrResult } from "../whr";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -24,6 +24,32 @@ function game(winner: string, loser: string, day = 0): EventType {
     type: EventTypeEnum.GAME_CREATED,
     data: { playedAt, winner, loser },
   };
+}
+
+/** A game with a set score, and the points of each set. */
+function scoredGame(
+  winner: string,
+  loser: string,
+  setPoints: { gameWinner: number; gameLoser: number }[],
+  day = 0,
+): EventType[] {
+  const playedAt = day * DAY_MS + nextSequence();
+  const stream = `game-${playedAt}`;
+  return [
+    { time: playedAt, stream, type: EventTypeEnum.GAME_CREATED, data: { playedAt, winner, loser } },
+    {
+      time: playedAt + 1,
+      stream,
+      type: EventTypeEnum.GAME_SCORE,
+      data: {
+        setsWon: {
+          gameWinner: setPoints.filter((set) => set.gameWinner > set.gameLoser).length,
+          gameLoser: setPoints.filter((set) => set.gameLoser > set.gameWinner).length,
+        },
+        setPoints,
+      },
+    },
+  ];
 }
 
 function games(winner: string, loser: string, count: number, day = 0): EventType[] {
@@ -250,6 +276,159 @@ describe("Whr", () => {
     expect(result.converged).toBe(true);
     expect(fitted[0].rating).toBeGreaterThan(1000);
     expect(fitted[fitted.length - 1].rating).toBeLessThan(1000);
+  });
+
+  describe("set and point scores", () => {
+    const crushing = [
+      { gameWinner: 11, gameLoser: 2 },
+      { gameWinner: 11, gameLoser: 1 },
+    ];
+    const narrow = [
+      { gameWinner: 11, gameLoser: 9 },
+      { gameWinner: 12, gameLoser: 10 },
+    ];
+
+    /** Two separate pairings, each with the same game record, so only the margin differs. */
+    function twoLeagues(options?: Partial<WhrConfig>) {
+      const dominant: EventType[] = [player("a"), player("b")];
+      const even: EventType[] = [player("c"), player("d")];
+      for (let day = 0; day < 5; day++) {
+        dominant.push(...scoredGame("a", "b", crushing, day));
+        even.push(...scoredGame("c", "d", narrow, day));
+      }
+      return {
+        dominant: lastRating(compute(dominant, options), "a"),
+        even: lastRating(compute(even, options), "c"),
+      };
+    }
+
+    it("rates a win by a large margin above a win by a small margin", () => {
+      const { dominant, even } = twoLeagues();
+
+      expect(dominant).toBeGreaterThan(even + 100);
+    });
+
+    it("ignores the margin when the score levels are switched off", () => {
+      const { dominant, even } = twoLeagues({ levelWeights: GAME_LEVEL_ONLY });
+
+      expect(dominant).toBeCloseTo(even, 6);
+    });
+
+    it("keeps a player who wins every game above the rating of a new player", () => {
+      // 'a' wins 2 sets to 1 every time, but takes 24 points against 29
+      const events: EventType[] = [player("a"), player("b")];
+      for (let day = 0; day < 6; day++) {
+        events.push(
+          ...scoredGame(
+            "a",
+            "b",
+            [
+              { gameWinner: 11, gameLoser: 9 },
+              { gameWinner: 11, gameLoser: 9 },
+              { gameWinner: 2, gameLoser: 11 },
+            ],
+            day,
+          ),
+        );
+      }
+
+      const result = compute(events);
+      const winner = lastRating(result, "a");
+
+      // The points pull the rating down, but the game result still decides the sign
+      expect(winner).toBeGreaterThan(1050);
+      expect(winner).toBeLessThan(lastRating(compute(events, { levelWeights: GAME_LEVEL_ONLY }), "a"));
+    });
+
+    it("rates a player who sweeps the sets above one who drops a set", () => {
+      const sweep: EventType[] = [player("a"), player("b")];
+      const dropped: EventType[] = [player("c"), player("d")];
+      for (let day = 0; day < 5; day++) {
+        sweep.push(
+          ...scoredGame(
+            "a",
+            "b",
+            [
+              { gameWinner: 11, gameLoser: 9 },
+              { gameWinner: 11, gameLoser: 9 },
+            ],
+            day,
+          ),
+        );
+        dropped.push(
+          ...scoredGame(
+            "c",
+            "d",
+            [
+              { gameWinner: 11, gameLoser: 9 },
+              { gameWinner: 9, gameLoser: 11 },
+              { gameWinner: 11, gameLoser: 9 },
+            ],
+            day,
+          ),
+        );
+      }
+
+      expect(lastRating(compute(sweep), "a")).toBeGreaterThan(lastRating(compute(dropped), "c"));
+    });
+
+    it("rates a win where a set was dropped below the same games with no score", () => {
+      // Losing a set is evidence that the two players are closer than the win
+      // alone suggests, so a recorded score can lower a rating.
+      const scored: EventType[] = [player("a"), player("b")];
+      const bare: EventType[] = [player("a"), player("b")];
+      for (let day = 0; day < 5; day++) {
+        scored.push(
+          ...scoredGame(
+            "a",
+            "b",
+            [
+              { gameWinner: 11, gameLoser: 9 },
+              { gameWinner: 9, gameLoser: 11 },
+              { gameWinner: 11, gameLoser: 9 },
+            ],
+            day,
+          ),
+        );
+        bare.push(...games("a", "b", 1, day));
+      }
+
+      expect(lastRating(compute(scored), "a")).toBeLessThan(lastRating(compute(bare), "a"));
+    });
+
+    it("derives each level's slope from the probability lookups", () => {
+      // A win fraction means something different per level, so each needs its own slope
+      expect(SET_SLOPE).toBeCloseTo(0.666, 2);
+      expect(POINT_SLOPE).toBeCloseTo(0.173, 2);
+      expect(SET_SLOPE).toBeLessThan(1);
+      expect(POINT_SLOPE).toBeLessThan(SET_SLOPE);
+
+      // A 400 Elo gap is a 0.909 game win chance. The slopes must agree with the
+      // lookups on what that means in sets and in points.
+      const gap = Math.log(10);
+      expect(1 / (1 + Math.exp(-gap * SET_SLOPE))).toBeCloseTo(0.822, 2);
+      expect(1 / (1 + Math.exp(-gap * POINT_SLOPE))).toBeCloseTo(0.598, 2);
+    });
+
+    it("reports how many games carry a score", () => {
+      const events: EventType[] = [player("a"), player("b")];
+      events.push(...games("a", "b", 2));
+      events.push(...scoredGame("a", "b", [{ gameWinner: 11, gameLoser: 4 }]));
+      events.push({
+        time: nextSequence(),
+        stream: "game-sets-only",
+        type: EventTypeEnum.GAME_CREATED,
+        data: { playedAt: nextSequence(), winner: "a", loser: "b" },
+      });
+      events.push({
+        time: nextSequence(),
+        stream: "game-sets-only",
+        type: EventTypeEnum.GAME_SCORE,
+        data: { setsWon: { gameWinner: 2, gameLoser: 0 } },
+      });
+
+      expect(compute(events).coverage).toEqual({ games: 4, withSets: 2, withPoints: 1 });
+    });
   });
 
   it("reports the configuration it used", () => {

--- a/frontend/src/client/client-db/tennis-table.ts
+++ b/frontend/src/client/client-db/tennis-table.ts
@@ -14,6 +14,7 @@ import { Seasons } from "./seasons/seasons";
 import { PredictionsHistory } from "./predictions-history";
 import { Predictions } from "./predictions";
 import { HallOfFame } from "./hall-of-fame";
+import { Whr } from "./whr";
 
 export class TennisTable {
   // --------------------------------------------------------------------------
@@ -48,6 +49,7 @@ export class TennisTable {
   predictions: Predictions;
   predictionsHistory: PredictionsHistory;
   hallOfFame: HallOfFame;
+  whr: Whr;
 
   constructor(data: { events: EventType[]; gameLimitForRankedOverride?: number; referenceTime?: number }) {
     this.events = data.events;
@@ -69,6 +71,7 @@ export class TennisTable {
     this.predictions = new Predictions(this, data.referenceTime);
     this.predictionsHistory = new PredictionsHistory(this);
     this.hallOfFame = new HallOfFame(this);
+    this.whr = new Whr(this);
   }
 
   /** Returns list of only active players */

--- a/frontend/src/client/client-db/web-worker/web-worker.ts
+++ b/frontend/src/client/client-db/web-worker/web-worker.ts
@@ -3,6 +3,7 @@ import { PredictionHistoryEntry } from "../predictions-history";
 import { ExpectedLeaderboard } from "../simulations";
 import { TennisTable } from "../tennis-table";
 import { TournamentPredictionResult } from "../tournaments/prediction";
+import { WhrConfig, WhrResult } from "../whr";
 
 export type WorkerMessage =
   | {
@@ -24,7 +25,10 @@ export type WorkerMessage =
   | { type: "start-predictions-history"; data: { playerId: string; events: EventType[] } }
   | { type: "predictions-history-times"; data: { times: number[] } }
   | { type: "predictions-history-data"; data: { entry: PredictionHistoryEntry; progress: number } }
-  | { type: "predictions-history-complete" };
+  | { type: "predictions-history-complete" }
+  | { type: "start-whr"; data: { events: EventType[]; config?: Partial<WhrConfig> } }
+  | { type: "whr-progress"; data: { progress: number } }
+  | { type: "whr-result"; data: { result: WhrResult } };
 
 // eslint-disable-next-line no-restricted-globals
 const scope = self as unknown as DedicatedWorkerGlobalScope;
@@ -86,6 +90,15 @@ function handleWorkerMessage(message: WorkerMessage) {
       );
       setTimeout(() => postWorkerMessage({ type: "predictions-history-complete" }), 1000);
       break;
+
+    case "start-whr": {
+      const tennisTableForWhr = new TennisTable({ events: message.data.events });
+      const result = tennisTableForWhr.whr.compute(message.data.config, (progress) =>
+        postWorkerMessage({ type: "whr-progress", data: { progress } }),
+      );
+      postWorkerMessage({ type: "whr-result", data: { result } });
+      break;
+    }
   }
 }
 

--- a/frontend/src/client/client-db/whr.ts
+++ b/frontend/src/client/client-db/whr.ts
@@ -98,7 +98,17 @@ export const GAME_LEVEL_ONLY: WhrLevelWeights = { game: 1, set: 0, point: 0 };
 export const DEFAULT_LEVEL_WEIGHTS: WhrLevelWeights = { game: 1, set: 0.5, point: 0.25 };
 
 export type WhrConfig = {
-  /** How much a player's skill can drift in Elo points over one day, as a standard deviation. */
+  /**
+   * How much a player's skill can drift in Elo points over one day, as a
+   * standard deviation.
+   *
+   * Measured against the real league: a fit on the first 75% of the games, used
+   * to predict the last 505 games, gives a log loss of 0.4969 at 1, 0.4980 at 2,
+   * 0.5047 at 4, 0.5244 at 8 and 0.5634 at 16. A lower value predicts a little
+   * better, but it also flattens the curve until a real change in form no longer
+   * shows. The default keeps the movement visible. Every value up to 8 still
+   * predicts better than the Elo leaderboard, which scores 0.5498.
+   */
   driftPerDay: number;
   /** Uncertainty in Elo points of the prior on a player's first rating. */
   newPlayerUncertainty: number;

--- a/frontend/src/client/client-db/whr.ts
+++ b/frontend/src/client/client-db/whr.ts
@@ -1,0 +1,375 @@
+import { Elo } from "./elo";
+import { Game } from "./event-store/projectors/games-projector";
+import { TennisTable } from "./tennis-table";
+
+/**
+ * Whole History Rating (Coulom, 2008).
+ *
+ * Every player gets a strength curve over time instead of one running number.
+ * All games are fitted at once, so a result from today also sharpens the
+ * estimate of who a player was months ago.
+ *
+ * The model is Bradley-Terry: the chance that player A beats player B is
+ * sigmoid(rA - rB) on a natural log-strength scale. A Wiener process prior
+ * connects each player's own time steps, so a rating moves only as far as the
+ * games justify.
+ *
+ * The rating depends on played games only. It never reads whether a player is
+ * active, so a retirement today does not change anyone's history. This is the
+ * property the expected score simulation does not have.
+ *
+ * The scale needs one anchor, because game results alone fix only the
+ * differences between players. The anchor is the prior on a player's first
+ * time step: a player is expected to start at `anchorRating` points. This keeps
+ * the scale comparable over time, and it defines the meaning of the numbers -
+ * a rating is measured against the skill of a new player, not against the
+ * current field.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Elo points per unit of natural log-strength. A 400 point gap is a 10:1 win ratio. */
+const ELO_PER_NATURAL = 400 / Math.LN10;
+
+/** Largest natural-scale move one Newton step may take, to keep early sweeps stable. */
+const MAX_NEWTON_STEP = 1;
+
+/** Sweeps between two progress reports. One report per sweep is more messages than useful. */
+const PROGRESS_INTERVAL = 5;
+
+export type WhrConfig = {
+  /** How much a player's skill can drift in Elo points over one day, as a standard deviation. */
+  driftPerDay: number;
+  /** Uncertainty in Elo points of the prior on a player's first rating. */
+  newPlayerUncertainty: number;
+  /** The rating a player is expected to have before any game is known. */
+  anchorRating: number;
+  /** Maximum number of sweeps over all players. A dense league needs a few hundred. */
+  maxIterations: number;
+  /** Stop early when the largest move in a sweep is below this many Elo points. */
+  tolerance: number;
+};
+
+export const DEFAULT_WHR_CONFIG: WhrConfig = {
+  driftPerDay: 8,
+  newPlayerUncertainty: 300,
+  anchorRating: Elo.INITIAL_ELO,
+  maxIterations: 400,
+  tolerance: 0.01,
+};
+
+export type WhrRatingPoint = {
+  /** UTC midnight of the day the games were played. */
+  time: number;
+  rating: number;
+  /** One standard deviation of the rating, in Elo points. */
+  uncertainty: number;
+  /** Games this player played on this day. */
+  games: number;
+};
+
+export type WhrPlayerCurve = {
+  playerId: string;
+  points: WhrRatingPoint[];
+  totalGames: number;
+};
+
+export type WhrResult = {
+  curves: WhrPlayerCurve[];
+  /** Sweeps actually run. */
+  iterations: number;
+  converged: boolean;
+  config: WhrConfig;
+};
+
+type StepGame = {
+  /** The opponent's fit, so the sweep reads their strength without a map lookup. */
+  opponent: PlayerFit;
+  opponentStep: number;
+  won: boolean;
+};
+
+type PlayerFit = {
+  id: string;
+  /** UTC midnight of each day this player played, ascending. */
+  days: number[];
+  games: StepGame[][];
+  /** Natural-scale log-strength per day. */
+  r: Float64Array;
+  /** Natural-scale variance per day, filled in after the fit converges. */
+  variance: Float64Array;
+  totalGames: number;
+};
+
+function toDay(time: number): number {
+  return Math.floor(time / DAY_MS) * DAY_MS;
+}
+
+function sigmoid(x: number): number {
+  return 1 / (1 + Math.exp(-x));
+}
+
+export class Whr {
+  private parent: TennisTable;
+
+  constructor(parent: TennisTable) {
+    this.parent = parent;
+  }
+
+  compute(options?: Partial<WhrConfig>, onProgress?: (progress: number) => void): WhrResult {
+    const config = { ...DEFAULT_WHR_CONFIG, ...options };
+
+    const fits = this.buildFits(this.ratedGames());
+    if (fits.length === 0) {
+      return { curves: [], iterations: 0, converged: true, config };
+    }
+
+    // Natural-scale versions of the Elo-scale settings
+    const driftVariancePerDay = Math.pow(config.driftPerDay / ELO_PER_NATURAL, 2);
+    const anchorPrecision = 1 / Math.pow(config.newPlayerUncertainty / ELO_PER_NATURAL, 2);
+    const toleranceNatural = config.tolerance / ELO_PER_NATURAL;
+
+    let iterations = 0;
+    let converged = false;
+
+    for (let sweep = 0; sweep < config.maxIterations; sweep++) {
+      let largestMove = 0;
+      for (const fit of fits) {
+        largestMove = Math.max(largestMove, this.newtonSweep(fit, driftVariancePerDay, anchorPrecision));
+      }
+      iterations = sweep + 1;
+      if (iterations % PROGRESS_INTERVAL === 0) {
+        onProgress?.(iterations / config.maxIterations);
+      }
+      if (largestMove < toleranceNatural) {
+        converged = true;
+        break;
+      }
+    }
+
+    for (const fit of fits) {
+      this.fillVariance(fit, driftVariancePerDay, anchorPrecision);
+    }
+    onProgress?.(1);
+
+    return {
+      curves: fits.map((fit) => ({
+        playerId: fit.id,
+        totalGames: fit.totalGames,
+        points: fit.days.map((day, index) => ({
+          time: day,
+          rating: config.anchorRating + fit.r[index] * ELO_PER_NATURAL,
+          uncertainty: Math.sqrt(Math.max(fit.variance[index], 0)) * ELO_PER_NATURAL,
+          games: fit.games[index].length,
+        })),
+      })),
+      iterations,
+      converged,
+      config,
+    };
+  }
+
+  /** Games where both players exist, oldest first. Retired players are included. */
+  private ratedGames(): Game[] {
+    const knownPlayers = new Set(this.parent.allPlayers.map((player) => player.id));
+    return this.parent.games
+      .filter((game) => knownPlayers.has(game.winner) && knownPlayers.has(game.loser))
+      .slice()
+      .sort((a, b) => a.playedAt - b.playedAt);
+  }
+
+  private buildFits(games: Game[]): PlayerFit[] {
+    // Pass 1: the set of days each player played
+    const daysByPlayer = new Map<string, Set<number>>();
+    const addDay = (playerId: string, day: number) => {
+      const days = daysByPlayer.get(playerId);
+      if (days) {
+        days.add(day);
+      } else {
+        daysByPlayer.set(playerId, new Set([day]));
+      }
+    };
+    for (const game of games) {
+      const day = toDay(game.playedAt);
+      addDay(game.winner, day);
+      addDay(game.loser, day);
+    }
+
+    // Pass 2: one fit per player, with a lookup from day to step index
+    const fits = new Map<string, PlayerFit>();
+    const stepIndex = new Map<string, Map<number, number>>();
+    daysByPlayer.forEach((daySet, playerId) => {
+      const days = Array.from(daySet).sort((a, b) => a - b);
+      const indexByDay = new Map<number, number>();
+      days.forEach((day, index) => indexByDay.set(day, index));
+      stepIndex.set(playerId, indexByDay);
+      fits.set(playerId, {
+        id: playerId,
+        days,
+        games: days.map(() => []),
+        r: new Float64Array(days.length),
+        variance: new Float64Array(days.length),
+        totalGames: 0,
+      });
+    });
+
+    // Pass 3: attach every game to both players' step for that day
+    for (const game of games) {
+      const day = toDay(game.playedAt);
+      const winner = fits.get(game.winner)!;
+      const loser = fits.get(game.loser)!;
+      const winnerStep = stepIndex.get(game.winner)!.get(day)!;
+      const loserStep = stepIndex.get(game.loser)!.get(day)!;
+
+      winner.games[winnerStep].push({ opponent: loser, opponentStep: loserStep, won: true });
+      loser.games[loserStep].push({ opponent: winner, opponentStep: winnerStep, won: false });
+      winner.totalGames++;
+      loser.totalGames++;
+    }
+
+    return Array.from(fits.values());
+  }
+
+  /**
+   * Builds the gradient and the tridiagonal Hessian of the log posterior for one
+   * player, then takes one Newton step. Every other player is held fixed, which
+   * is what makes the whole fit a sweep over players.
+   *
+   * Returns the largest natural-scale move, to drive the convergence check.
+   */
+  private newtonSweep(fit: PlayerFit, driftVariancePerDay: number, anchorPrecision: number): number {
+    const n = fit.days.length;
+    const gradient = new Float64Array(n);
+    const diagonal = new Float64Array(n);
+    const offDiagonal = new Float64Array(Math.max(n - 1, 0));
+
+    this.accumulate(fit, gradient, diagonal, offDiagonal, driftVariancePerDay, anchorPrecision);
+
+    // The Hessian is negative definite, so solving it gives an ascent step
+    const delta = this.solveTridiagonal(diagonal, offDiagonal, gradient, true);
+
+    let largestMove = 0;
+    for (let i = 0; i < n; i++) {
+      const move = Math.max(Math.min(delta[i], MAX_NEWTON_STEP), -MAX_NEWTON_STEP);
+      fit.r[i] += move;
+      largestMove = Math.max(largestMove, Math.abs(move));
+    }
+    return largestMove;
+  }
+
+  /** Gradient and tridiagonal Hessian of the log posterior for one player. */
+  private accumulate(
+    fit: PlayerFit,
+    gradient: Float64Array,
+    diagonal: Float64Array,
+    offDiagonal: Float64Array,
+    driftVariancePerDay: number,
+    anchorPrecision: number,
+  ): void {
+    const n = fit.days.length;
+
+    // Bradley-Terry likelihood of the games played on each day
+    for (let k = 0; k < n; k++) {
+      const own = fit.r[k];
+      for (const game of fit.games[k]) {
+        const expected = sigmoid(own - game.opponent.r[game.opponentStep]);
+        gradient[k] += (game.won ? 1 : 0) - expected;
+        diagonal[k] -= expected * (1 - expected);
+      }
+    }
+
+    // Anchor on the first day: a player starts at the rating of a new player.
+    // This fixes the one degree of freedom that game results leave open.
+    gradient[0] -= fit.r[0] * anchorPrecision;
+    diagonal[0] -= anchorPrecision;
+
+    // Wiener process prior between consecutive days
+    for (let k = 0; k < n - 1; k++) {
+      const days = Math.max((fit.days[k + 1] - fit.days[k]) / DAY_MS, 1);
+      const precision = 1 / (driftVariancePerDay * days);
+      const difference = fit.r[k + 1] - fit.r[k];
+      gradient[k] += difference * precision;
+      gradient[k + 1] -= difference * precision;
+      diagonal[k] -= precision;
+      diagonal[k + 1] -= precision;
+      offDiagonal[k] += precision;
+    }
+  }
+
+  /**
+   * Solves a symmetric tridiagonal system with the Thomas algorithm.
+   * With `negateRhs` the solution is of `matrix * x = -rhs`.
+   */
+  private solveTridiagonal(
+    diagonal: Float64Array,
+    offDiagonal: Float64Array,
+    rhs: Float64Array,
+    negateRhs: boolean,
+  ): Float64Array {
+    const n = diagonal.length;
+    const solution = new Float64Array(n);
+    const sign = negateRhs ? -1 : 1;
+
+    if (n === 1) {
+      solution[0] = (sign * rhs[0]) / diagonal[0];
+      return solution;
+    }
+
+    const sweptOffDiagonal = new Float64Array(n);
+    const sweptRhs = new Float64Array(n);
+
+    sweptOffDiagonal[0] = offDiagonal[0] / diagonal[0];
+    sweptRhs[0] = (sign * rhs[0]) / diagonal[0];
+
+    for (let i = 1; i < n; i++) {
+      const pivot = diagonal[i] - offDiagonal[i - 1] * sweptOffDiagonal[i - 1];
+      sweptOffDiagonal[i] = i < n - 1 ? offDiagonal[i] / pivot : 0;
+      sweptRhs[i] = (sign * rhs[i] - offDiagonal[i - 1] * sweptRhs[i - 1]) / pivot;
+    }
+
+    solution[n - 1] = sweptRhs[n - 1];
+    for (let i = n - 2; i >= 0; i--) {
+      solution[i] = sweptRhs[i] - sweptOffDiagonal[i] * solution[i + 1];
+    }
+    return solution;
+  }
+
+  /**
+   * Fills in the variance of each day's rating from the diagonal of the inverse
+   * of the negated Hessian.
+   *
+   * For a symmetric tridiagonal matrix a forward and a backward recursion give
+   * that diagonal directly: with `forward[i]` and `backward[i]` the pivots of
+   * the two sweeps, `inverse[i][i] = 1 / (forward[i] + backward[i] - a[i][i])`.
+   * Both recursions use ratios only, so long curves stay numerically stable.
+   */
+  private fillVariance(fit: PlayerFit, driftVariancePerDay: number, anchorPrecision: number): void {
+    const n = fit.days.length;
+    const gradient = new Float64Array(n);
+    const diagonal = new Float64Array(n);
+    const offDiagonal = new Float64Array(Math.max(n - 1, 0));
+
+    this.accumulate(fit, gradient, diagonal, offDiagonal, driftVariancePerDay, anchorPrecision);
+
+    // Negate to get a positive definite matrix
+    for (let i = 0; i < n; i++) diagonal[i] = -diagonal[i];
+    for (let i = 0; i < offDiagonal.length; i++) offDiagonal[i] = -offDiagonal[i];
+
+    const forward = new Float64Array(n);
+    const backward = new Float64Array(n);
+
+    forward[0] = diagonal[0];
+    for (let i = 1; i < n; i++) {
+      forward[i] = diagonal[i] - Math.pow(offDiagonal[i - 1], 2) / forward[i - 1];
+    }
+
+    backward[n - 1] = diagonal[n - 1];
+    for (let i = n - 2; i >= 0; i--) {
+      backward[i] = diagonal[i] - Math.pow(offDiagonal[i], 2) / backward[i + 1];
+    }
+
+    for (let i = 0; i < n; i++) {
+      fit.variance[i] = 1 / (forward[i] + backward[i] - diagonal[i]);
+    }
+  }
+}

--- a/frontend/src/client/client-db/whr.ts
+++ b/frontend/src/client/client-db/whr.ts
@@ -1,5 +1,6 @@
 import { Elo } from "./elo";
 import { Game } from "./event-store/projectors/games-projector";
+import { pointToGame, setToGame } from "./future-elo-probability-lookups";
 import { TennisTable } from "./tennis-table";
 
 /**
@@ -24,6 +25,10 @@ import { TennisTable } from "./tennis-table";
  * the scale comparable over time, and it defines the meaning of the numbers -
  * a rating is measured against the skill of a new player, not against the
  * current field.
+ *
+ * The fit reads three levels of a result: the game, the sets and the points.
+ * A win by a large margin moves a rating more than a win by a small margin.
+ * See `levelSlope` for why each level needs its own slope.
  */
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -37,6 +42,61 @@ const MAX_NEWTON_STEP = 1;
 /** Sweeps between two progress reports. One report per sweep is more messages than useful. */
 const PROGRESS_INTERVAL = 5;
 
+/**
+ * The logistic slope of one level, so a set and a point enter the fit on their
+ * own scale.
+ *
+ * A win fraction means something different at each level. The probability
+ * lookups say that 60% of the sets is a 65% chance to win the game, while 60%
+ * of the points is a 93% chance. Points at the slope of games would read a
+ * dominant player as an even one, and every rating would collapse toward the
+ * anchor.
+ *
+ * A lookup maps a win fraction at its level to the chance of winning the game.
+ * Where the two players are even, that curve has slope `s`, and the level then
+ * needs the slope `1 / s`: a rating gap that gives sigmoid(gap) games gives
+ * sigmoid(gap / s) of the smaller units. The value comes from the lookup
+ * itself, so the slopes follow the measured curves and need no separate
+ * calibration.
+ */
+function levelSlope(probabilityLookup: number[]): number {
+  return 0.02 / (probabilityLookup[51] - probabilityLookup[49]);
+}
+
+/** About 0.67. One point of set share is 1.5 points of game probability. */
+export const SET_SLOPE = levelSlope(setToGame);
+
+/** About 0.17. One point of point share is 5.8 points of game probability. */
+export const POINT_SLOPE = levelSlope(pointToGame);
+
+/**
+ * How much each level counts.
+ *
+ * The game result decides the sign of a rating, and the sets and the points
+ * refine it. The order is the same as the one the prediction code uses when it
+ * combines the levels: the game first, then the sets, then the points.
+ *
+ * The weights are needed because a game holds one game result, about 3 sets and
+ * about 60 points. At equal weights the sets and the points carry 3 times the
+ * information of the result, and they then outvote it. A player who won 6 of 6
+ * games by 2 sets to 1, but took 24 points against 29 in each game, measured
+ * 1 035 points at equal weights. The result is a player who wins every game, so
+ * a rating at the level of a new player is wrong.
+ *
+ * At the weights below the sets and the points together carry about as much as
+ * the game result. The same player measures 1 094 points, and a win by a large
+ * margin still separates clearly from a win by a small margin. Set a level to 0
+ * to leave it out.
+ */
+export type WhrLevelWeights = {
+  game: number;
+  set: number;
+  point: number;
+};
+
+export const GAME_LEVEL_ONLY: WhrLevelWeights = { game: 1, set: 0, point: 0 };
+export const DEFAULT_LEVEL_WEIGHTS: WhrLevelWeights = { game: 1, set: 0.5, point: 0.25 };
+
 export type WhrConfig = {
   /** How much a player's skill can drift in Elo points over one day, as a standard deviation. */
   driftPerDay: number;
@@ -44,6 +104,8 @@ export type WhrConfig = {
   newPlayerUncertainty: number;
   /** The rating a player is expected to have before any game is known. */
   anchorRating: number;
+  /** How much the game, the sets and the points of a result each count. */
+  levelWeights: WhrLevelWeights;
   /** Maximum number of sweeps over all players. A dense league needs a few hundred. */
   maxIterations: number;
   /** Stop early when the largest move in a sweep is below this many Elo points. */
@@ -54,6 +116,7 @@ export const DEFAULT_WHR_CONFIG: WhrConfig = {
   driftPerDay: 8,
   newPlayerUncertainty: 300,
   anchorRating: Elo.INITIAL_ELO,
+  levelWeights: DEFAULT_LEVEL_WEIGHTS,
   maxIterations: 400,
   tolerance: 0.01,
 };
@@ -74,26 +137,45 @@ export type WhrPlayerCurve = {
   totalGames: number;
 };
 
+/** How many of the rated games carry a score. Set and point data is newer than the league. */
+export type WhrCoverage = {
+  games: number;
+  withSets: number;
+  withPoints: number;
+};
+
 export type WhrResult = {
   curves: WhrPlayerCurve[];
+  coverage: WhrCoverage;
   /** Sweeps actually run. */
   iterations: number;
   converged: boolean;
   config: WhrConfig;
 };
 
-type StepGame = {
+/**
+ * Everything one player did against one opponent on one day, counted at all
+ * three levels. Counting instead of listing keeps the sweep over a long point
+ * log as cheap as one binomial term.
+ */
+type Observation = {
   /** The opponent's fit, so the sweep reads their strength without a map lookup. */
   opponent: PlayerFit;
   opponentStep: number;
-  won: boolean;
+  gamesWon: number;
+  gamesLost: number;
+  setsWon: number;
+  setsLost: number;
+  pointsWon: number;
+  pointsLost: number;
 };
 
 type PlayerFit = {
   id: string;
   /** UTC midnight of each day this player played, ascending. */
   days: number[];
-  games: StepGame[][];
+  observations: Observation[][];
+  gamesPerDay: number[];
   /** Natural-scale log-strength per day. */
   r: Float64Array;
   /** Natural-scale variance per day, filled in after the fit converges. */
@@ -119,9 +201,11 @@ export class Whr {
   compute(options?: Partial<WhrConfig>, onProgress?: (progress: number) => void): WhrResult {
     const config = { ...DEFAULT_WHR_CONFIG, ...options };
 
-    const fits = this.buildFits(this.ratedGames());
+    const games = this.ratedGames();
+    const coverage = Whr.coverageOf(games);
+    const fits = this.buildFits(games);
     if (fits.length === 0) {
-      return { curves: [], iterations: 0, converged: true, config };
+      return { curves: [], coverage, iterations: 0, converged: true, config };
     }
 
     // Natural-scale versions of the Elo-scale settings
@@ -135,7 +219,10 @@ export class Whr {
     for (let sweep = 0; sweep < config.maxIterations; sweep++) {
       let largestMove = 0;
       for (const fit of fits) {
-        largestMove = Math.max(largestMove, this.newtonSweep(fit, driftVariancePerDay, anchorPrecision));
+        largestMove = Math.max(
+          largestMove,
+          this.newtonSweep(fit, driftVariancePerDay, anchorPrecision, config.levelWeights),
+        );
       }
       iterations = sweep + 1;
       if (iterations % PROGRESS_INTERVAL === 0) {
@@ -148,7 +235,7 @@ export class Whr {
     }
 
     for (const fit of fits) {
-      this.fillVariance(fit, driftVariancePerDay, anchorPrecision);
+      this.fillVariance(fit, driftVariancePerDay, anchorPrecision, config.levelWeights);
     }
     onProgress?.(1);
 
@@ -160,9 +247,10 @@ export class Whr {
           time: day,
           rating: config.anchorRating + fit.r[index] * ELO_PER_NATURAL,
           uncertainty: Math.sqrt(Math.max(fit.variance[index], 0)) * ELO_PER_NATURAL,
-          games: fit.games[index].length,
+          games: fit.gamesPerDay[index],
         })),
       })),
+      coverage,
       iterations,
       converged,
       config,
@@ -176,6 +264,16 @@ export class Whr {
       .filter((game) => knownPlayers.has(game.winner) && knownPlayers.has(game.loser))
       .slice()
       .sort((a, b) => a.playedAt - b.playedAt);
+  }
+
+  private static coverageOf(games: Game[]): WhrCoverage {
+    let withSets = 0;
+    let withPoints = 0;
+    for (const game of games) {
+      if (game.score) withSets++;
+      if (game.score?.setPoints) withPoints++;
+    }
+    return { games: games.length, withSets, withPoints };
   }
 
   private buildFits(games: Game[]): PlayerFit[] {
@@ -206,14 +304,41 @@ export class Whr {
       fits.set(playerId, {
         id: playerId,
         days,
-        games: days.map(() => []),
+        observations: days.map(() => []),
+        gamesPerDay: days.map(() => 0),
         r: new Float64Array(days.length),
         variance: new Float64Array(days.length),
         totalGames: 0,
       });
     });
 
-    // Pass 3: attach every game to both players' step for that day
+    // Pass 3: count every game into one observation per opponent per day.
+    // `byOpponent` finds an existing observation; it is only needed while building.
+    const byOpponent = new Map<string, Map<string, Observation>[]>();
+    const observationFor = (fit: PlayerFit, step: number, opponent: PlayerFit, opponentStep: number) => {
+      let steps = byOpponent.get(fit.id);
+      if (!steps) {
+        steps = fit.days.map(() => new Map<string, Observation>());
+        byOpponent.set(fit.id, steps);
+      }
+      const existing = steps[step].get(opponent.id);
+      if (existing) return existing;
+
+      const created: Observation = {
+        opponent,
+        opponentStep,
+        gamesWon: 0,
+        gamesLost: 0,
+        setsWon: 0,
+        setsLost: 0,
+        pointsWon: 0,
+        pointsLost: 0,
+      };
+      steps[step].set(opponent.id, created);
+      fit.observations[step].push(created);
+      return created;
+    };
+
     for (const game of games) {
       const day = toDay(game.playedAt);
       const winner = fits.get(game.winner)!;
@@ -221,8 +346,33 @@ export class Whr {
       const winnerStep = stepIndex.get(game.winner)!.get(day)!;
       const loserStep = stepIndex.get(game.loser)!.get(day)!;
 
-      winner.games[winnerStep].push({ opponent: loser, opponentStep: loserStep, won: true });
-      loser.games[loserStep].push({ opponent: winner, opponentStep: winnerStep, won: false });
+      const winnerSide = observationFor(winner, winnerStep, loser, loserStep);
+      const loserSide = observationFor(loser, loserStep, winner, winnerStep);
+
+      winnerSide.gamesWon++;
+      loserSide.gamesLost++;
+
+      if (game.score) {
+        winnerSide.setsWon += game.score.setsWon.gameWinner;
+        winnerSide.setsLost += game.score.setsWon.gameLoser;
+        loserSide.setsWon += game.score.setsWon.gameLoser;
+        loserSide.setsLost += game.score.setsWon.gameWinner;
+      }
+      if (game.score?.setPoints) {
+        let winnerPoints = 0;
+        let loserPoints = 0;
+        for (const set of game.score.setPoints) {
+          winnerPoints += set.gameWinner;
+          loserPoints += set.gameLoser;
+        }
+        winnerSide.pointsWon += winnerPoints;
+        winnerSide.pointsLost += loserPoints;
+        loserSide.pointsWon += loserPoints;
+        loserSide.pointsLost += winnerPoints;
+      }
+
+      winner.gamesPerDay[winnerStep]++;
+      loser.gamesPerDay[loserStep]++;
       winner.totalGames++;
       loser.totalGames++;
     }
@@ -237,13 +387,18 @@ export class Whr {
    *
    * Returns the largest natural-scale move, to drive the convergence check.
    */
-  private newtonSweep(fit: PlayerFit, driftVariancePerDay: number, anchorPrecision: number): number {
+  private newtonSweep(
+    fit: PlayerFit,
+    driftVariancePerDay: number,
+    anchorPrecision: number,
+    levelWeights: WhrLevelWeights,
+  ): number {
     const n = fit.days.length;
     const gradient = new Float64Array(n);
     const diagonal = new Float64Array(n);
     const offDiagonal = new Float64Array(Math.max(n - 1, 0));
 
-    this.accumulate(fit, gradient, diagonal, offDiagonal, driftVariancePerDay, anchorPrecision);
+    this.accumulate(fit, gradient, diagonal, offDiagonal, driftVariancePerDay, anchorPrecision, levelWeights);
 
     // The Hessian is negative definite, so solving it gives an ascent step
     const delta = this.solveTridiagonal(diagonal, offDiagonal, gradient, true);
@@ -265,16 +420,45 @@ export class Whr {
     offDiagonal: Float64Array,
     driftVariancePerDay: number,
     anchorPrecision: number,
+    levelWeights: WhrLevelWeights,
   ): void {
     const n = fit.days.length;
 
-    // Bradley-Terry likelihood of the games played on each day
+    // Bradley-Terry likelihood of everything played on each day
     for (let k = 0; k < n; k++) {
       const own = fit.r[k];
-      for (const game of fit.games[k]) {
-        const expected = sigmoid(own - game.opponent.r[game.opponentStep]);
-        gradient[k] += (game.won ? 1 : 0) - expected;
-        diagonal[k] -= expected * (1 - expected);
+      for (const observation of fit.observations[k]) {
+        const difference = own - observation.opponent.r[observation.opponentStep];
+        Whr.addBinomial(
+          gradient,
+          diagonal,
+          k,
+          difference,
+          observation.gamesWon,
+          observation.gamesLost,
+          1,
+          levelWeights.game,
+        );
+        Whr.addBinomial(
+          gradient,
+          diagonal,
+          k,
+          difference,
+          observation.setsWon,
+          observation.setsLost,
+          SET_SLOPE,
+          levelWeights.set,
+        );
+        Whr.addBinomial(
+          gradient,
+          diagonal,
+          k,
+          difference,
+          observation.pointsWon,
+          observation.pointsLost,
+          POINT_SLOPE,
+          levelWeights.point,
+        );
       }
     }
 
@@ -294,6 +478,32 @@ export class Whr {
       diagonal[k + 1] -= precision;
       offDiagonal[k] += precision;
     }
+  }
+
+  /**
+   * Adds one level of a result: `won` wins and `lost` losses at the same rating
+   * difference. Counted as one binomial term, which is the same as one term per
+   * unit and much faster over a long point log.
+   *
+   * The slope scales the rating difference, so the derivatives carry it through:
+   * the gradient once and the second derivative twice.
+   */
+  private static addBinomial(
+    gradient: Float64Array,
+    diagonal: Float64Array,
+    step: number,
+    difference: number,
+    won: number,
+    lost: number,
+    slope: number,
+    weight: number,
+  ): void {
+    const trials = won + lost;
+    if (trials === 0 || weight === 0) return;
+
+    const expected = sigmoid(slope * difference);
+    gradient[step] += weight * slope * (won - trials * expected);
+    diagonal[step] -= weight * slope * slope * trials * expected * (1 - expected);
   }
 
   /**
@@ -343,13 +553,18 @@ export class Whr {
    * the two sweeps, `inverse[i][i] = 1 / (forward[i] + backward[i] - a[i][i])`.
    * Both recursions use ratios only, so long curves stay numerically stable.
    */
-  private fillVariance(fit: PlayerFit, driftVariancePerDay: number, anchorPrecision: number): void {
+  private fillVariance(
+    fit: PlayerFit,
+    driftVariancePerDay: number,
+    anchorPrecision: number,
+    levelWeights: WhrLevelWeights,
+  ): void {
     const n = fit.days.length;
     const gradient = new Float64Array(n);
     const diagonal = new Float64Array(n);
     const offDiagonal = new Float64Array(Math.max(n - 1, 0));
 
-    this.accumulate(fit, gradient, diagonal, offDiagonal, driftVariancePerDay, anchorPrecision);
+    this.accumulate(fit, gradient, diagonal, offDiagonal, driftVariancePerDay, anchorPrecision, levelWeights);
 
     // Negate to get a positive definite matrix
     for (let i = 0; i < n; i++) diagonal[i] = -diagonal[i];

--- a/frontend/src/hooks/use-whr-worker.ts
+++ b/frontend/src/hooks/use-whr-worker.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from "react";
+import { WorkerMessage } from "../client/client-db/web-worker/web-worker";
+import { useEventDbContext } from "../wrappers/event-db-context";
+import { WhrConfig, WhrResult } from "../client/client-db/whr";
+import { createModernWorker } from "./use-elo-simulation-worker";
+
+/**
+ * Fits the Whole History Rating in a web worker. The fit restarts whenever the
+ * configuration changes, so a new setting replaces the previous result.
+ */
+export function useWhrWorker(config?: Partial<WhrConfig>) {
+  const context = useEventDbContext();
+
+  const [result, setResult] = useState<WhrResult | null>(null);
+  const [progress, setProgress] = useState(0);
+
+  // A stable key over the settings, so the effect restarts on a real change only
+  const configKey = JSON.stringify(config ?? {});
+
+  useEffect(() => {
+    const activeConfig = JSON.parse(configKey) as Partial<WhrConfig>;
+    setResult(null);
+    setProgress(0);
+
+    const worker = createModernWorker();
+
+    if (!worker) {
+      // Fallback: run on the main thread if workers are unavailable
+      setResult(context.whr.compute(activeConfig));
+      setProgress(1);
+      return;
+    }
+
+    worker.addEventListener("message", (e) => {
+      const message = e.data as WorkerMessage;
+      switch (message.type) {
+        case "whr-progress":
+          setProgress(message.data.progress);
+          break;
+
+        case "whr-result":
+          setResult(message.data.result);
+          setProgress(1);
+          break;
+      }
+    });
+
+    const message: WorkerMessage = {
+      type: "start-whr",
+      data: { events: context.events, config: activeConfig },
+    };
+    worker.postMessage(message);
+
+    return () => {
+      worker.terminate();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [configKey]);
+
+  return { result, progress };
+}

--- a/frontend/src/pages/simulations/simulations-page.tsx
+++ b/frontend/src/pages/simulations/simulations-page.tsx
@@ -7,6 +7,7 @@ export const SimulationsPage: React.FC = () => {
       title="Simulations"
       links={[
         { name: "Expected leaderboard 🥇🥈🥉", url: "expected-leaderboard" },
+        { name: "Skill rating over time 📈", url: "skill-rating" },
         { name: "Player network 🕸️", url: "/player-network" },
         { name: "Expected win/loss rate 🏆💔", url: "win-loss" },
         { name: "Numbered points 🔢🧮 (Experimental)", url: "individual-points" },

--- a/frontend/src/pages/simulations/skill-rating/skill-rating-page.test.tsx
+++ b/frontend/src/pages/simulations/skill-rating/skill-rating-page.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { EventDbContext } from "../../../wrappers/event-db-context";
+import { TennisTable } from "../../../client/client-db/tennis-table";
+import { EventType, EventTypeEnum } from "../../../client/client-db/event-store/event-types";
+import { WhrResult } from "../../../client/client-db/whr";
+import { SkillRatingPage } from "./skill-rating-page";
+
+// The worker hook cannot be imported under Jest, because the worker entry uses
+// `import.meta`. The fit itself is the real one, see whr.test.ts.
+let mockWorkerState: { result: WhrResult | null; progress: number } = { result: null, progress: 0 };
+jest.mock("../../../hooks/use-whr-worker", () => ({
+  useWhrWorker: () => mockWorkerState,
+}));
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+let sequence = 0;
+
+function player(id: string): EventType {
+  return { time: ++sequence, stream: id, type: EventTypeEnum.PLAYER_CREATED, data: { name: id } };
+}
+
+function game(winner: string, loser: string, day: number): EventType {
+  const playedAt = day * DAY_MS + ++sequence;
+  return {
+    time: playedAt,
+    stream: `game-${playedAt}`,
+    type: EventTypeEnum.GAME_CREATED,
+    data: { playedAt, winner, loser },
+  };
+}
+
+function renderPage(events: EventType[]) {
+  const context = new TennisTable({ events });
+  mockWorkerState = { result: context.whr.compute(), progress: 1 };
+
+  return render(
+    <MemoryRouter>
+      <EventDbContext.Provider value={context}>
+        <SkillRatingPage />
+      </EventDbContext.Provider>
+    </MemoryRouter>,
+  );
+}
+
+function playerColumn(): (string | null)[] {
+  return screen
+    .getAllByRole("row")
+    .slice(1)
+    .map((row) => (row as HTMLTableRowElement).cells[1].textContent);
+}
+
+describe("SkillRatingPage", () => {
+  beforeEach(() => {
+    sequence = 0;
+    mockWorkerState = { result: null, progress: 0 };
+  });
+
+  it("lists the rated players, strongest first", () => {
+    const events: EventType[] = [player("Ada"), player("Bo"), player("Cy")];
+    for (let day = 0; day < 6; day++) {
+      events.push(game("Ada", "Bo", day), game("Ada", "Cy", day), game("Bo", "Cy", day));
+    }
+
+    renderPage(events);
+
+    expect(screen.getByText("Skill rating over time")).toBeInTheDocument();
+    expect(playerColumn()).toEqual(["Ada", "Bo", "Cy"]);
+  });
+
+  it("tells the user when there is nothing to rate", () => {
+    renderPage([player("Ada"), player("Bo")]);
+
+    expect(screen.getByText("No games to rate yet.")).toBeInTheDocument();
+  });
+
+  it("hides a retired player from the list until it is asked for", () => {
+    const events: EventType[] = [player("Ada"), player("Bo"), player("Cy")];
+    for (let day = 0; day < 4; day++) {
+      events.push(game("Ada", "Bo", day), game("Bo", "Cy", day));
+    }
+    events.push({ time: ++sequence, stream: "Bo", type: EventTypeEnum.PLAYER_DEACTIVATED, data: null });
+
+    renderPage(events);
+
+    expect(playerColumn()).toEqual(["Ada", "Cy"]);
+    // The retired player is still rated, so the fit does not change when they leave
+    expect(mockWorkerState.result?.curves.map((curve) => curve.playerId).sort()).toEqual(["Ada", "Bo", "Cy"]);
+  });
+
+  it("shows the progress bar while the fit runs", () => {
+    render(
+      <MemoryRouter>
+        <EventDbContext.Provider value={new TennisTable({ events: [] })}>
+          <SkillRatingPage />
+        </EventDbContext.Provider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Fitting every game in the history…")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/simulations/skill-rating/skill-rating-page.test.tsx
+++ b/frontend/src/pages/simulations/skill-rating/skill-rating-page.test.tsx
@@ -89,6 +89,40 @@ describe("SkillRatingPage", () => {
     expect(mockWorkerState.result?.curves.map((curve) => curve.playerId).sort()).toEqual(["Ada", "Bo", "Cy"]);
   });
 
+  it("says how many games carry a score", () => {
+    const events: EventType[] = [player("Ada"), player("Bo")];
+    for (let day = 0; day < 3; day++) {
+      events.push(game("Ada", "Bo", day));
+    }
+    const scoredAt = 9 * DAY_MS + ++sequence;
+    events.push(
+      { time: scoredAt, stream: "scored", type: EventTypeEnum.GAME_CREATED, data: { playedAt: scoredAt, winner: "Ada", loser: "Bo" } },
+      {
+        time: scoredAt + 1,
+        stream: "scored",
+        type: EventTypeEnum.GAME_SCORE,
+        data: { setsWon: { gameWinner: 2, gameLoser: 0 }, setPoints: [{ gameWinner: 11, gameLoser: 5 }, { gameWinner: 11, gameLoser: 7 }] },
+      },
+    );
+
+    renderPage(events);
+
+    expect(screen.getByText(/A set score is recorded on/)).toHaveTextContent(
+      "A set score is recorded on 1 of 4 games, and the points of each set on 1.",
+    );
+  });
+
+  it("offers a switch for the set and point scores", () => {
+    const events: EventType[] = [player("Ada"), player("Bo")];
+    for (let day = 0; day < 3; day++) {
+      events.push(game("Ada", "Bo", day));
+    }
+
+    renderPage(events);
+
+    expect(screen.getByLabelText("Use set and point scores")).toBeChecked();
+  });
+
   it("shows the progress bar while the fit runs", () => {
     render(
       <MemoryRouter>

--- a/frontend/src/pages/simulations/skill-rating/skill-rating-page.test.tsx
+++ b/frontend/src/pages/simulations/skill-rating/skill-rating-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { EventDbContext } from "../../../wrappers/event-db-context";
 import { TennisTable } from "../../../client/client-db/tennis-table";
@@ -44,6 +44,12 @@ function renderPage(events: EventType[]) {
   );
 }
 
+function selectedNames(): (string | null)[] {
+  return Array.from(document.querySelectorAll('tr[data-selected="true"]')).map(
+    (row) => (row as HTMLTableRowElement).cells[1].textContent,
+  );
+}
+
 function playerColumn(): (string | null)[] {
   return screen
     .getAllByRole("row")
@@ -77,7 +83,7 @@ describe("SkillRatingPage", () => {
 
   it("hides a retired player from the list until it is asked for", () => {
     const events: EventType[] = [player("Ada"), player("Bo"), player("Cy")];
-    for (let day = 0; day < 4; day++) {
+    for (let day = 0; day < 6; day++) {
       events.push(game("Ada", "Bo", day), game("Bo", "Cy", day));
     }
     events.push({ time: ++sequence, stream: "Bo", type: EventTypeEnum.PLAYER_DEACTIVATED, data: null });
@@ -87,6 +93,47 @@ describe("SkillRatingPage", () => {
     expect(playerColumn()).toEqual(["Ada", "Cy"]);
     // The retired player is still rated, so the fit does not change when they leave
     expect(mockWorkerState.result?.curves.map((curve) => curve.playerId).sort()).toEqual(["Ada", "Bo", "Cy"]);
+
+    fireEvent.click(screen.getByLabelText("Include retired players"));
+    // The retired row carries a "retired" badge next to the name
+    expect(playerColumn()).toHaveLength(3);
+    expect(playerColumn().some((name) => name?.startsWith("Bo"))).toBe(true);
+  });
+
+  it("hides an unranked player from the list until it is asked for", () => {
+    // 'Cy' plays 2 games, below the 5 a ranked place needs
+    const events: EventType[] = [player("Ada"), player("Bo"), player("Cy")];
+    for (let day = 0; day < 6; day++) {
+      events.push(game("Ada", "Bo", day));
+    }
+    events.push(game("Ada", "Cy", 7), game("Bo", "Cy", 7));
+
+    renderPage(events);
+
+    expect(playerColumn()).not.toContain("Cy");
+
+    fireEvent.click(screen.getByLabelText("Include unranked players"));
+    expect(playerColumn()).toContain("Cy");
+  });
+
+  it("adds every player in the filter, and clears the selection", () => {
+    const events: EventType[] = [player("Ada"), player("Bo"), player("Cy")];
+    for (let day = 0; day < 6; day++) {
+      events.push(game("Ada", "Bo", day), game("Bo", "Cy", day), game("Ada", "Cy", day));
+    }
+
+    renderPage(events);
+
+    fireEvent.click(screen.getByText("Clear all"));
+    expect(selectedNames()).toEqual([]);
+
+    fireEvent.click(screen.getByText("Add all"));
+    expect(selectedNames().sort()).toEqual(["Ada", "Bo", "Cy"]);
+
+    // No upper limit, so the whole filter can go on the chart
+    fireEvent.click(screen.getByLabelText("Include unranked players"));
+    fireEvent.click(screen.getByText("Add all"));
+    expect(selectedNames().length).toBe(playerColumn().length);
   });
 
   it("says how many games carry a score", () => {
@@ -110,17 +157,6 @@ describe("SkillRatingPage", () => {
     expect(screen.getByText(/A set score is recorded on/)).toHaveTextContent(
       "A set score is recorded on 1 of 4 games, and the points of each set on 1.",
     );
-  });
-
-  it("offers a switch for the set and point scores", () => {
-    const events: EventType[] = [player("Ada"), player("Bo")];
-    for (let day = 0; day < 3; day++) {
-      events.push(game("Ada", "Bo", day));
-    }
-
-    renderPage(events);
-
-    expect(screen.getByLabelText("Use set and point scores")).toBeChecked();
   });
 
   it("shows the progress bar while the fit runs", () => {

--- a/frontend/src/pages/simulations/skill-rating/skill-rating-page.tsx
+++ b/frontend/src/pages/simulations/skill-rating/skill-rating-page.tsx
@@ -17,24 +17,25 @@ import { useWindowSize } from "usehooks-ts";
 import { classNames } from "../../../common/class-names";
 import { fmtNum } from "../../../common/number-utils";
 import { stringToColor } from "../../../common/string-to-color";
-import { relativeTimeStringShort } from "../../../common/date-utils";
+import { relativeTimeString, relativeTimeStringShort } from "../../../common/date-utils";
 import { useEventDbContext } from "../../../wrappers/event-db-context";
 import { useWhrWorker } from "../../../hooks/use-whr-worker";
-import { DEFAULT_LEVEL_WEIGHTS, GAME_LEVEL_ONLY, WhrPlayerCurve } from "../../../client/client-db/whr";
+import { WhrPlayerCurve } from "../../../client/client-db/whr";
 import { ProfilePicture } from "../../player/profile-picture";
-
-/** More curves than this on one chart cannot be told apart. */
-const MAX_SELECTED = 8;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const TREND_DAYS = 90;
 
-const DRIFT_PRESETS = [
-  { label: "Stable", driftPerDay: 1 },
-  { label: "Slow", driftPerDay: 4 },
-  { label: "Normal", driftPerDay: 8 },
-  { label: "Fast", driftPerDay: 16 },
-];
+/**
+ * How far a rating may move in one day, as a standard deviation in Elo points.
+ * A high value follows a change in form, and it also follows a run of luck. The
+ * points of a curve are then noisy, but the trend of a curve is readable, which
+ * is what this page is for.
+ */
+const DRIFT_PER_DAY = 16;
+
+/** More curves than this make a legend longer than it is useful. */
+const MAX_LEGEND_SERIES = 12;
 
 type ChartRow = {
   time: number;
@@ -51,6 +52,8 @@ type PlayerSummary = {
   /** Rating change over the last 90 days, when the player has a rating that far back. */
   trend: number | undefined;
   active: boolean;
+  /** Enough games to hold a place on the leaderboard. */
+  ranked: boolean;
 };
 
 /** Short axis tick. Includes the year only when the range covers more than one. */
@@ -62,7 +65,7 @@ function axisTick(time: number, spansYears: boolean): string {
   });
 }
 
-function summarize(curve: WhrPlayerCurve, active: boolean): PlayerSummary {
+function summarize(curve: WhrPlayerCurve, active: boolean, gameLimitForRanked: number): PlayerSummary {
   const last = curve.points[curve.points.length - 1];
   const trendFrom = curve.points.filter((point) => point.time <= last.time - TREND_DAYS * DAY_MS).pop();
 
@@ -74,6 +77,7 @@ function summarize(curve: WhrPlayerCurve, active: boolean): PlayerSummary {
     lastPlayed: last.time,
     trend: trendFrom ? last.rating - trendFrom.rating : undefined,
     active,
+    ranked: curve.totalGames >= gameLimitForRanked,
   };
 }
 
@@ -81,23 +85,21 @@ export const SkillRatingPage: React.FC = () => {
   const context = useEventDbContext();
   const { width = 0 } = useWindowSize();
 
-  const [driftPerDay, setDriftPerDay] = useState(DRIFT_PRESETS[1].driftPerDay);
   const [showRetired, setShowRetired] = useState(false);
-  const [useScores, setUseScores] = useState(true);
+  const [showUnranked, setShowUnranked] = useState(false);
   const [selected, setSelected] = useState<string[] | null>(null);
 
-  const { result, progress } = useWhrWorker(
-    useMemo(
-      () => ({ driftPerDay, levelWeights: useScores ? DEFAULT_LEVEL_WEIGHTS : GAME_LEVEL_ONLY }),
-      [driftPerDay, useScores],
-    ),
-  );
+  const { result, progress } = useWhrWorker(useMemo(() => ({ driftPerDay: DRIFT_PER_DAY }), []));
 
   const summaries = useMemo<PlayerSummary[]>(() => {
     if (!result) return [];
     return result.curves
       .map((curve) =>
-        summarize(curve, context.eventStore.playersProjector.getPlayer(curve.playerId)?.active === true),
+        summarize(
+          curve,
+          context.eventStore.playersProjector.getPlayer(curve.playerId)?.active === true,
+          context.client.gameLimitForRanked,
+        ),
       )
       .sort((a, b) => b.rating - a.rating);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -107,7 +109,7 @@ export const SkillRatingPage: React.FC = () => {
   const activeSelection = useMemo(() => {
     if (selected !== null) return selected;
     return summaries
-      .filter((summary) => summary.active)
+      .filter((summary) => summary.active && summary.ranked)
       .slice(0, 5)
       .map((summary) => summary.playerId);
   }, [selected, summaries]);
@@ -148,7 +150,6 @@ export const SkillRatingPage: React.FC = () => {
     setSelected(() => {
       const current = activeSelection;
       if (current.includes(playerId)) return current.filter((id) => id !== playerId);
-      if (current.length >= MAX_SELECTED) return current;
       return [...current, playerId];
     });
 
@@ -177,8 +178,9 @@ export const SkillRatingPage: React.FC = () => {
     );
   }
 
-  const selectable = summaries.filter((summary) => showRetired || summary.active);
-  const atCap = activeSelection.length >= MAX_SELECTED;
+  const selectable = summaries.filter(
+    (summary) => (showRetired || summary.active) && (showUnranked || summary.ranked),
+  );
 
   return (
     <div className="max-w-5xl mx-auto bg-primary-background rounded-lg p-2 md:p-4 text-primary-text">
@@ -192,33 +194,28 @@ export const SkillRatingPage: React.FC = () => {
 
       {/* Controls */}
       <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 mb-4">
-        <div className="flex items-center gap-2">
-          <span className="text-xs md:text-sm text-primary-text/80">Rating moves:</span>
-          <div className="flex gap-1">
-            {DRIFT_PRESETS.map((preset) => (
-              <button
-                key={preset.label}
-                onClick={() => setDriftPerDay(preset.driftPerDay)}
-                className={classNames(
-                  "px-2.5 py-1 rounded text-xs md:text-sm font-medium transition-colors",
-                  driftPerDay === preset.driftPerDay
-                    ? "bg-secondary-background text-secondary-text"
-                    : "border border-primary-text/20 hover:bg-secondary-background/50",
-                )}
-              >
-                {preset.label}
-              </button>
-            ))}
-          </div>
-        </div>
         <label className="flex items-center gap-2 text-xs md:text-sm text-primary-text/80">
-          <input type="checkbox" checked={useScores} onChange={(e) => setUseScores(e.target.checked)} />
-          Use set and point scores
+          <input type="checkbox" checked={showUnranked} onChange={(e) => setShowUnranked(e.target.checked)} />
+          Include unranked players
         </label>
         <label className="flex items-center gap-2 text-xs md:text-sm text-primary-text/80">
           <input type="checkbox" checked={showRetired} onChange={(e) => setShowRetired(e.target.checked)} />
-          Show retired players
+          Include retired players
         </label>
+        <div className="flex gap-1">
+          <button
+            onClick={() => setSelected(selectable.map((summary) => summary.playerId))}
+            className="px-2.5 py-1 rounded text-xs md:text-sm font-medium border border-primary-text/20 hover:bg-secondary-background/50 transition-colors"
+          >
+            Add all
+          </button>
+          <button
+            onClick={() => setSelected([])}
+            className="px-2.5 py-1 rounded text-xs md:text-sm font-medium border border-primary-text/20 hover:bg-secondary-background/50 transition-colors"
+          >
+            Clear all
+          </button>
+        </div>
       </div>
 
       {/* Chart */}
@@ -242,11 +239,13 @@ export const SkillRatingPage: React.FC = () => {
             stroke="rgb(var(--color-primary-text))"
             tick={{ fontSize: 11 }}
           />
-          <Tooltip animationDuration={0} content={<RatingTooltip spansYears={spansYears} />} />
-          <Legend
-            formatter={(value: string) => <span className="text-primary-text text-xs md:text-sm">{value}</span>}
-            iconType="plainline"
-          />
+          <Tooltip animationDuration={0} content={<RatingTooltip />} />
+          {activeSelection.length <= MAX_LEGEND_SERIES && (
+            <Legend
+              formatter={(value: string) => <span className="text-primary-text text-xs md:text-sm">{value}</span>}
+              iconType="plainline"
+            />
+          )}
           <ReferenceLine
             y={1000}
             stroke="rgb(var(--color-primary-text))"
@@ -291,9 +290,9 @@ export const SkillRatingPage: React.FC = () => {
       {activeSelection.length === 0 && (
         <p className="text-center text-primary-text/60 text-sm mt-2">Select a player below to see a curve.</p>
       )}
-      {atCap && (
+      {activeSelection.length > MAX_LEGEND_SERIES && (
         <p className="text-center text-primary-text/60 text-xs mt-1">
-          {MAX_SELECTED} players is the maximum. Remove one to add another.
+          {activeSelection.length} players on the chart. The colour of a row in the table matches its curve.
         </p>
       )}
 
@@ -317,11 +316,11 @@ export const SkillRatingPage: React.FC = () => {
               return (
                 <tr
                   key={summary.playerId}
+                  data-selected={isSelected}
                   onClick={() => toggle(summary.playerId)}
                   className={classNames(
                     "cursor-pointer transition-colors",
                     isSelected ? "bg-primary-text/10" : "hover:bg-primary-text/5",
-                    !isSelected && atCap && "opacity-60",
                   )}
                 >
                   <td className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-medium">
@@ -372,9 +371,8 @@ export const SkillRatingPage: React.FC = () => {
           a curve can change when new games arrive.
         </p>
         <p>
-          "Rating moves" sets how far a rating may move per day. A faster setting follows a change in form sooner, and it
-          also follows a run of luck. Stable holds a curve almost flat, which predicts new games slightly better but
-          hides a real change in form.
+          A curve follows a change in form closely, so it also follows a run of luck. Read the trend of a curve, not a
+          single point. The band of one player shows how exact each point is.
         </p>
         <p>
           The game result decides whether a rating goes up or down. The sets and the points then refine it. A set score
@@ -388,11 +386,7 @@ export const SkillRatingPage: React.FC = () => {
   );
 };
 
-const RatingTooltip: React.FC<{ spansYears?: boolean } & TooltipProps<ValueType, NameType>> = ({
-  active,
-  payload,
-  label,
-}) => {
+const RatingTooltip: React.FC<TooltipProps<ValueType, NameType>> = ({ active, payload, label }) => {
   if (!active || !payload || payload.length === 0) return null;
 
   const rows = payload.filter((item) => typeof item.value === "number");
@@ -401,7 +395,7 @@ const RatingTooltip: React.FC<{ spansYears?: boolean } & TooltipProps<ValueType,
   return (
     <div className="p-2 bg-primary-background ring-1 ring-primary-text rounded-lg text-primary-text text-sm">
       <p className="text-primary-text/70 text-xs mb-1">
-        {typeof label === "number" ? new Date(label).toLocaleDateString("nb-NO") : ""}
+        {typeof label === "number" ? relativeTimeString(new Date(label)) : ""}
       </p>
       {rows.map((item) => (
         <p key={item.name} className="flex items-center gap-2">

--- a/frontend/src/pages/simulations/skill-rating/skill-rating-page.tsx
+++ b/frontend/src/pages/simulations/skill-rating/skill-rating-page.tsx
@@ -294,7 +294,7 @@ export const SkillRatingPage: React.FC = () => {
               <th className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-medium">#</th>
               <th className="py-1 px-1 xs:px-2 md:px-3 text-left w-[50%] max-w-0 font-medium">Player</th>
               <th className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-medium">Rating</th>
-              <th className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light">±</th>
+              <th className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light">Uncertainty</th>
               <th className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light"></th>
             </tr>
           </thead>
@@ -329,7 +329,7 @@ export const SkillRatingPage: React.FC = () => {
                     {fmtNum(summary.rating, { digits: 0 })}
                   </td>
                   <td className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light text-primary-text/70">
-                    {fmtNum(summary.uncertainty, { digits: 0 })}
+                    ±{fmtNum(summary.uncertainty, { digits: 0 })}
                   </td>
                   <td className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light text-primary-text/70">
                     {relativeTimeStringShort(new Date(summary.lastPlayed))}

--- a/frontend/src/pages/simulations/skill-rating/skill-rating-page.tsx
+++ b/frontend/src/pages/simulations/skill-rating/skill-rating-page.tsx
@@ -23,9 +23,6 @@ import { useWhrWorker } from "../../../hooks/use-whr-worker";
 import { WhrPlayerCurve } from "../../../client/client-db/whr";
 import { ProfilePicture } from "../../player/profile-picture";
 
-const DAY_MS = 24 * 60 * 60 * 1000;
-const TREND_DAYS = 90;
-
 /**
  * How far a rating may move in one day, as a standard deviation in Elo points.
  * A high value follows a change in form, and it also follows a run of luck. The
@@ -47,10 +44,7 @@ type PlayerSummary = {
   playerId: string;
   rating: number;
   uncertainty: number;
-  games: number;
   lastPlayed: number;
-  /** Rating change over the last 90 days, when the player has a rating that far back. */
-  trend: number | undefined;
   active: boolean;
   /** Enough games to hold a place on the leaderboard. */
   ranked: boolean;
@@ -67,15 +61,11 @@ function axisTick(time: number, spansYears: boolean): string {
 
 function summarize(curve: WhrPlayerCurve, active: boolean, gameLimitForRanked: number): PlayerSummary {
   const last = curve.points[curve.points.length - 1];
-  const trendFrom = curve.points.filter((point) => point.time <= last.time - TREND_DAYS * DAY_MS).pop();
-
   return {
     playerId: curve.playerId,
     rating: last.rating,
     uncertainty: last.uncertainty,
-    games: curve.totalGames,
     lastPlayed: last.time,
-    trend: trendFrom ? last.rating - trendFrom.rating : undefined,
     active,
     ranked: curve.totalGames >= gameLimitForRanked,
   };
@@ -305,8 +295,6 @@ export const SkillRatingPage: React.FC = () => {
               <th className="py-1 px-1 xs:px-2 md:px-3 text-left w-[50%] max-w-0 font-medium">Player</th>
               <th className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-medium">Rating</th>
               <th className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light">±</th>
-              <th className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light">90 d</th>
-              <th className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light">Games</th>
               <th className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light"></th>
             </tr>
           </thead>
@@ -342,18 +330,6 @@ export const SkillRatingPage: React.FC = () => {
                   </td>
                   <td className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light text-primary-text/70">
                     {fmtNum(summary.uncertainty, { digits: 0 })}
-                  </td>
-                  <td className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light">
-                    {summary.trend === undefined ? (
-                      <span className="text-primary-text/40">-</span>
-                    ) : (
-                      <span className={summary.trend >= 0 ? "text-green-500" : "text-red-500"}>
-                        {fmtNum(summary.trend, { digits: 0, signedPositive: true })}
-                      </span>
-                    )}
-                  </td>
-                  <td className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light text-primary-text/70">
-                    {summary.games}
                   </td>
                   <td className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light text-primary-text/70">
                     {relativeTimeStringShort(new Date(summary.lastPlayed))}

--- a/frontend/src/pages/simulations/skill-rating/skill-rating-page.tsx
+++ b/frontend/src/pages/simulations/skill-rating/skill-rating-page.tsx
@@ -1,0 +1,396 @@
+import { useMemo, useState } from "react";
+import {
+  Area,
+  CartesianGrid,
+  ComposedChart,
+  Legend,
+  Line,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  TooltipProps,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { NameType, ValueType } from "recharts/types/component/DefaultTooltipContent";
+import { useWindowSize } from "usehooks-ts";
+import { classNames } from "../../../common/class-names";
+import { fmtNum } from "../../../common/number-utils";
+import { stringToColor } from "../../../common/string-to-color";
+import { relativeTimeStringShort } from "../../../common/date-utils";
+import { useEventDbContext } from "../../../wrappers/event-db-context";
+import { useWhrWorker } from "../../../hooks/use-whr-worker";
+import { WhrPlayerCurve } from "../../../client/client-db/whr";
+import { ProfilePicture } from "../../player/profile-picture";
+
+/** More curves than this on one chart cannot be told apart. */
+const MAX_SELECTED = 8;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const TREND_DAYS = 90;
+
+const DRIFT_PRESETS = [
+  { label: "Slow", driftPerDay: 4 },
+  { label: "Normal", driftPerDay: 8 },
+  { label: "Fast", driftPerDay: 16 },
+];
+
+type ChartRow = {
+  time: number;
+  band?: [number, number];
+  [playerId: string]: number | [number, number] | undefined;
+};
+
+type PlayerSummary = {
+  playerId: string;
+  rating: number;
+  uncertainty: number;
+  games: number;
+  lastPlayed: number;
+  /** Rating change over the last 90 days, when the player has a rating that far back. */
+  trend: number | undefined;
+  active: boolean;
+};
+
+/** Short axis tick. Includes the year only when the range covers more than one. */
+function axisTick(time: number, spansYears: boolean): string {
+  return new Date(time).toLocaleDateString("nb-NO", {
+    day: spansYears ? undefined : "numeric",
+    month: "short",
+    year: spansYears ? "2-digit" : undefined,
+  });
+}
+
+function summarize(curve: WhrPlayerCurve, active: boolean): PlayerSummary {
+  const last = curve.points[curve.points.length - 1];
+  const trendFrom = curve.points.filter((point) => point.time <= last.time - TREND_DAYS * DAY_MS).pop();
+
+  return {
+    playerId: curve.playerId,
+    rating: last.rating,
+    uncertainty: last.uncertainty,
+    games: curve.totalGames,
+    lastPlayed: last.time,
+    trend: trendFrom ? last.rating - trendFrom.rating : undefined,
+    active,
+  };
+}
+
+export const SkillRatingPage: React.FC = () => {
+  const context = useEventDbContext();
+  const { width = 0 } = useWindowSize();
+
+  const [driftPerDay, setDriftPerDay] = useState(DRIFT_PRESETS[1].driftPerDay);
+  const [showRetired, setShowRetired] = useState(false);
+  const [selected, setSelected] = useState<string[] | null>(null);
+
+  const { result, progress } = useWhrWorker(useMemo(() => ({ driftPerDay }), [driftPerDay]));
+
+  const summaries = useMemo<PlayerSummary[]>(() => {
+    if (!result) return [];
+    return result.curves
+      .map((curve) =>
+        summarize(curve, context.eventStore.playersProjector.getPlayer(curve.playerId)?.active === true),
+      )
+      .sort((a, b) => b.rating - a.rating);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [result]);
+
+  // Default to the five highest rated active players, until the user picks
+  const activeSelection = useMemo(() => {
+    if (selected !== null) return selected;
+    return summaries
+      .filter((summary) => summary.active)
+      .slice(0, 5)
+      .map((summary) => summary.playerId);
+  }, [selected, summaries]);
+
+  const curvesById = useMemo(
+    () => new Map((result?.curves ?? []).map((curve) => [curve.playerId, curve])),
+    [result],
+  );
+
+  const chartData = useMemo<ChartRow[]>(() => {
+    const rowsByTime = new Map<number, ChartRow>();
+    const single = activeSelection.length === 1;
+
+    for (const playerId of activeSelection) {
+      const curve = curvesById.get(playerId);
+      if (!curve) continue;
+      for (const point of curve.points) {
+        const row: ChartRow = rowsByTime.get(point.time) ?? { time: point.time };
+        row[playerId] = point.rating;
+        if (single) {
+          row.band = [point.rating - point.uncertainty, point.rating + point.uncertainty];
+        }
+        rowsByTime.set(point.time, row);
+      }
+    }
+
+    return Array.from(rowsByTime.values()).sort((a, b) => a.time - b.time);
+  }, [activeSelection, curvesById]);
+
+  const spansYears = useMemo(() => {
+    if (chartData.length < 2) return false;
+    const first = new Date(chartData[0].time).getFullYear();
+    const last = new Date(chartData[chartData.length - 1].time).getFullYear();
+    return first !== last;
+  }, [chartData]);
+
+  const toggle = (playerId: string) =>
+    setSelected(() => {
+      const current = activeSelection;
+      if (current.includes(playerId)) return current.filter((id) => id !== playerId);
+      if (current.length >= MAX_SELECTED) return current;
+      return [...current, playerId];
+    });
+
+  if (!result) {
+    return (
+      <div className="max-w-md mx-auto mt-12 p-6 bg-primary-background rounded-lg text-center">
+        <h1 className="text-xl md:text-2xl text-primary-text">Skill rating over time</h1>
+        <p className="text-primary-text/60 text-sm mt-2 mb-6">Fitting every game in the history…</p>
+        <div className="h-2.5 w-full rounded-full bg-primary-text/10 overflow-hidden">
+          <div
+            className="h-full rounded-full bg-secondary-background transition-all duration-150"
+            style={{ width: `${Math.round(progress * 100)}%` }}
+          />
+        </div>
+        <p className="text-primary-text/60 text-xs mt-2">{Math.round(progress * 100)} %</p>
+      </div>
+    );
+  }
+
+  if (summaries.length === 0) {
+    return (
+      <div className="max-w-md mx-auto mt-12 p-6 bg-primary-background rounded-lg text-center">
+        <h1 className="text-xl md:text-2xl text-primary-text">Skill rating over time</h1>
+        <p className="text-primary-text/60 text-sm mt-2">No games to rate yet.</p>
+      </div>
+    );
+  }
+
+  const selectable = summaries.filter((summary) => showRetired || summary.active);
+  const atCap = activeSelection.length >= MAX_SELECTED;
+
+  return (
+    <div className="max-w-5xl mx-auto bg-primary-background rounded-lg p-2 md:p-4 text-primary-text">
+      <h1 className="text-xl md:text-2xl text-center pt-2">Skill rating over time</h1>
+      <p className="text-center text-primary-text/60 text-xs md:text-sm mt-1 mb-4 max-w-2xl mx-auto">
+        One skill curve per player, fitted over every game at once. A rating of 1 000 is the skill of a new player, so
+        the numbers stay comparable back in time. The rating uses played games only. It does not change when a player
+        retires, and it does not depend on who is on the leaderboard today.
+      </p>
+
+      {/* Controls */}
+      <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 mb-4">
+        <div className="flex items-center gap-2">
+          <span className="text-xs md:text-sm text-primary-text/80">Rating moves:</span>
+          <div className="flex gap-1">
+            {DRIFT_PRESETS.map((preset) => (
+              <button
+                key={preset.label}
+                onClick={() => setDriftPerDay(preset.driftPerDay)}
+                className={classNames(
+                  "px-2.5 py-1 rounded text-xs md:text-sm font-medium transition-colors",
+                  driftPerDay === preset.driftPerDay
+                    ? "bg-secondary-background text-secondary-text"
+                    : "border border-primary-text/20 hover:bg-secondary-background/50",
+                )}
+              >
+                {preset.label}
+              </button>
+            ))}
+          </div>
+        </div>
+        <label className="flex items-center gap-2 text-xs md:text-sm text-primary-text/80">
+          <input type="checkbox" checked={showRetired} onChange={(e) => setShowRetired(e.target.checked)} />
+          Show retired players
+        </label>
+      </div>
+
+      {/* Chart */}
+      <ResponsiveContainer width="100%" height={width > 768 ? 400 : 300}>
+        <ComposedChart data={chartData} margin={{ top: 5, right: 8, left: -14 }}>
+          <CartesianGrid strokeDasharray="1 4" vertical={false} stroke="rgb(var(--color-primary-text))" opacity={0.4} />
+          <XAxis
+            dataKey="time"
+            type="number"
+            scale="time"
+            domain={["dataMin", "dataMax"]}
+            tickFormatter={(time: number) => axisTick(time, spansYears)}
+            stroke="rgb(var(--color-primary-text))"
+            tick={{ fontSize: 11 }}
+            minTickGap={28}
+          />
+          <YAxis
+            type="number"
+            domain={["dataMin - 30", "dataMax + 30"]}
+            tickFormatter={(value: number) => fmtNum(value, { digits: 0 }) ?? ""}
+            stroke="rgb(var(--color-primary-text))"
+            tick={{ fontSize: 11 }}
+          />
+          <Tooltip animationDuration={0} content={<RatingTooltip spansYears={spansYears} />} />
+          <Legend
+            formatter={(value: string) => <span className="text-primary-text text-xs md:text-sm">{value}</span>}
+            iconType="plainline"
+          />
+          <ReferenceLine
+            y={1000}
+            stroke="rgb(var(--color-primary-text))"
+            strokeDasharray="4 4"
+            opacity={0.6}
+            label={{ value: "New player", position: "insideBottomLeft", fill: "rgb(var(--color-primary-text))", fontSize: 11 }}
+          />
+          {activeSelection.length === 1 && (
+            <Area
+              dataKey="band"
+              stroke="none"
+              fill={stringToColor(activeSelection[0])}
+              fillOpacity={0.18}
+              legendType="none"
+              tooltipType="none"
+              connectNulls
+              activeDot={false}
+              isAnimationActive={false}
+            />
+          )}
+          {activeSelection.map((playerId) => (
+            <Line
+              key={playerId}
+              type="monotone"
+              dataKey={playerId}
+              name={context.playerName(playerId)}
+              stroke={stringToColor(playerId)}
+              strokeWidth={2}
+              dot={false}
+              connectNulls
+              isAnimationActive={false}
+            />
+          ))}
+        </ComposedChart>
+      </ResponsiveContainer>
+
+      {activeSelection.length === 1 && (
+        <p className="text-center text-primary-text/60 text-xs mt-1">
+          The band is one standard deviation. It is wide where there are few games.
+        </p>
+      )}
+      {activeSelection.length === 0 && (
+        <p className="text-center text-primary-text/60 text-sm mt-2">Select a player below to see a curve.</p>
+      )}
+      {atCap && (
+        <p className="text-center text-primary-text/60 text-xs mt-1">
+          {MAX_SELECTED} players is the maximum. Remove one to add another.
+        </p>
+      )}
+
+      {/* Ratings table, which is also the player selection */}
+      <div className="mt-4 rounded-lg w-full overflow-hidden">
+        <table className="w-full text-primary-text border-collapse text-xs xs:text-sm md:text-base">
+          <thead>
+            <tr className="text-primary-text">
+              <th className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-medium">#</th>
+              <th className="py-1 px-1 xs:px-2 md:px-3 text-left w-[50%] max-w-0 font-medium">Player</th>
+              <th className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-medium">Rating</th>
+              <th className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light">±</th>
+              <th className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light">90 d</th>
+              <th className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light">Games</th>
+              <th className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light"></th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-primary-text/50">
+            {selectable.map((summary, index) => {
+              const isSelected = activeSelection.includes(summary.playerId);
+              return (
+                <tr
+                  key={summary.playerId}
+                  onClick={() => toggle(summary.playerId)}
+                  className={classNames(
+                    "cursor-pointer transition-colors",
+                    isSelected ? "bg-primary-text/10" : "hover:bg-primary-text/5",
+                    !isSelected && atCap && "opacity-60",
+                  )}
+                >
+                  <td className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-medium">
+                    {index + 1}
+                  </td>
+                  <td className="py-1 px-1 xs:px-2 md:px-3 w-[50%] max-w-0">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span
+                        className="shrink-0 w-2.5 h-2.5 rounded-full"
+                        style={{ backgroundColor: isSelected ? stringToColor(summary.playerId) : "transparent" }}
+                      />
+                      <ProfilePicture playerId={summary.playerId} size={24} border={2} shape="rounded" />
+                      <span className="truncate">{context.playerName(summary.playerId)}</span>
+                      {!summary.active && <span className="shrink-0 text-primary-text/50 text-xs">retired</span>}
+                    </div>
+                  </td>
+                  <td className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-medium">
+                    {fmtNum(summary.rating, { digits: 0 })}
+                  </td>
+                  <td className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light text-primary-text/70">
+                    {fmtNum(summary.uncertainty, { digits: 0 })}
+                  </td>
+                  <td className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light">
+                    {summary.trend === undefined ? (
+                      <span className="text-primary-text/40">-</span>
+                    ) : (
+                      <span className={summary.trend >= 0 ? "text-green-500" : "text-red-500"}>
+                        {fmtNum(summary.trend, { digits: 0, signedPositive: true })}
+                      </span>
+                    )}
+                  </td>
+                  <td className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light text-primary-text/70">
+                    {summary.games}
+                  </td>
+                  <td className="py-1 px-1 xs:px-2 md:px-3 text-right w-[1%] whitespace-nowrap font-light text-primary-text/70">
+                    {relativeTimeStringShort(new Date(summary.lastPlayed))}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-4 space-y-1 text-xs text-primary-text/60">
+        <p>
+          The method is Whole History Rating. A result from today also sharpens the estimate of a player months back, so
+          a curve can change when new games arrive.
+        </p>
+        <p>
+          "Rating moves" sets how far a rating may move per day. A faster setting follows a change in form sooner, and it
+          also reacts more to a run of luck.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+const RatingTooltip: React.FC<{ spansYears?: boolean } & TooltipProps<ValueType, NameType>> = ({
+  active,
+  payload,
+  label,
+}) => {
+  if (!active || !payload || payload.length === 0) return null;
+
+  const rows = payload.filter((item) => typeof item.value === "number");
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="p-2 bg-primary-background ring-1 ring-primary-text rounded-lg text-primary-text text-sm">
+      <p className="text-primary-text/70 text-xs mb-1">
+        {typeof label === "number" ? new Date(label).toLocaleDateString("nb-NO") : ""}
+      </p>
+      {rows.map((item) => (
+        <p key={item.name} className="flex items-center gap-2">
+          <span className="w-2.5 h-2.5 rounded-full shrink-0" style={{ backgroundColor: item.color }} />
+          <span>
+            {item.name}: {fmtNum(item.value as number, { digits: 0 })}
+          </span>
+        </p>
+      ))}
+    </div>
+  );
+};

--- a/frontend/src/pages/simulations/skill-rating/skill-rating-page.tsx
+++ b/frontend/src/pages/simulations/skill-rating/skill-rating-page.tsx
@@ -31,6 +31,12 @@ import { ProfilePicture } from "../../player/profile-picture";
  */
 const DRIFT_PER_DAY = 16;
 
+/**
+ * TEMPORARY, for tuning only. Remove this list and the control that uses it,
+ * and the page goes back to the fixed DRIFT_PER_DAY above.
+ */
+const DEBUG_DRIFT_OPTIONS = [2, 4, 8, 16, 32, 64, 128];
+
 /** More curves than this make a legend longer than it is useful. */
 const MAX_LEGEND_SERIES = 12;
 
@@ -78,8 +84,10 @@ export const SkillRatingPage: React.FC = () => {
   const [showRetired, setShowRetired] = useState(false);
   const [showUnranked, setShowUnranked] = useState(false);
   const [selected, setSelected] = useState<string[] | null>(null);
+  // TEMPORARY, for tuning only
+  const [driftPerDay, setDriftPerDay] = useState(DRIFT_PER_DAY);
 
-  const { result, progress } = useWhrWorker(useMemo(() => ({ driftPerDay: DRIFT_PER_DAY }), []));
+  const { result, progress } = useWhrWorker(useMemo(() => ({ driftPerDay }), [driftPerDay]));
 
   const summaries = useMemo<PlayerSummary[]>(() => {
     if (!result) return [];
@@ -184,6 +192,26 @@ export const SkillRatingPage: React.FC = () => {
 
       {/* Controls */}
       <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 mb-4">
+        {/* TEMPORARY, for tuning only */}
+        <div className="flex items-center gap-2">
+          <span className="text-xs md:text-sm text-primary-text/80">Rating moves:</span>
+          <div className="flex flex-wrap gap-1">
+            {DEBUG_DRIFT_OPTIONS.map((option) => (
+              <button
+                key={option}
+                onClick={() => setDriftPerDay(option)}
+                className={classNames(
+                  "px-2 py-1 rounded text-xs md:text-sm font-medium transition-colors",
+                  driftPerDay === option
+                    ? "bg-secondary-background text-secondary-text"
+                    : "border border-primary-text/20 hover:bg-secondary-background/50",
+                )}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+        </div>
         <label className="flex items-center gap-2 text-xs md:text-sm text-primary-text/80">
           <input type="checkbox" checked={showUnranked} onChange={(e) => setShowUnranked(e.target.checked)} />
           Include unranked players

--- a/frontend/src/pages/simulations/skill-rating/skill-rating-page.tsx
+++ b/frontend/src/pages/simulations/skill-rating/skill-rating-page.tsx
@@ -31,12 +31,6 @@ import { ProfilePicture } from "../../player/profile-picture";
  */
 const DRIFT_PER_DAY = 16;
 
-/**
- * TEMPORARY, for tuning only. Remove this list and the control that uses it,
- * and the page goes back to the fixed DRIFT_PER_DAY above.
- */
-const DEBUG_DRIFT_OPTIONS = [2, 4, 8, 16, 32, 64, 128];
-
 /** More curves than this make a legend longer than it is useful. */
 const MAX_LEGEND_SERIES = 12;
 
@@ -84,10 +78,8 @@ export const SkillRatingPage: React.FC = () => {
   const [showRetired, setShowRetired] = useState(false);
   const [showUnranked, setShowUnranked] = useState(false);
   const [selected, setSelected] = useState<string[] | null>(null);
-  // TEMPORARY, for tuning only
-  const [driftPerDay, setDriftPerDay] = useState(DRIFT_PER_DAY);
 
-  const { result, progress } = useWhrWorker(useMemo(() => ({ driftPerDay }), [driftPerDay]));
+  const { result, progress } = useWhrWorker(useMemo(() => ({ driftPerDay: DRIFT_PER_DAY }), []));
 
   const summaries = useMemo<PlayerSummary[]>(() => {
     if (!result) return [];
@@ -192,26 +184,6 @@ export const SkillRatingPage: React.FC = () => {
 
       {/* Controls */}
       <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 mb-4">
-        {/* TEMPORARY, for tuning only */}
-        <div className="flex items-center gap-2">
-          <span className="text-xs md:text-sm text-primary-text/80">Rating moves:</span>
-          <div className="flex flex-wrap gap-1">
-            {DEBUG_DRIFT_OPTIONS.map((option) => (
-              <button
-                key={option}
-                onClick={() => setDriftPerDay(option)}
-                className={classNames(
-                  "px-2 py-1 rounded text-xs md:text-sm font-medium transition-colors",
-                  driftPerDay === option
-                    ? "bg-secondary-background text-secondary-text"
-                    : "border border-primary-text/20 hover:bg-secondary-background/50",
-                )}
-              >
-                {option}
-              </button>
-            ))}
-          </div>
-        </div>
         <label className="flex items-center gap-2 text-xs md:text-sm text-primary-text/80">
           <input type="checkbox" checked={showUnranked} onChange={(e) => setShowUnranked(e.target.checked)} />
           Include unranked players

--- a/frontend/src/pages/simulations/skill-rating/skill-rating-page.tsx
+++ b/frontend/src/pages/simulations/skill-rating/skill-rating-page.tsx
@@ -30,6 +30,7 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 const TREND_DAYS = 90;
 
 const DRIFT_PRESETS = [
+  { label: "Stable", driftPerDay: 1 },
   { label: "Slow", driftPerDay: 4 },
   { label: "Normal", driftPerDay: 8 },
   { label: "Fast", driftPerDay: 16 },
@@ -372,7 +373,8 @@ export const SkillRatingPage: React.FC = () => {
         </p>
         <p>
           "Rating moves" sets how far a rating may move per day. A faster setting follows a change in form sooner, and it
-          also reacts more to a run of luck.
+          also follows a run of luck. Stable holds a curve almost flat, which predicts new games slightly better but
+          hides a real change in form.
         </p>
         <p>
           The game result decides whether a rating goes up or down. The sets and the points then refine it. A set score

--- a/frontend/src/pages/simulations/skill-rating/skill-rating-page.tsx
+++ b/frontend/src/pages/simulations/skill-rating/skill-rating-page.tsx
@@ -20,7 +20,7 @@ import { stringToColor } from "../../../common/string-to-color";
 import { relativeTimeStringShort } from "../../../common/date-utils";
 import { useEventDbContext } from "../../../wrappers/event-db-context";
 import { useWhrWorker } from "../../../hooks/use-whr-worker";
-import { WhrPlayerCurve } from "../../../client/client-db/whr";
+import { DEFAULT_LEVEL_WEIGHTS, GAME_LEVEL_ONLY, WhrPlayerCurve } from "../../../client/client-db/whr";
 import { ProfilePicture } from "../../player/profile-picture";
 
 /** More curves than this on one chart cannot be told apart. */
@@ -82,9 +82,15 @@ export const SkillRatingPage: React.FC = () => {
 
   const [driftPerDay, setDriftPerDay] = useState(DRIFT_PRESETS[1].driftPerDay);
   const [showRetired, setShowRetired] = useState(false);
+  const [useScores, setUseScores] = useState(true);
   const [selected, setSelected] = useState<string[] | null>(null);
 
-  const { result, progress } = useWhrWorker(useMemo(() => ({ driftPerDay }), [driftPerDay]));
+  const { result, progress } = useWhrWorker(
+    useMemo(
+      () => ({ driftPerDay, levelWeights: useScores ? DEFAULT_LEVEL_WEIGHTS : GAME_LEVEL_ONLY }),
+      [driftPerDay, useScores],
+    ),
+  );
 
   const summaries = useMemo<PlayerSummary[]>(() => {
     if (!result) return [];
@@ -178,8 +184,9 @@ export const SkillRatingPage: React.FC = () => {
       <h1 className="text-xl md:text-2xl text-center pt-2">Skill rating over time</h1>
       <p className="text-center text-primary-text/60 text-xs md:text-sm mt-1 mb-4 max-w-2xl mx-auto">
         One skill curve per player, fitted over every game at once. A rating of 1 000 is the skill of a new player, so
-        the numbers stay comparable back in time. The rating uses played games only. It does not change when a player
-        retires, and it does not depend on who is on the leaderboard today.
+        the numbers stay comparable back in time. A win by a large margin moves a rating more than a win by a small
+        margin. The rating uses played games only. It does not change when a player retires, and it does not depend on
+        who is on the leaderboard today.
       </p>
 
       {/* Controls */}
@@ -203,6 +210,10 @@ export const SkillRatingPage: React.FC = () => {
             ))}
           </div>
         </div>
+        <label className="flex items-center gap-2 text-xs md:text-sm text-primary-text/80">
+          <input type="checkbox" checked={useScores} onChange={(e) => setUseScores(e.target.checked)} />
+          Use set and point scores
+        </label>
         <label className="flex items-center gap-2 text-xs md:text-sm text-primary-text/80">
           <input type="checkbox" checked={showRetired} onChange={(e) => setShowRetired(e.target.checked)} />
           Show retired players
@@ -362,6 +373,13 @@ export const SkillRatingPage: React.FC = () => {
         <p>
           "Rating moves" sets how far a rating may move per day. A faster setting follows a change in form sooner, and it
           also reacts more to a run of luck.
+        </p>
+        <p>
+          The game result decides whether a rating goes up or down. The sets and the points then refine it. A set score
+          is recorded on {fmtNum(result.coverage.withSets, { digits: 0 })} of{" "}
+          {fmtNum(result.coverage.games, { digits: 0 })} games, and the points of each set on{" "}
+          {fmtNum(result.coverage.withPoints, { digits: 0 })}. Games with no score still count in full at the game
+          level, so a rating is more exact over the period with recorded scores.
         </p>
       </div>
     </div>

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -5,6 +5,13 @@ import "@testing-library/jest-dom";
 process.env.REACT_APP_API_BASE_URL = "http://localhost:8000";
 process.env.REACT_APP_IMAGE_KIT_PUBLIC_KEY = "test_key";
 
+// jsdom does not implement ResizeObserver, which Recharts' ResponsiveContainer needs
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
 // jsdom does not implement window.matchMedia
 Object.defineProperty(window, "matchMedia", {
   writable: true,


### PR DESCRIPTION
The expected score simulation measures a player's share of the active
field. Its pool total is pinned at N * 1000 because Elo is zero-sum, so
the mean is always 1000 and the number cannot represent absolute skill.
It also reads the active flag as of today, so a retirement rewrites every
player's simulated history.

This adds a separate rating that answers the skill question instead, and
leaves the expected score simulation unchanged.

Whole History Rating (Coulom, 2008) fits a Bradley-Terry model over the
whole game history at once, with one time step per player per day played
and a Wiener process prior between a player's own steps. The gauge that
game results leave open is fixed by a prior on each player's first step,
so a rating is measured against the skill of a new player and stays
comparable across years. Uncertainty comes from the diagonal of the
inverse Hessian, computed with a forward and a backward recursion so long
curves stay numerically stable.

The rating reads played games only and never the active flag, so a
retirement changes nobody's history. A test asserts that property.

- whr.ts: the fit, with a tridiagonal Newton solve per player
- use-whr-worker.ts and worker messages: runs off the main thread
- skill-rating-page.tsx: curves, uncertainty band, ratings table
- 400 sweeps by default, measured as what a dense league needs to converge
- ResizeObserver polyfill in setupTests, needed by Recharts under jsdom

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Dxu75RbMXcEbe8hyzuT2Dg