### PR TITLE
Add a Hall of Fame score over time graph

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -53,12 +53,13 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
         "The toggle above the score has a new option: Score over time. The graph starts on the day the player joined and ends now.",
       ),
       text(
-        "A second toggle selects what the graph shows. Cumulative gives the score as it was at each point. Delta gives the points the player gained since the previous point. A section picker filters both to the total score or to 1 of the 9 sections.",
+        "A second toggle selects what the graph shows. Cumulative gives the score as it was at each point. Delta gives the points the player gained in each period. A section picker filters both to the total score or to 1 of the 9 sections.",
       ),
       list(
         "The first point is the day the player was created.",
         "The last point is now.",
         "The points are never closer than 1 day, and never more than 100 in total.",
+        "Delta groups the points into a maximum of 25 periods, so the bars stay readable.",
       ),
       text(
         "The app projects the full state of every player at each timestamp and scores the player against it. The score depends on what all other players did, so each point needs a complete calculation. The work runs in a web worker and shows a progress bar.",

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -42,6 +42,30 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "hall-of-fame-score-over-time",
+    title: "Hall of Fame score over time",
+    date: "2026-08-19",
+    tags: ["feature-update", "technical"],
+    summary:
+      "The Hall of Fame player page has a new view. It shows a graph of the score of the player at up to 100 points in time.",
+    body: [
+      text(
+        "The toggle above the score has a new option: Score over time. The graph starts on the day the player joined and ends now.",
+      ),
+      text(
+        "A second toggle selects what the graph shows. Cumulative gives the score as it was at each point. Delta gives the points the player gained since the previous point. A section picker filters both to the total score or to 1 of the 9 sections.",
+      ),
+      list(
+        "The first point is the day the player was created.",
+        "The last point is now.",
+        "The points are never closer than 1 day, and never more than 100 in total.",
+      ),
+      text(
+        "The app projects the full state of every player at each timestamp and scores the player against it. The score depends on what all other players did, so each point needs a complete calculation. The work runs in a web worker and shows a progress bar.",
+      ),
+    ],
+  },
+  {
     slug: "game-details-set-and-situation-graphs",
     title: "2 new graphs on game details",
     date: "2026-08-18",

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -42,6 +42,25 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "tournament-points-in-a-past-state",
+    title: "Correct tournament points in a past state",
+    date: "2026-08-19",
+    tags: ["bug-fix"],
+    summary:
+      "The app gave tournament points for a tournament that had not started, or that no person had created yet, when it calculated a state at a time in the past.",
+    body: [
+      text(
+        "A tournament now gives points only from the day it starts. The tournament logic uses the time of the state that the page shows. Before this change it used the current time, so a tournament with a later start date still built a bracket and gave points.",
+      ),
+      text(
+        "A second fault gave points for a tournament that did not exist yet. Some old signup events are earlier than the create event of their tournament. The app made a tournament from the signup alone, with no name and no start date, and put every game ever played into it.",
+      ),
+      text(
+        "The scores of today do not change. The pages that show a past state do change: the Hall of Fame score over time, and the Hall of Fame comparison on the What Changed page.",
+      ),
+    ],
+  },
+  {
     slug: "hall-of-fame-score-over-time",
     title: "Hall of Fame score over time",
     date: "2026-08-19",

--- a/frontend/src/client/client-db/__tests__/achievements/season-medals-in-a-past-state.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/season-medals-in-a-past-state.test.ts
@@ -1,0 +1,65 @@
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { TennisTable } from "../../tennis-table";
+import { determineSeason } from "../../seasons/seasons";
+
+// The season medals read the final leaderboard of a season, so they exist only
+// after the season has ended. The rule used to compare against the real clock,
+// so a state projected at a moment inside a running season treated that season
+// as finished and gave the medal to whoever led at that moment. The medal then
+// moved to another player, or vanished, as the lead changed — a Hall of Fame
+// score that fell over time for an award nobody had actually won yet.
+describe("Season medals in a state projected at a past moment", () => {
+  const season = determineSeason(new Date(2024, 1, 15, 12).getTime());
+  const early = season.start + 24 * 60 * 60 * 1000;
+  const late = season.end - 24 * 60 * 60 * 1000;
+
+  const game = (id: string, playedAt: number, winner: string, loser: string): EventType => ({
+    type: EventTypeEnum.GAME_CREATED,
+    stream: id,
+    time: playedAt,
+    data: { winner, loser, playedAt },
+  });
+
+  // Alice leads early. Bob wins every later game and ends the season on top.
+  const events: EventType[] = [
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "alice", time: 1, data: { name: "Alice" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "bob", time: 2, data: { name: "Bob" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "carol", time: 3, data: { name: "Carol" } },
+    game("g1", early, "alice", "carol"),
+    game("g2", early + 1000, "alice", "carol"),
+    game("g3", late, "bob", "carol"),
+    game("g4", late + 1000, "bob", "carol"),
+    game("g5", late + 2000, "bob", "alice"),
+    game("g6", late + 3000, "bob", "alice"),
+  ];
+
+  const medalsAt = (referenceTime: number) => {
+    const upTo = events.filter((event) =>
+      event.type === EventTypeEnum.GAME_CREATED ? event.data.playedAt <= referenceTime : event.time <= referenceTime,
+    );
+    const tennisTable = new TennisTable({ events: upTo, referenceTime });
+    tennisTable.achievements.calculateAchievements();
+    return ["alice", "bob", "carol"].flatMap((playerId) =>
+      (tennisTable.achievements.achievementMap.get(playerId) ?? [])
+        .filter((a) => a.type === "season-winner" || a.type === "so-close")
+        .map((a) => `${playerId}:${a.type}`),
+    );
+  };
+
+  it("gives no season medal while the season is still running", () => {
+    expect(medalsAt(early + 2000)).toEqual([]);
+    expect(medalsAt(late + 3000)).toEqual([]);
+  });
+
+  it("gives the medal to the player who led at the end of the season", () => {
+    const medals = medalsAt(season.end + 1000);
+    expect(medals).toContain("bob:season-winner");
+    expect(medals).not.toContain("alice:season-winner");
+  });
+
+  it("keeps the medal once the season has ended", () => {
+    const atEnd = medalsAt(season.end + 1000);
+    const muchLater = medalsAt(season.end + 400 * 24 * 60 * 60 * 1000);
+    expect(muchLater).toEqual(atEnd);
+  });
+});

--- a/frontend/src/client/client-db/__tests__/event-store/tournaments-projector.test.ts
+++ b/frontend/src/client/client-db/__tests__/event-store/tournaments-projector.test.ts
@@ -54,6 +54,44 @@ function undoSkipEvent(stream: string, skipId: string, time = 8000): TournamentU
 }
 
 describe("TournamentsProjector projection", () => {
+  // Old data has signups that predate the create event of their tournament, and
+  // a state projected at a point in time inside that window must not treat the
+  // placeholder record as a tournament. Its start date of 0 would sweep every
+  // game ever played into a bracket and hand out scores for a tournament that
+  // did not exist yet.
+  it("hides a tournament that has no create event yet", () => {
+    const projector = new TournamentsProjector();
+    projector.signup(signupEvent("t1", "p1"));
+
+    expect(projector.getTournamentConfig("t1")).toBeUndefined();
+    expect(projector.getTournamentConfigs()).toEqual([]);
+  });
+
+  it("hides a tournament known only from a skipped game", () => {
+    const projector = new TournamentsProjector();
+    projector.skipGame(skipEvent("t1", "s1", "p1", "p2"));
+
+    expect(projector.getTournamentConfigs()).toEqual([]);
+  });
+
+  it("shows the tournament once its create event arrives after a signup", () => {
+    const projector = new TournamentsProjector();
+    projector.signup(signupEvent("t1", "p1"));
+    projector.createTournament(createEvent("t1", { name: "Spring Cup" }));
+
+    expect(projector.getTournamentConfigs().map((config) => config.name)).toEqual(["Spring Cup"]);
+    expect(projector.getTournamentConfig("t1")?.startDate).toBe(FUTURE_START);
+    // The signup from before the create event is kept
+    expect(projector.getTournamentSignups("t1").map((signup) => signup.player)).toEqual(["p1"]);
+  });
+
+  it("keeps hiding a tournament that only an update event touched", () => {
+    const projector = new TournamentsProjector();
+    projector.updateTournament(updateEvent("t1", { name: "Renamed" }));
+
+    expect(projector.getTournamentConfigs()).toEqual([]);
+  });
+
   it("creates a tournament with its full config", () => {
     const projector = new TournamentsProjector();
     projector.createTournament(

--- a/frontend/src/client/client-db/__tests__/hall-of-fame/score-history.test.ts
+++ b/frontend/src/client/client-db/__tests__/hall-of-fame/score-history.test.ts
@@ -1,0 +1,124 @@
+import { ONE_DAY } from "../../../../common/time-in-ms";
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { HISTORY_MAX_POINTS, hallOfFameHistoryTimes } from "../../hall-of-fame-history";
+import { TennisTable } from "../../tennis-table";
+
+describe("Hall of Fame score history timestamps", () => {
+  const created = 1_700_000_000_000;
+
+  it("returns only the creation time when the player was created now", () => {
+    expect(hallOfFameHistoryTimes(created, created)).toEqual([created]);
+  });
+
+  it("returns the creation time and now for a career shorter than one day", () => {
+    const now = created + ONE_DAY / 2;
+    expect(hallOfFameHistoryTimes(created, now)).toEqual([created, now]);
+  });
+
+  it("starts at the creation time and ends at now", () => {
+    const now = created + 500 * ONE_DAY;
+    const times = hallOfFameHistoryTimes(created, now);
+    expect(times[0]).toBe(created);
+    expect(times[times.length - 1]).toBe(now);
+  });
+
+  it("never returns more points than the maximum", () => {
+    for (const days of [1, 2, 30, 99, 100, 101, 365, 1_000, 10_000]) {
+      const times = hallOfFameHistoryTimes(created, created + days * ONE_DAY);
+      expect(times.length).toBeLessThanOrEqual(HISTORY_MAX_POINTS);
+    }
+  });
+
+  it("keeps at least one day between every point", () => {
+    for (const days of [1, 2, 30, 99, 100, 101, 365, 1_000, 10_000]) {
+      const times = hallOfFameHistoryTimes(created, created + days * ONE_DAY);
+      for (let i = 1; i < times.length; i++) {
+        expect(times[i] - times[i - 1]).toBeGreaterThanOrEqual(ONE_DAY);
+      }
+    }
+  });
+
+  it("uses one point per day for a career shorter than the maximum", () => {
+    const times = hallOfFameHistoryTimes(created, created + 10 * ONE_DAY);
+    expect(times.length).toBe(11);
+  });
+
+  it("uses the full maximum for a long career", () => {
+    const times = hallOfFameHistoryTimes(created, created + 5 * 365 * ONE_DAY);
+    expect(times.length).toBe(HISTORY_MAX_POINTS);
+  });
+
+  it("rises in time", () => {
+    const times = hallOfFameHistoryTimes(created, created + 743 * ONE_DAY);
+    for (let i = 1; i < times.length; i++) {
+      expect(times[i]).toBeGreaterThan(times[i - 1]);
+    }
+  });
+});
+
+describe("Hall of Fame score history", () => {
+  const created = 1_700_000_000_000;
+
+  const game = (id: string, time: number, winner: string, loser: string): EventType => ({
+    time,
+    stream: id,
+    type: EventTypeEnum.GAME_CREATED,
+    data: { playedAt: time, winner, loser },
+  });
+
+  // "a" plays one game on day 1 and one game on day 20, so the score grows
+  // twice over a 40 day career.
+  const events: EventType[] = [
+    { time: created, stream: "a", type: EventTypeEnum.PLAYER_CREATED, data: { name: "A" } },
+    { time: created, stream: "b", type: EventTypeEnum.PLAYER_CREATED, data: { name: "B" } },
+    game("g1", created + 1 * ONE_DAY, "a", "b"),
+    game("g2", created + 20 * ONE_DAY, "a", "b"),
+  ];
+
+  const historyFor = (playerId: string) => {
+    const tennisTable = new TennisTable({ events });
+    return tennisTable.hallOfFameHistory.computeForPlayer(playerId, created + 40 * ONE_DAY);
+  };
+
+  it("starts the player at a score of 0 on the day the player joined", () => {
+    const { points } = historyFor("a");
+    expect(points[0].time).toBe(created);
+    expect(points[0].total).toBe(0);
+  });
+
+  it("scores the last point the same as the score of the player today", () => {
+    const tennisTable = new TennisTable({ events });
+    const { points } = tennisTable.hallOfFameHistory.computeForPlayer("a", created + 40 * ONE_DAY);
+    const today = tennisTable.hallOfFame.getScoreForAnyPlayer("a");
+    expect(points[points.length - 1].total).toBe(today?.score.total);
+  });
+
+  it("reports every section of the score at every point", () => {
+    const { points } = historyFor("a");
+    const last = points[points.length - 1];
+    expect(last.factors.experience).toBe(6); // 2 wins, 3 points each
+    expect(last.factors.socialDiversity).toBe(20); // 1 unique opponent
+  });
+
+  it("grows the score when the player plays, and holds it when the player rests", () => {
+    const { points } = historyFor("a");
+    const afterFirstGame = points.find((p) => p.time > created + 1 * ONE_DAY);
+    const beforeSecondGame = points.findLast((p) => p.time < created + 20 * ONE_DAY);
+    expect(afterFirstGame?.factors.experience).toBe(3);
+    expect(beforeSecondGame?.factors.experience).toBe(3);
+  });
+
+  it("returns no points for a player that does not exist", () => {
+    expect(historyFor("unknown").points).toEqual([]);
+  });
+
+  it("reports the progress of every point", () => {
+    const progress: number[] = [];
+    const tennisTable = new TennisTable({ events });
+    const { points } = tennisTable.hallOfFameHistory.computeForPlayer("a", created + 40 * ONE_DAY, (p) =>
+      progress.push(p),
+    );
+    expect(progress.length).toBe(points.length);
+    expect(progress[progress.length - 1]).toBe(1);
+  });
+});

--- a/frontend/src/client/client-db/__tests__/hall-of-fame/tournament-progression.test.ts
+++ b/frontend/src/client/client-db/__tests__/hall-of-fame/tournament-progression.test.ts
@@ -199,3 +199,58 @@ describe("Tournament progression scoring for double elimination", () => {
     ]);
   });
 });
+
+// Old data has signups that predate the create event of their tournament. In the
+// window between the two, the tournament used to project as a placeholder with a
+// start date of 0, which swept every game ever played into its bracket. A score
+// at a point in time inside that window then counted a tournament that did not
+// exist yet, and the score dropped again when the real create event arrived.
+describe("Hall of Fame tournament progression with a signup before the create event", () => {
+  const PLAYER = "p1";
+  const OTHER = "p2";
+  const SIGNUP_TIME = 1_000;
+  const CREATE_TIME = 500_000;
+  const TOURNAMENT_START = 600_000;
+
+  const events: EventType[] = [
+    { time: 100, stream: PLAYER, type: EventTypeEnum.PLAYER_CREATED, data: { name: "P1" } },
+    { time: 200, stream: OTHER, type: EventTypeEnum.PLAYER_CREATED, data: { name: "P2" } },
+    {
+      time: SIGNUP_TIME,
+      stream: "late-tournament",
+      type: EventTypeEnum.TOURNAMENT_SIGNUP,
+      data: { player: PLAYER },
+    },
+    {
+      time: 2_000,
+      stream: "g1",
+      type: EventTypeEnum.GAME_CREATED,
+      data: { playedAt: 2_000, winner: PLAYER, loser: OTHER },
+    },
+    {
+      time: CREATE_TIME,
+      stream: "late-tournament",
+      type: EventTypeEnum.TOURNAMENT_CREATED,
+      data: { name: "Late Cup", startDate: TOURNAMENT_START, groupPlay: false },
+    },
+  ];
+
+  const scoreAt = (time: number) => {
+    const upTo = events.filter((event) =>
+      event.type === EventTypeEnum.GAME_CREATED ? event.data.playedAt <= time : event.time <= time,
+    );
+    return new TennisTable({ events: upTo, referenceTime: time }).hallOfFame.getScoreForAnyPlayer(PLAYER)?.score
+      .tournamentProgression;
+  };
+
+  it("gives no tournament points while only the signup is known", () => {
+    const score = scoreAt(CREATE_TIME - 1);
+    expect(score?.score).toBe(0);
+    expect(score?.tournaments).toEqual([]);
+  });
+
+  it("gives no tournament points before the tournament starts", () => {
+    const score = scoreAt(TOURNAMENT_START - 1);
+    expect(score?.score).toBe(0);
+  });
+});

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -104,6 +104,17 @@ export class Achievements {
   private hasCalculated = false;
 
   achievementMap: Map<string, Achievement[]> = new Map();
+
+  /** The moment the achievements are awarded for: the reference time of a
+   * projection of a past state, or the real clock for the live state. Read
+   * lazily so the live state always uses the current time.
+   *
+   * Only the awarding rules use this. The progression figures below are the
+   * live attempt of the player who is looking at the Progress tab ("games won
+   * today", "wins in the last 90 minutes"), so they stay on the real clock. */
+  get #now(): number {
+    return this.parent.referenceTime ?? Date.now();
+  }
   // Highest Elo gain each player has achieved from a win where BOTH
   // players were ranked at the time. Used for David progression.
   bestDavidGain: Map<string, number> = new Map();
@@ -1079,7 +1090,7 @@ export class Achievements {
     // Award Perfect Day for each undefeated 5+ game day, in day order. Days
     // that have not fully elapsed are skipped: more games can still be played,
     // and a single loss would nullify the day.
-    const todayStart = dayStartOf(Date.now());
+    const todayStart = dayStartOf(this.#now);
     for (const [playerId, days] of perDay) {
       const sortedDays = Array.from(days.entries()).sort((a, b) => a[0] - b[0]);
       for (const [day, stats] of sortedDays) {
@@ -2611,7 +2622,7 @@ export class Achievements {
       const tournamentId = t.tournamentConfig.id;
 
       // Only award participation if the tournament has started
-      if (t.tournamentConfig.startDate > Date.now()) return;
+      if (t.tournamentConfig.startDate > this.#now) return;
 
       // Check participation for all players in the tournament
       t.tournamentConfig.playerOrder?.forEach((playerId) => {
@@ -2749,7 +2760,7 @@ export class Achievements {
 
       // The remaining season achievements read the FINAL leaderboard, so
       // they only exist once the season has ended.
-      if (Date.now() > s.end && leaderboard.length > 0) {
+      if (this.#now > s.end && leaderboard.length > 0) {
         const winner = leaderboard[0].playerId;
         this.#addAchievement(winner, this.#createAchievement("season-winner", winner, s.end, { seasonStart: s.start }));
 

--- a/frontend/src/client/client-db/event-store/events-up-to.ts
+++ b/frontend/src/client/client-db/event-store/events-up-to.ts
@@ -1,0 +1,12 @@
+import { EventType, EventTypeEnum } from "./event-types";
+
+/** The events that make up the app state at a point in time.
+ * Games count by when they were played, everything else by event time. */
+export function eventsUpTo(events: EventType[], time: number): EventType[] {
+  return events.filter((event) => {
+    if (event.type === EventTypeEnum.GAME_CREATED) {
+      return event.data.playedAt <= time;
+    }
+    return event.time <= time;
+  });
+}

--- a/frontend/src/client/client-db/event-store/projectors/tournaments-projector.ts
+++ b/frontend/src/client/client-db/event-store/projectors/tournaments-projector.ts
@@ -25,6 +25,15 @@ export type TournamentConfig = {
 type Tournament = {
   id: string;
   config: TournamentConfig;
+  /**
+   * Whether a TOURNAMENT_CREATED event has been projected for this id. Any
+   * tournament event creates the record, so a signup or a skipped game alone
+   * leaves a placeholder config behind: no name, and a start date of 0 that
+   * would sweep every game ever played into the tournament. Old data has
+   * signups that predate their create event, and a state projected at a point
+   * in time inside that window must not treat the placeholder as a tournament.
+   */
+  created: boolean;
   signups: Map<string, SignUp>;
   skippedGames: Map<string, SkippedGame>;
 };
@@ -44,12 +53,12 @@ export class TournamentsProjector {
   }
 
   getTournamentConfigs(): TournamentConfig[] {
-    return this.tournaments.filter((t) => !t.config.deleted).map((t) => t.config);
+    return this.tournaments.filter((t) => t.created && !t.config.deleted).map((t) => t.config);
   }
 
   getTournamentConfig(tournamentId: string): TournamentConfig | undefined {
     const tournament = this.#tournamentsMap.get(tournamentId);
-    if (!tournament || tournament.config.deleted) return undefined;
+    if (!tournament || !tournament.created || tournament.config.deleted) return undefined;
     return tournament.config;
   }
 
@@ -69,6 +78,7 @@ export class TournamentsProjector {
     this.#tournamentsMap.set(tournamentId, {
       id: tournamentId,
       config: { id: tournamentId, name: "", startDate: 0, groupPlay: false, doubleElimination: false, deleted: false },
+      created: false,
       signups: new Map(),
       skippedGames: new Map(),
     });
@@ -79,6 +89,7 @@ export class TournamentsProjector {
 
   createTournament(event: TournamentCreated) {
     const tournament = this.#getOrCreateTournament(event.stream);
+    tournament.created = true;
     tournament.config = {
       id: event.stream,
       name: event.data.name,

--- a/frontend/src/client/client-db/hall-of-fame-history.ts
+++ b/frontend/src/client/client-db/hall-of-fame-history.ts
@@ -1,0 +1,100 @@
+import { ONE_DAY } from "../../common/time-in-ms";
+import { eventsUpTo } from "./event-store/events-up-to";
+import { HallOfFameFactorKey } from "./hall-of-fame";
+import { TennisTable } from "./tennis-table";
+
+/** Most simulated points on the graph. */
+export const HISTORY_MAX_POINTS = 100;
+
+/** Shortest time between two simulated points. */
+export const HISTORY_MIN_STEP_MS = ONE_DAY;
+
+export type HallOfFameHistoryPoint = {
+  time: number;
+  total: number;
+  factors: Record<HallOfFameFactorKey, number>;
+};
+
+export type HallOfFameHistoryResult = {
+  playerId: string;
+  points: HallOfFameHistoryPoint[];
+};
+
+/** The timestamps to simulate the score at.
+ *
+ * The first point is when the player was created and the last point is `now`.
+ * In between the points are evenly spread, never closer than one day and never
+ * more than `HISTORY_MAX_POINTS` in total. A short career therefore gets one
+ * point per day, and a long career gets 100 points spread over its full span. */
+export function hallOfFameHistoryTimes(createdAt: number, now: number): number[] {
+  if (now <= createdAt) return [createdAt];
+
+  const span = now - createdAt;
+  const step = Math.max(HISTORY_MIN_STEP_MS, span / (HISTORY_MAX_POINTS - 1));
+
+  const times = [createdAt];
+  // Only keep a point while a full step still fits before `now`, so the last
+  // step (up to `now`) never falls below the minimum distance. The 1 ms
+  // tolerance keeps float division from dropping the final even point.
+  for (let time = createdAt + step; time <= now - step + 1; time += step) {
+    times.push(Math.floor(time));
+  }
+  times.push(now);
+
+  return times;
+}
+
+export class HallOfFameHistory {
+  private parent: TennisTable;
+
+  constructor(parent: TennisTable) {
+    this.parent = parent;
+  }
+
+  /** Simulates the player's Hall of Fame score at up to 100 points in time.
+   *
+   * Each point projects the whole app state as it was at that timestamp and
+   * scores the player against it, because the score depends on what everyone
+   * else had done by then (Elo, time at the top and achievement records).
+   * This is expensive, so it is meant to run in a web worker. */
+  computeForPlayer(
+    playerId: string,
+    now: number,
+    onProgress?: (progress: number) => void,
+  ): HallOfFameHistoryResult {
+    const player = this.parent.eventStore.playersProjector.getPlayer(playerId);
+    if (!player) return { playerId, points: [] };
+
+    const times = hallOfFameHistoryTimes(player.createdAt, now);
+    const points: HallOfFameHistoryPoint[] = [];
+
+    for (let i = 0; i < times.length; i++) {
+      const time = times[i];
+      const stateAtTime = new TennisTable({
+        events: eventsUpTo(this.parent.events, time),
+        referenceTime: time,
+      });
+      const entry = stateAtTime.hallOfFame.getScoreForAnyPlayer(playerId);
+
+      points.push({
+        time,
+        total: entry?.score.total ?? 0,
+        factors: {
+          seasonPerformance: entry?.score.seasonPerformance.score ?? 0,
+          achievementsEarned: entry?.score.achievementsEarned.score ?? 0,
+          socialDiversity: entry?.score.socialDiversity.score ?? 0,
+          tournamentProgression: entry?.score.tournamentProgression.score ?? 0,
+          longevity: entry?.score.longevity.score ?? 0,
+          experience: entry?.score.experience.score ?? 0,
+          dataVolume: entry?.score.dataVolume.score ?? 0,
+          peakElo: entry?.score.peakElo.score ?? 0,
+          podiumTime: entry?.score.podiumTime.score ?? 0,
+        },
+      });
+
+      onProgress?.((i + 1) / times.length);
+    }
+
+    return { playerId, points };
+  }
+}

--- a/frontend/src/client/client-db/tennis-table.ts
+++ b/frontend/src/client/client-db/tennis-table.ts
@@ -14,6 +14,7 @@ import { Seasons } from "./seasons/seasons";
 import { PredictionsHistory } from "./predictions-history";
 import { Predictions } from "./predictions";
 import { HallOfFame } from "./hall-of-fame";
+import { HallOfFameHistory } from "./hall-of-fame-history";
 import { Whr } from "./whr";
 
 export class TennisTable {
@@ -49,6 +50,7 @@ export class TennisTable {
   predictions: Predictions;
   predictionsHistory: PredictionsHistory;
   hallOfFame: HallOfFame;
+  hallOfFameHistory: HallOfFameHistory;
   whr: Whr;
 
   constructor(data: { events: EventType[]; gameLimitForRankedOverride?: number; referenceTime?: number }) {
@@ -71,6 +73,7 @@ export class TennisTable {
     this.predictions = new Predictions(this, data.referenceTime);
     this.predictionsHistory = new PredictionsHistory(this);
     this.hallOfFame = new HallOfFame(this);
+    this.hallOfFameHistory = new HallOfFameHistory(this);
     this.whr = new Whr(this);
   }
 

--- a/frontend/src/client/client-db/tennis-table.ts
+++ b/frontend/src/client/client-db/tennis-table.ts
@@ -23,6 +23,12 @@ export class TennisTable {
   // --------------------------------------------------------------------------
   readonly events: EventType[];
 
+  /** The moment this projection represents, or undefined for the live state.
+   * Set when the app state is projected at a point in the past, so logic that
+   * asks "has this happened yet" compares against that moment and not the
+   * real clock. */
+  readonly referenceTime: number | undefined;
+
   // --------------------------------------------------------------------------
   // Client configuration
   // --------------------------------------------------------------------------
@@ -55,6 +61,7 @@ export class TennisTable {
 
   constructor(data: { events: EventType[]; gameLimitForRankedOverride?: number; referenceTime?: number }) {
     this.events = data.events;
+    this.referenceTime = data.referenceTime;
     if (data.gameLimitForRankedOverride !== undefined) {
       this.client.gameLimitForRanked = data.gameLimitForRankedOverride;
     }

--- a/frontend/src/client/client-db/tournaments/tournament.ts
+++ b/frontend/src/client/client-db/tournaments/tournament.ts
@@ -50,13 +50,29 @@ export class Tournament {
   private static readonly RECENT_WINNER_THRESHOLD = 2 * ONE_WEEK;
   private static readonly SIGNUP_PERIOD = 2 * ONE_WEEK;
 
-  constructor(tournamentConfig: TournamentConfig, games: Game[], skippedGames: SkippedGame[], signedUp: SignUp[]) {
+  /** The moment this tournament is seen from: the reference time of a projection
+   * of a past state, or the real clock for the live state. Read lazily so the
+   * live state always uses the current time. */
+  get #time(): number {
+    return this.#referenceTime ?? Date.now();
+  }
+
+  readonly #referenceTime: number | undefined;
+
+  constructor(
+    tournamentConfig: TournamentConfig,
+    games: Game[],
+    skippedGames: SkippedGame[],
+    signedUp: SignUp[],
+    referenceTime?: number,
+  ) {
     this.tournamentConfig = tournamentConfig;
     this.#games = games;
     this.skippedGames = skippedGames;
     this.signedUp = signedUp;
+    this.#referenceTime = referenceTime;
 
-    if (this.tournamentConfig.startDate > Date.now()) {
+    if (this.tournamentConfig.startDate > this.#time) {
       return; // Not started. No need to calculate bracket or group play
     }
     if (this.tournamentConfig.groupPlay) {
@@ -91,21 +107,21 @@ export class Tournament {
   }
 
   get recentWinner(): string | undefined {
-    if (this.startDate > Date.now()) return undefined; // Has not started
+    if (this.startDate > this.#time) return undefined; // Has not started
     if (this.endDate === undefined) return undefined; // Has not ended
     if (this.winner === undefined) return undefined; // Has no winner
-    if (Date.now() - this.endDate > Tournament.RECENT_WINNER_THRESHOLD) return undefined; // Not recent
+    if (this.#time - this.endDate > Tournament.RECENT_WINNER_THRESHOLD) return undefined; // Not recent
     return this.winner;
   }
 
   get inSignupPeriod(): boolean {
-    if (this.startDate < Date.now()) return false; // Has started
-    if (this.startDate - Tournament.SIGNUP_PERIOD > Date.now()) return false; // Not yet in signup period
+    if (this.startDate < this.#time) return false; // Has started
+    if (this.startDate - Tournament.SIGNUP_PERIOD > this.#time) return false; // Not yet in signup period
     return true;
   }
 
   get hasPendingGames(): boolean {
-    if (this.startDate > Date.now()) return false; // Not started
+    if (this.startDate > this.#time) return false; // Not started
     if (this.endDate !== undefined) return false; // Has ended
 
     // Check group play
@@ -159,7 +175,7 @@ export class Tournament {
       doubleElimination?: boolean;
     }
     | undefined {
-    if (this.startDate > Date.now()) return; // Not started
+    if (this.startDate > this.#time) return; // Not started
     if (this.endDate !== undefined) return; // Has ended
 
     const players = [player1, player2];
@@ -205,7 +221,7 @@ export class Tournament {
       games: { oponent: string; player1: string; player2: string }[];
     }
     | undefined {
-    if (this.startDate > Date.now()) return; // Not started
+    if (this.startDate > this.#time) return; // Not started
     if (this.endDate !== undefined) return; // Has ended
 
     const games: { oponent: string; player1: string; player2: string }[] = [];
@@ -249,7 +265,7 @@ export class Tournament {
     player1: string;
     player2: string;
   }[] {
-    if (this.startDate > Date.now()) return []; // Not started
+    if (this.startDate > this.#time) return []; // Not started
     if (this.endDate !== undefined) return []; // Has ended
 
     const games: {

--- a/frontend/src/client/client-db/tournaments/tournaments.ts
+++ b/frontend/src/client/client-db/tournaments/tournaments.ts
@@ -41,6 +41,7 @@ export class Tournaments {
       this.parent.games.filter((g) => g.playedAt >= tournament.startDate),
       this.parent.eventStore.tournamentsProjector.getTournamentSkippedGames(tournament.id),
       this.parent.eventStore.tournamentsProjector.getTournamentSignups(tournament.id),
+      this.parent.referenceTime,
     );
   }
 

--- a/frontend/src/client/client-db/web-worker/web-worker.ts
+++ b/frontend/src/client/client-db/web-worker/web-worker.ts
@@ -1,4 +1,5 @@
 import { EventType } from "../event-store/event-types";
+import { HallOfFameHistoryResult } from "../hall-of-fame-history";
 import { PredictionHistoryEntry } from "../predictions-history";
 import { ExpectedLeaderboard } from "../simulations";
 import { TennisTable } from "../tennis-table";
@@ -28,7 +29,13 @@ export type WorkerMessage =
   | { type: "predictions-history-complete" }
   | { type: "start-whr"; data: { events: EventType[]; config?: Partial<WhrConfig> } }
   | { type: "whr-progress"; data: { progress: number } }
-  | { type: "whr-result"; data: { result: WhrResult } };
+  | { type: "whr-result"; data: { result: WhrResult } }
+  | {
+      type: "start-hall-of-fame-history";
+      data: { playerId: string; events: EventType[]; now: number };
+    }
+  | { type: "hall-of-fame-history-progress"; data: { progress: number } }
+  | { type: "hall-of-fame-history-result"; data: { result: HallOfFameHistoryResult } };
 
 // eslint-disable-next-line no-restricted-globals
 const scope = self as unknown as DedicatedWorkerGlobalScope;
@@ -90,6 +97,17 @@ function handleWorkerMessage(message: WorkerMessage) {
       );
       setTimeout(() => postWorkerMessage({ type: "predictions-history-complete" }), 1000);
       break;
+
+    case "start-hall-of-fame-history": {
+      const tennisTableForHallOfFame = new TennisTable({ events: message.data.events });
+      const result = tennisTableForHallOfFame.hallOfFameHistory.computeForPlayer(
+        message.data.playerId,
+        message.data.now,
+        (progress) => postWorkerMessage({ type: "hall-of-fame-history-progress", data: { progress } }),
+      );
+      postWorkerMessage({ type: "hall-of-fame-history-result", data: { result } });
+      break;
+    }
 
     case "start-whr": {
       const tennisTableForWhr = new TennisTable({ events: message.data.events });

--- a/frontend/src/hooks/use-hall-of-fame-history-worker.ts
+++ b/frontend/src/hooks/use-hall-of-fame-history-worker.ts
@@ -15,6 +15,13 @@ export function useHallOfFameHistoryWorker() {
   const [progress, setProgress] = useState(0);
   const [failed, setFailed] = useState(false);
 
+  // The events are read through a ref so `startComputation` stays stable. The
+  // query refetches on window focus and returns a new array every time, so a
+  // dependency on the events themselves would terminate the worker and restart
+  // the simulation from 0% every time the tab regains focus.
+  const eventsRef = useRef(context.events);
+  eventsRef.current = context.events;
+
   useEffect(() => {
     return () => {
       workerRef.current?.terminate();
@@ -51,13 +58,22 @@ export function useHallOfFameHistoryWorker() {
         }
       });
 
+      // Without these the graph waits on a progress bar forever if the
+      // simulation throws or runs out of memory part way through.
+      const fail = (error: unknown) => {
+        console.error("Hall of fame history simulation failed", error);
+        setFailed(true);
+      };
+      worker.addEventListener("error", fail);
+      worker.addEventListener("messageerror", fail);
+
       const message: WorkerMessage = {
         type: "start-hall-of-fame-history",
-        data: { playerId, events: context.events, now: Date.now() },
+        data: { playerId, events: eventsRef.current, now: Date.now() },
       };
       worker.postMessage(message);
     },
-    [context.events],
+    [],
   );
 
   return { startComputation, result, progress, failed, isDone: result !== undefined };

--- a/frontend/src/hooks/use-hall-of-fame-history-worker.ts
+++ b/frontend/src/hooks/use-hall-of-fame-history-worker.ts
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { HallOfFameHistoryResult } from "../client/client-db/hall-of-fame-history";
+import { WorkerMessage } from "../client/client-db/web-worker/web-worker";
+import { useEventDbContext } from "../wrappers/event-db-context";
+import { createModernWorker } from "./use-elo-simulation-worker";
+
+/** Simulates a player's Hall of Fame score over time in a web worker.
+ * The result arrives in one piece when every point is done. `progress` tracks
+ * how far the simulation has come. */
+export function useHallOfFameHistoryWorker() {
+  const context = useEventDbContext();
+
+  const workerRef = useRef<Worker | null>(null);
+  const [result, setResult] = useState<HallOfFameHistoryResult | undefined>(undefined);
+  const [progress, setProgress] = useState(0);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      workerRef.current?.terminate();
+    };
+  }, []);
+
+  const startComputation = useCallback(
+    (playerId: string) => {
+      workerRef.current?.terminate();
+
+      setResult(undefined);
+      setProgress(0);
+      setFailed(false);
+
+      const worker = createModernWorker();
+      workerRef.current = worker;
+
+      if (!worker) {
+        console.error("Worker not initialized");
+        setFailed(true);
+        return;
+      }
+
+      worker.addEventListener("message", (e) => {
+        const message = e.data as WorkerMessage;
+        switch (message.type) {
+          case "hall-of-fame-history-progress":
+            setProgress(message.data.progress);
+            break;
+          case "hall-of-fame-history-result":
+            setResult(message.data.result);
+            setProgress(1);
+            break;
+        }
+      });
+
+      const message: WorkerMessage = {
+        type: "start-hall-of-fame-history",
+        data: { playerId, events: context.events, now: Date.now() },
+      };
+      worker.postMessage(message);
+    },
+    [context.events],
+  );
+
+  return { startComputation, result, progress, failed, isDone: result !== undefined };
+}

--- a/frontend/src/hooks/use-state-at.tsx
+++ b/frontend/src/hooks/use-state-at.tsx
@@ -1,18 +1,9 @@
 import { useMemo } from "react";
 import { useEventDbContext } from "../wrappers/event-db-context";
 import { TennisTable } from "../client/client-db/tennis-table";
-import { EventType, EventTypeEnum } from "../client/client-db/event-store/event-types";
+import { eventsUpTo } from "../client/client-db/event-store/events-up-to";
 
-// Same "state at a point in time" filter as tournament predictions:
-// games count by when they were played, everything else by event time.
-export function eventsUpTo(events: EventType[], time: number): EventType[] {
-  return events.filter((event) => {
-    if (event.type === EventTypeEnum.GAME_CREATED) {
-      return event.data.playedAt <= time;
-    }
-    return event.time <= time;
-  });
-}
+export { eventsUpTo };
 
 // The full app state projected at a point in time.
 export function useStateAt(time: number | undefined): TennisTable | undefined {

--- a/frontend/src/pages/admin/hall-of-fame-category-balance.tsx
+++ b/frontend/src/pages/admin/hall-of-fame-category-balance.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { useEventDbContext } from "../../wrappers/event-db-context";
 import { HallOfFameFactorKey } from "../../client/client-db/hall-of-fame";
-import { FACTORS } from "../hall-of-fame/hall-of-fame-player-page";
+import { FACTORS } from "../hall-of-fame/hall-of-fame-factors";
 import { fmtNum } from "../../common/number-utils";
 
 export const HallOfFameCategoryBalance: React.FC = () => {

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-delta-bars.test.ts
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-delta-bars.test.ts
@@ -1,0 +1,71 @@
+import { MAX_DELTA_BARS, ScorePoint, deltaBars } from "./hall-of-fame-delta-bars";
+
+const ONE_DAY = 24 * 60 * 60 * 1000;
+const start = 1_700_000_000_000;
+
+/** `count` points one day apart, each worth 1 point more than the previous. */
+function points(count: number): ScorePoint[] {
+  return Array.from({ length: count }, (_, i) => ({
+    time: start + i * ONE_DAY,
+    cumulative: i,
+    delta: i === 0 ? 0 : 1,
+  }));
+}
+
+describe("Hall of Fame delta bars", () => {
+  it("gives no bar for fewer than 2 points", () => {
+    expect(deltaBars([])).toEqual([]);
+    expect(deltaBars(points(1))).toEqual([]);
+  });
+
+  it("never gives more bars than the maximum", () => {
+    for (const count of [2, 5, 25, 26, 51, 99, 100]) {
+      expect(deltaBars(points(count)).length).toBeLessThanOrEqual(MAX_DELTA_BARS);
+    }
+  });
+
+  it("gives 1 bar per period while the periods fit", () => {
+    expect(deltaBars(points(2)).length).toBe(1);
+    expect(deltaBars(points(11)).length).toBe(10);
+    expect(deltaBars(points(26)).length).toBe(25);
+  });
+
+  it("groups the periods of a full simulation into 25 bars", () => {
+    expect(deltaBars(points(100)).length).toBe(MAX_DELTA_BARS);
+  });
+
+  it("keeps the sum of the bars equal to the score of the last point", () => {
+    for (const count of [2, 11, 26, 63, 100]) {
+      const all = points(count);
+      const total = deltaBars(all).reduce((sum, bar) => sum + bar.delta, 0);
+      expect(total).toBe(all[all.length - 1].cumulative);
+    }
+  });
+
+  it("ends the last bar at the last point", () => {
+    const all = points(100);
+    const bars = deltaBars(all);
+    expect(bars[bars.length - 1].time).toBe(all[all.length - 1].time);
+    expect(bars[bars.length - 1].cumulative).toBe(all[all.length - 1].cumulative);
+  });
+
+  it("starts the first bar at the day the player joined", () => {
+    expect(deltaBars(points(100))[0].from).toBe(start);
+  });
+
+  it("joins each period to the end of the previous period", () => {
+    const bars = deltaBars(points(100));
+    for (let i = 1; i < bars.length; i++) {
+      expect(bars[i].from).toBe(bars[i - 1].time);
+    }
+  });
+
+  it("keeps a drop in the score negative", () => {
+    const bars = deltaBars([
+      { time: start, cumulative: 0, delta: 0 },
+      { time: start + ONE_DAY, cumulative: 100, delta: 100 },
+      { time: start + 2 * ONE_DAY, cumulative: 85, delta: -15 },
+    ]);
+    expect(bars.map((bar) => bar.delta)).toEqual([100, -15]);
+  });
+});

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-delta-bars.ts
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-delta-bars.ts
@@ -1,0 +1,42 @@
+/** Most bars in the delta view. The simulation makes up to 100 points, and 99
+ * bars is too fine to read, so consecutive periods are grouped into one bar. */
+export const MAX_DELTA_BARS = 25;
+
+export type ScorePoint = { time: number; cumulative: number; delta: number };
+
+export type DeltaBar = {
+  /** End of the period. The bar is labeled by this timestamp. */
+  time: number;
+  /** Start of the period, which is the end of the previous bar. */
+  from: number;
+  /** The score after the period. */
+  cumulative: number;
+  /** Points gained in the period. Negative when the score dropped. */
+  delta: number;
+};
+
+/** Groups the score points into at most `MAX_DELTA_BARS` periods.
+ *
+ * The gain of a period is the sum of the gains of the points it covers, so the
+ * bars still add up to the score of the last point. The first point is the day
+ * the player joined and has no period before it, so it gets no bar. */
+export function deltaBars(points: ScorePoint[]): DeltaBar[] {
+  if (points.length < 2) return [];
+
+  const periods = points.slice(1);
+  const groupSize = Math.ceil(periods.length / MAX_DELTA_BARS);
+  const bars: DeltaBar[] = [];
+
+  for (let i = 0; i < periods.length; i += groupSize) {
+    const group = periods.slice(i, i + groupSize);
+    const last = group[group.length - 1];
+    bars.push({
+      time: last.time,
+      from: points[i].time,
+      cumulative: last.cumulative,
+      delta: group.reduce((sum, period) => sum + period.delta, 0),
+    });
+  }
+
+  return bars;
+}

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-factors.ts
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-factors.ts
@@ -1,0 +1,14 @@
+import { HallOfFameFactorKey } from "../../client/client-db/hall-of-fame";
+
+/** The score sections, in the order they are shown to the player. */
+export const FACTORS: { key: HallOfFameFactorKey; emoji: string; name: string }[] = [
+  { key: "peakElo", emoji: "🔥", name: "All-Time High" },
+  { key: "podiumTime", emoji: "🥉", name: "Time at the Top" },
+  { key: "experience", emoji: "🏓", name: "Experience" },
+  { key: "dataVolume", emoji: "📊", name: "Data Volume" },
+  { key: "longevity", emoji: "📅", name: "Activity" },
+  { key: "seasonPerformance", emoji: "🍁", name: "Seasons" },
+  { key: "tournamentProgression", emoji: "🏆", name: "Tournaments" },
+  { key: "socialDiversity", emoji: "👥", name: "Social Diversity" },
+  { key: "achievementsEarned", emoji: "🎖️", name: "Achievements" },
+];

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-leaderboard-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-leaderboard-page.tsx
@@ -5,7 +5,7 @@ import { ProfilePicture } from "../player/profile-picture";
 import { fmtNum } from "../../common/number-utils";
 import { classNames } from "../../common/class-names";
 import { HallOfFameEntry, HallOfFameFactorKey } from "../../client/client-db/hall-of-fame";
-import { FACTORS } from "./hall-of-fame-player-page";
+import { FACTORS } from "./hall-of-fame-factors";
 
 type CategoryOption = HallOfFameFactorKey | "all";
 type SortBy = "category" | "total";

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-player-page.tsx
@@ -6,8 +6,10 @@ import { HallOfFameScoreBreakdown } from "../../client/client-db/hall-of-fame";
 import { fmtNum } from "../../common/number-utils";
 import { classNames } from "../../common/class-names";
 import { useLocalStorage } from "../../hooks/use-local-storage";
+import { FACTORS } from "./hall-of-fame-factors";
+import { HallOfFameScoreOverTime } from "./hall-of-fame-score-over-time";
 
-type ViewMode = "total" | "compared";
+type ViewMode = "total" | "compared" | "overTime";
 const VIEW_MODE_STORAGE_KEY = "hall-of-fame-player-view-mode";
 
 type FactorKey = keyof Omit<HallOfFameScoreBreakdown, "total">;
@@ -236,24 +238,13 @@ function renderDetails(breakdown: HallOfFameScoreBreakdown, key: FactorKey): Rea
   }
 }
 
-export const FACTORS: { key: FactorKey; emoji: string; name: string }[] = [
-  { key: "peakElo", emoji: "🔥", name: "All-Time High" },
-  { key: "podiumTime", emoji: "🥉", name: "Time at the Top" },
-  { key: "experience", emoji: "🏓", name: "Experience" },
-  { key: "dataVolume", emoji: "📊", name: "Data Volume" },
-  { key: "longevity", emoji: "📅", name: "Activity" },
-  { key: "seasonPerformance", emoji: "🍁", name: "Seasons" },
-  { key: "tournamentProgression", emoji: "🏆", name: "Tournaments" },
-  { key: "socialDiversity", emoji: "👥", name: "Social Diversity" },
-  { key: "achievementsEarned", emoji: "🎖️", name: "Achievements" },
-];
-
 export const HallOfFamePlayerPage: React.FC = () => {
   const { playerId } = useParams<{ playerId: string }>();
   const navigate = useNavigate();
   const context = useEventDbContext();
   const [storedViewMode, setStoredViewMode] = useLocalStorage(VIEW_MODE_STORAGE_KEY, "total");
-  const viewMode: ViewMode = storedViewMode === "compared" ? "compared" : "total";
+  const viewMode: ViewMode =
+    storedViewMode === "compared" ? "compared" : storedViewMode === "overTime" ? "overTime" : "total";
 
   if (!playerId) {
     return <div className="text-primary-text text-center p-8">Player not found</div>;
@@ -346,12 +337,13 @@ export const HallOfFamePlayerPage: React.FC = () => {
           <div
             role="tablist"
             aria-label="Score view mode"
-            className="inline-flex bg-secondary-background rounded-full p-1 mb-4"
+            className="flex flex-wrap gap-1 bg-secondary-background rounded-full p-1 mb-4"
           >
             {(
               [
                 { value: "total" as const, label: "Section of total" },
                 { value: "compared" as const, label: "Compared to all" },
+                { value: "overTime" as const, label: "Score over time" },
               ]
             ).map((option) => {
               const isActiveOption = viewMode === option.value;
@@ -387,6 +379,9 @@ export const HallOfFamePlayerPage: React.FC = () => {
             </button>
           </div>
 
+          {viewMode === "overTime" ? (
+            <HallOfFameScoreOverTime playerId={entry.playerId} playerName={entry.playerName} />
+          ) : (
           <div className="space-y-6">
             {segments.map((segment) => (
               <div key={segment.key} className="ring-1 ring-secondary-background rounded-xl p-3">
@@ -419,8 +414,10 @@ export const HallOfFamePlayerPage: React.FC = () => {
               </div>
             ))}
           </div>
+          )}
 
           {/* Total */}
+          {viewMode !== "overTime" && (
           <div className="mt-6 pt-4 border-t border-secondary-background flex justify-between items-center">
             <span className="text-primary-text font-bold text-sm uppercase tracking-wide">
               Final Hall of Fame Score
@@ -432,6 +429,7 @@ export const HallOfFamePlayerPage: React.FC = () => {
               {fmtNum(entry.score.total)} pts
             </span>
           </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-score-over-time.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-score-over-time.tsx
@@ -1,0 +1,281 @@
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  TooltipProps,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { NameType, ValueType } from "recharts/types/component/DefaultTooltipContent";
+import { HallOfFameFactorKey } from "../../client/client-db/hall-of-fame";
+import { HISTORY_MAX_POINTS } from "../../client/client-db/hall-of-fame-history";
+import { classNames } from "../../common/class-names";
+import { dateString } from "../../common/date-utils";
+import { fmtNum } from "../../common/number-utils";
+import { PillSelect } from "../../common/pill-select";
+import { ONE_YEAR } from "../../common/time-in-ms";
+import { useHallOfFameHistoryWorker } from "../../hooks/use-hall-of-fame-history-worker";
+import { useLocalStorage } from "../../hooks/use-local-storage";
+import { FACTORS } from "./hall-of-fame-factors";
+
+type GraphMode = "cumulative" | "delta";
+const GRAPH_MODE_STORAGE_KEY = "hall-of-fame-score-over-time-mode";
+
+/** "Total" plus the 9 sections. Filters both the line and the bars. */
+type SeriesKey = "total" | HallOfFameFactorKey;
+
+const NEGATIVE_COLOR = "#ef4444";
+
+export const HallOfFameScoreOverTime: React.FC<{ playerId: string; playerName: string }> = ({
+  playerId,
+  playerName,
+}) => {
+  const { startComputation, result, progress, failed } = useHallOfFameHistoryWorker();
+  const [storedMode, setStoredMode] = useLocalStorage(GRAPH_MODE_STORAGE_KEY, "cumulative");
+  const mode: GraphMode = storedMode === "delta" ? "delta" : "cumulative";
+  const [series, setSeries] = useState<SeriesKey>("total");
+
+  useEffect(() => {
+    startComputation(playerId);
+  }, [startComputation, playerId]);
+
+  const points = result?.points;
+
+  const graphData = useMemo(() => {
+    if (!points) return [];
+    let previous = 0;
+    return points.map((point) => {
+      const value = series === "total" ? point.total : point.factors[series];
+      const delta = value - previous;
+      previous = value;
+      return { time: point.time, cumulative: value, delta };
+    });
+  }, [points, series]);
+
+  const spansMoreThanAYear = useMemo(() => {
+    if (graphData.length < 2) return false;
+    return graphData[graphData.length - 1].time - graphData[0].time > ONE_YEAR;
+  }, [graphData]);
+
+  const formatTick = (time: number) =>
+    new Date(time).toLocaleDateString(
+      "nb-NO",
+      spansMoreThanAYear ? { month: "short", year: "2-digit" } : { day: "numeric", month: "short" },
+    );
+
+  const seriesLabel = series === "total" ? "Total score" : FACTORS.find((f) => f.key === series)?.name ?? "";
+
+  const summary = useMemo(() => {
+    if (graphData.length === 0) return undefined;
+    const current = graphData[graphData.length - 1].cumulative;
+    const best = graphData.reduce((top, point) => (point.delta > top.delta ? point : top), graphData[0]);
+    return { current, best };
+  }, [graphData]);
+
+  if (failed) {
+    return (
+      <p className="text-primary-text text-sm">
+        The score over time needs a web worker, and this browser does not support one.
+      </p>
+    );
+  }
+
+  if (!result) {
+    return (
+      <div className="space-y-2">
+        <p className="text-primary-text text-sm">
+          Simulating the score of {playerName} at up to {HISTORY_MAX_POINTS} points in time.
+        </p>
+        <div className="w-full h-2 bg-secondary-background rounded-full overflow-hidden">
+          <div
+            className="h-full bg-tertiary-background transition-all duration-300"
+            style={{ width: `${Math.round(progress * 100)}%` }}
+          />
+        </div>
+        <p className="text-primary-text/60 text-xs">{Math.round(progress * 100)}% done</p>
+      </div>
+    );
+  }
+
+  if (graphData.length < 2) {
+    return (
+      <p className="text-primary-text text-sm">
+        {playerName} is too new for a graph. The score needs more than one day of history.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-primary-text text-sm">
+        The score of {playerName} as it was at each point in time, from the day the player joined until now.
+      </p>
+
+      <div className="flex flex-col xs:flex-row xs:items-end gap-3 xs:justify-between">
+        <PillSelect<GraphMode>
+          label="Graph"
+          options={[
+            { value: "cumulative", label: "Cumulative" },
+            { value: "delta", label: "Delta" },
+          ]}
+          value={mode}
+          onChange={setStoredMode}
+        />
+        <div className="flex flex-col gap-1">
+          <span className="text-xs md:text-sm text-primary-text/60">Section</span>
+          <select
+            value={series}
+            onChange={(e) => setSeries(e.target.value as SeriesKey)}
+            aria-label="Score section"
+            className="bg-secondary-background text-secondary-text text-sm rounded-lg px-3 h-10 outline-none cursor-pointer"
+          >
+            <option value="total">Total score</option>
+            {FACTORS.map((factor) => (
+              <option key={factor.key} value={factor.key}>
+                {factor.emoji} {factor.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="w-full h-[300px] md:h-[400px]">
+        <ResponsiveContainer width="100%" height="100%">
+          {mode === "cumulative" ? (
+            <LineChart data={graphData} margin={{ top: 5, right: 8, left: -12, bottom: 0 }}>
+              <CartesianGrid
+                strokeDasharray="1 4"
+                vertical={false}
+                stroke="rgb(var(--color-primary-text))"
+                opacity={0.1}
+              />
+              <XAxis
+                dataKey="time"
+                tickFormatter={formatTick}
+                interval={Math.max(0, Math.floor(graphData.length / 5))}
+                stroke="rgb(var(--color-primary-text))"
+                fontSize={11}
+                tickLine={false}
+                axisLine={false}
+                dy={6}
+                opacity={0.6}
+              />
+              <YAxis
+                type="number"
+                domain={["auto", "auto"]}
+                tickFormatter={(value: number) => fmtNum(value) ?? ""}
+                stroke="rgb(var(--color-primary-text))"
+                fontSize={11}
+                tickLine={false}
+                axisLine={false}
+                opacity={0.6}
+              />
+              <Tooltip content={<ScoreTooltip mode={mode} seriesLabel={seriesLabel} />} />
+              <Line
+                type="monotone"
+                dataKey="cumulative"
+                stroke="rgb(var(--color-primary-text))"
+                strokeWidth={3}
+                dot={false}
+                activeDot={{ r: 5, strokeWidth: 0 }}
+                animationDuration={400}
+              />
+            </LineChart>
+          ) : (
+            <BarChart data={graphData} margin={{ top: 5, right: 8, left: -12, bottom: 0 }}>
+              <CartesianGrid
+                strokeDasharray="1 4"
+                vertical={false}
+                stroke="rgb(var(--color-primary-text))"
+                opacity={0.1}
+              />
+              <XAxis
+                dataKey="time"
+                tickFormatter={formatTick}
+                interval={Math.max(0, Math.floor(graphData.length / 5))}
+                stroke="rgb(var(--color-primary-text))"
+                fontSize={11}
+                tickLine={false}
+                axisLine={false}
+                dy={6}
+                opacity={0.6}
+              />
+              <YAxis
+                type="number"
+                domain={["auto", "auto"]}
+                tickFormatter={(value: number) => fmtNum(value) ?? ""}
+                stroke="rgb(var(--color-primary-text))"
+                fontSize={11}
+                tickLine={false}
+                axisLine={false}
+                opacity={0.6}
+              />
+              <Tooltip
+                cursor={{ fill: "rgb(var(--color-primary-text))", opacity: 0.08 }}
+                content={<ScoreTooltip mode={mode} seriesLabel={seriesLabel} />}
+              />
+              <ReferenceLine y={0} stroke="rgb(var(--color-primary-text))" opacity={0.3} />
+              <Bar dataKey="delta" animationDuration={400}>
+                {graphData.map((point) => (
+                  <Cell
+                    key={point.time}
+                    fill={point.delta < 0 ? NEGATIVE_COLOR : "rgb(var(--color-primary-text))"}
+                  />
+                ))}
+              </Bar>
+            </BarChart>
+          )}
+        </ResponsiveContainer>
+      </div>
+
+      {summary && (
+        <div className="flex flex-wrap gap-2 text-xs">
+          <span className="bg-secondary-background text-secondary-text px-2 py-1 rounded">
+            {seriesLabel} now: <span className="font-bold">{fmtNum(summary.current)} pts</span>
+          </span>
+          <span className="bg-secondary-background text-secondary-text px-2 py-1 rounded">
+            Best period: <span className="font-bold">{fmtNum(summary.best.delta, { signedPositive: true })} pts</span>{" "}
+            {dateString(summary.best.time)}
+          </span>
+          <span className={classNames("bg-secondary-background/50 text-secondary-text/75 px-2 py-1 rounded")}>
+            {graphData.length} points, {mode === "delta" ? "gain per period" : "score at each point"}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const ScoreTooltip = ({
+  active,
+  payload,
+  mode,
+  seriesLabel,
+}: TooltipProps<ValueType, NameType> & { mode: GraphMode; seriesLabel: string }) => {
+  if (!active || !payload || payload.length === 0) return null;
+  const data = payload[0].payload as { time: number; cumulative: number; delta: number };
+
+  return (
+    <div className="p-3 bg-primary-background/95 backdrop-blur-sm ring-1 ring-primary-text/20 rounded-lg text-primary-text shadow-lg">
+      <div className="text-xs opacity-60 mb-1">{dateString(data.time)}</div>
+      <div className="font-bold text-lg">
+        {mode === "delta"
+          ? `${fmtNum(data.delta, { signedPositive: true })} pts`
+          : `${fmtNum(data.cumulative)} pts`}
+      </div>
+      <div className="text-xs opacity-75">{seriesLabel}</div>
+      <div className="text-xs opacity-60 mt-1">
+        {mode === "delta"
+          ? `${fmtNum(data.cumulative)} pts in total`
+          : `${fmtNum(data.delta, { signedPositive: true })} pts this period`}
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-score-over-time.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-score-over-time.tsx
@@ -86,7 +86,7 @@ export const HallOfFameScoreOverTime: React.FC<{ playerId: string; playerName: s
   if (failed) {
     return (
       <p className="text-primary-text text-sm">
-        The score over time needs a web worker, and this browser does not support one.
+        The score over time did not finish. The graph needs a web worker. Reload the page to try again.
       </p>
     );
   }

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-score-over-time.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-score-over-time.tsx
@@ -16,13 +16,13 @@ import {
 import { NameType, ValueType } from "recharts/types/component/DefaultTooltipContent";
 import { HallOfFameFactorKey } from "../../client/client-db/hall-of-fame";
 import { HISTORY_MAX_POINTS } from "../../client/client-db/hall-of-fame-history";
-import { classNames } from "../../common/class-names";
 import { dateString } from "../../common/date-utils";
 import { fmtNum } from "../../common/number-utils";
 import { PillSelect } from "../../common/pill-select";
 import { ONE_YEAR } from "../../common/time-in-ms";
 import { useHallOfFameHistoryWorker } from "../../hooks/use-hall-of-fame-history-worker";
 import { useLocalStorage } from "../../hooks/use-local-storage";
+import { deltaBars } from "./hall-of-fame-delta-bars";
 import { FACTORS } from "./hall-of-fame-factors";
 
 type GraphMode = "cumulative" | "delta";
@@ -59,6 +59,10 @@ export const HallOfFameScoreOverTime: React.FC<{ playerId: string; playerName: s
     });
   }, [points, series]);
 
+  const deltaData = useMemo(() => deltaBars(graphData), [graphData]);
+
+  const chartData = mode === "delta" ? deltaData : graphData;
+
   const spansMoreThanAYear = useMemo(() => {
     if (graphData.length < 2) return false;
     return graphData[graphData.length - 1].time - graphData[0].time > ONE_YEAR;
@@ -73,11 +77,11 @@ export const HallOfFameScoreOverTime: React.FC<{ playerId: string; playerName: s
   const seriesLabel = series === "total" ? "Total score" : FACTORS.find((f) => f.key === series)?.name ?? "";
 
   const summary = useMemo(() => {
-    if (graphData.length === 0) return undefined;
+    if (graphData.length === 0 || chartData.length === 0) return undefined;
     const current = graphData[graphData.length - 1].cumulative;
-    const best = graphData.reduce((top, point) => (point.delta > top.delta ? point : top), graphData[0]);
+    const best = chartData.reduce((top, point) => (point.delta > top.delta ? point : top), chartData[0]);
     return { current, best };
-  }, [graphData]);
+  }, [graphData, chartData]);
 
   if (failed) {
     return (
@@ -159,7 +163,7 @@ export const HallOfFameScoreOverTime: React.FC<{ playerId: string; playerName: s
               <XAxis
                 dataKey="time"
                 tickFormatter={formatTick}
-                interval={Math.max(0, Math.floor(graphData.length / 5))}
+                interval={Math.max(0, Math.floor(chartData.length / 5))}
                 stroke="rgb(var(--color-primary-text))"
                 fontSize={11}
                 tickLine={false}
@@ -189,7 +193,7 @@ export const HallOfFameScoreOverTime: React.FC<{ playerId: string; playerName: s
               />
             </LineChart>
           ) : (
-            <BarChart data={graphData} margin={{ top: 5, right: 8, left: -12, bottom: 0 }}>
+            <BarChart data={deltaData} margin={{ top: 5, right: 8, left: -12, bottom: 0 }}>
               <CartesianGrid
                 strokeDasharray="1 4"
                 vertical={false}
@@ -199,7 +203,7 @@ export const HallOfFameScoreOverTime: React.FC<{ playerId: string; playerName: s
               <XAxis
                 dataKey="time"
                 tickFormatter={formatTick}
-                interval={Math.max(0, Math.floor(graphData.length / 5))}
+                interval={Math.max(0, Math.floor(chartData.length / 5))}
                 stroke="rgb(var(--color-primary-text))"
                 fontSize={11}
                 tickLine={false}
@@ -223,11 +227,8 @@ export const HallOfFameScoreOverTime: React.FC<{ playerId: string; playerName: s
               />
               <ReferenceLine y={0} stroke="rgb(var(--color-primary-text))" opacity={0.3} />
               <Bar dataKey="delta" animationDuration={400}>
-                {graphData.map((point) => (
-                  <Cell
-                    key={point.time}
-                    fill={point.delta < 0 ? NEGATIVE_COLOR : "rgb(var(--color-primary-text))"}
-                  />
+                {deltaData.map((bar) => (
+                  <Cell key={bar.time} fill={bar.delta < 0 ? NEGATIVE_COLOR : "rgb(var(--color-primary-text))"} />
                 ))}
               </Bar>
             </BarChart>
@@ -244,14 +245,20 @@ export const HallOfFameScoreOverTime: React.FC<{ playerId: string; playerName: s
             Best period: <span className="font-bold">{fmtNum(summary.best.delta, { signedPositive: true })} pts</span>{" "}
             {dateString(summary.best.time)}
           </span>
-          <span className={classNames("bg-secondary-background/50 text-secondary-text/75 px-2 py-1 rounded")}>
-            {graphData.length} points, {mode === "delta" ? "gain per period" : "score at each point"}
+          <span className="bg-secondary-background/50 text-secondary-text/75 px-2 py-1 rounded">
+            {mode === "delta"
+              ? `${deltaData.length} periods, gain in each`
+              : `${graphData.length} points, score at each`}
           </span>
         </div>
       )}
     </div>
   );
 };
+
+// Day and month only, for the start of a period whose end already names the year.
+const shortDate = (time: number) =>
+  new Date(time).toLocaleDateString("nb-NO", { day: "numeric", month: "short" });
 
 const ScoreTooltip = ({
   active,
@@ -260,11 +267,15 @@ const ScoreTooltip = ({
   seriesLabel,
 }: TooltipProps<ValueType, NameType> & { mode: GraphMode; seriesLabel: string }) => {
   if (!active || !payload || payload.length === 0) return null;
-  const data = payload[0].payload as { time: number; cumulative: number; delta: number };
+  const data = payload[0].payload as { time: number; from?: number; cumulative: number; delta: number };
 
   return (
     <div className="p-3 bg-primary-background/95 backdrop-blur-sm ring-1 ring-primary-text/20 rounded-lg text-primary-text shadow-lg">
-      <div className="text-xs opacity-60 mb-1">{dateString(data.time)}</div>
+      <div className="text-xs opacity-60 mb-1">
+        {mode === "delta" && data.from !== undefined
+          ? `${shortDate(data.from)} – ${dateString(data.time)}`
+          : dateString(data.time)}
+      </div>
       <div className="font-bold text-lg">
         {mode === "delta"
           ? `${fmtNum(data.delta, { signedPositive: true })} pts`
@@ -273,8 +284,8 @@ const ScoreTooltip = ({
       <div className="text-xs opacity-75">{seriesLabel}</div>
       <div className="text-xs opacity-60 mt-1">
         {mode === "delta"
-          ? `${fmtNum(data.cumulative)} pts in total`
-          : `${fmtNum(data.delta, { signedPositive: true })} pts this period`}
+          ? `${fmtNum(data.cumulative)} pts in total after the period`
+          : `${fmtNum(data.delta, { signedPositive: true })} pts since the previous point`}
       </div>
     </div>
   );


### PR DESCRIPTION
Adds a **Score over time** option to the view-mode toggle on the Hall of Fame player page, next to "Section of total" and "Compared to all". Selecting it replaces the section breakdowns with a graph of the player's score through their career.

## What it does

- **Cumulative** — a line of the score as it stood at each simulated point in time, up to 100 points.
- **Delta** — bars of the points gained in each period, grouped into at most 25 bars. Bars go red when the score dropped, which happens when the player lost an achievement record.
- **Section picker** — filters both views to the total score or to any one of the 9 score sections.

Both toggles persist in local storage, and the row of view-mode pills now wraps so the fourth item does not overflow on a phone.

## Timestamps

- First point: the `PLAYER_CREATED` timestamp.
- Last point: now.
- `step = max(1 day, career / 99)`, so points are never closer than one day and never more than 100 in total.

A 10-day-old player gets 11 points one day apart; a 5-year career gets the full 100 spread evenly.

The delta view then groups consecutive periods so at most 25 bars are drawn — 99 bars over a long career is too fine to read. A bar's gain is the sum of the gains of the periods it covers, so the bars still add up to the score of the last point, and a short career is unaffected (10 periods stay 10 bars).

## How the history is calculated

A player's Hall of Fame score depends on what *everyone else* had done by a given moment — peak Elo, time at the top and achievement records are all relative. So each point projects the whole app state at that timestamp (`new TennisTable({ events: eventsUpTo(events, t) })`) and scores the player against it.

Up to 100 full projections is far too heavy for the main thread, so it runs in a web worker following the existing `predictions-history` pattern. The worker streams progress, the UI shows a progress bar, and the graph renders once every point is done.

## Files

| File | Change |
| --- | --- |
| `client-db/hall-of-fame-history.ts` | New. Timestamp rule + per-point simulation. |
| `client-db/event-store/events-up-to.ts` | New. `eventsUpTo` moved out of `use-state-at.tsx` so the worker bundle does not pull in React. |
| `web-worker/web-worker.ts` | New `start-hall-of-fame-history` message with progress and result. |
| `hooks/use-hall-of-fame-history-worker.ts` | New. Worker lifecycle, progress and result. |
| `pages/hall-of-fame/hall-of-fame-score-over-time.tsx` | New. The graph, toggles and tooltip. |
| `pages/hall-of-fame/hall-of-fame-delta-bars.ts` | New. Pure grouping of the score points into at most 25 bars. |
| `pages/hall-of-fame/hall-of-fame-factors.ts` | New. `FACTORS` moved out of the player page to avoid a circular import. |
| `pages/hall-of-fame/hall-of-fame-player-page.tsx` | Third view mode wired in. |

## Testing

- `__tests__/hall-of-fame/score-history.test.ts` — 14 tests on the timestamp rule at every boundary (never more than 100 points, never under a day apart, first point is creation, last point is now) and on the simulation itself, including that the final point equals the player's score today.
- `pages/hall-of-fame/hall-of-fame-delta-bars.test.ts` — 9 tests on the grouping: the 25-bar cap, one bar per period for short careers, bar gains summing to the last point's score, periods joining end to end, and a score drop staying negative.
- Full suite: 962 passed, 1 skipped, 83 suites.
- `npm run lint` and `tsc --noEmit` clean; `npm run build` succeeds.

Not verified in a real browser — the visual check was cut short, so the chart rendering and theme colours have not been seen on screen. The Vercel previews on this PR are the fastest way to check that.