### PR TITLE
Track the side of the table each set of a tracked game

### DIFF
--- a/DenoServer/db/database.ts
+++ b/DenoServer/db/database.ts
@@ -31,6 +31,14 @@ export type LiveGameState = {
   completedSetFirstServers: (1 | 2)[];
   /** Which player (1 or 2) served the first point of the current set. */
   firstServer: 1 | 2;
+  /**
+   * Who had the bad side of the table in each completed set: 1 or 2 for that
+   * player, "neutral" when the 2 sides are equally good, and null when nobody
+   * recorded the sides.
+   */
+  completedSetBadSides: (1 | 2 | "neutral" | null)[];
+  /** Who has the bad side of the table in the current set. */
+  badSide: 1 | 2 | "neutral" | null;
   /** How many points were undone while tracking this match. */
   corrections: number;
   startedAt: number | null;

--- a/DenoServer/event-store/event-types.ts
+++ b/DenoServer/event-store/event-types.ts
@@ -59,6 +59,12 @@ export type GameTracking = {
   endedAfter: number;
   /** Who served the first point of each set: "W" = game winner, "L" = game loser. */
   firstServers: string;
+  /**
+   * Which side of the table the game winner had in each set: "G" = the good
+   * side, "B" = the bad side, "N" = the 2 sides are equally good. Left out when
+   * the sides were not recorded.
+   */
+  winnerSides?: string;
   /** How many points were undone while tracking. */
   corrections: number;
 };

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -50,10 +50,10 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
       "A tracked game records the player who has the bad side of the table in each set. The game details page shows the side of every set.",
     body: [
       text(
-        "The game tracker and the live game admin page have a selector below the serve tracker. It gives 3 options: player 1 has the bad side, player 2 has the bad side, or the 2 sides are equally good. A second press on the selected option removes the record.",
+        "The game tracker and the live game admin page have a selector below the serve tracker. It gives 3 options: the first player has the bad side, the 2 sides are equally good, or the second player has the bad side.",
       ),
       text(
-        "After each set the tracker moves the bad side to the other player, because the players usually change sides. Correct it when the players keep the same side.",
+        "The side locks with the first point of the set, the same as the first server. After each set the tracker moves the bad side to the other player, because the players usually change sides. Correct it at 0-0 when the players keep the same side.",
       ),
       text(
         'The `GAME_SCORE` event stores one char per set, from the side of the game winner: "G" for the good side, "B" for the bad side and "N" for 2 equal sides. A game stores the sides only when every set has one.',

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -42,6 +42,28 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "table-sides-on-tracked-games",
+    title: "Tracked games record the side of the table",
+    date: "2026-08-20",
+    tags: ["feature-update", "technical"],
+    summary:
+      "A tracked game records the player who has the bad side of the table in each set. The game details page shows the side of every set.",
+    body: [
+      text(
+        "The game tracker and the live game admin page have a selector below the serve tracker. It gives 3 options: player 1 has the bad side, player 2 has the bad side, or the 2 sides are equally good. A second press on the selected option removes the record.",
+      ),
+      text(
+        "After each set the tracker moves the bad side to the other player, because the players usually change sides. Correct it when the players keep the same side.",
+      ),
+      text(
+        'The `GAME_SCORE` event stores one char per set, from the side of the game winner: "G" for the good side, "B" for the bad side and "N" for 2 equal sides. A game stores the sides only when every set has one.',
+      ),
+      text(
+        "The set by set table on the game details page has a new Bad side column. A game tracked before this change does not show the column.",
+      ),
+    ],
+  },
+  {
     slug: "leap-frog-and-party-pooper-rules",
     title: "New rules for Leap Frog and Party Pooper",
     date: "2026-08-20",

--- a/frontend/src/client/client-db/__tests__/event-store/games-projector.test.ts
+++ b/frontend/src/client/client-db/__tests__/event-store/games-projector.test.ts
@@ -403,6 +403,31 @@ describe("validateScoreGame", () => {
     expect(result.message).toBe("Tracking data is invalid. Only 'W' and 'L' first servers are allowed");
   });
 
+  it("accepts tracking data without table sides", () => {
+    expect(projector.validateScoreGame(trackedScoreEvent({ winnerSides: undefined })).valid).toBe(true);
+  });
+
+  it("accepts a table side for every set", () => {
+    for (const winnerSides of ["G", "B", "N"]) {
+      expect(projector.validateScoreGame(trackedScoreEvent({ winnerSides })).valid).toBe(true);
+    }
+  });
+
+  it("rejects a table side list that does not cover every set", () => {
+    const result = projector.validateScoreGame(trackedScoreEvent({ winnerSides: "GB" }));
+    expectInvalid(result);
+    expect(result.message).toBe("Tracking data is invalid. There must be one table side per set");
+    const empty = projector.validateScoreGame(trackedScoreEvent({ winnerSides: "" }));
+    expectInvalid(empty);
+    expect(empty.message).toBe("Tracking data is invalid. There must be one table side per set");
+  });
+
+  it("rejects a table side that is not G, B or N", () => {
+    const result = projector.validateScoreGame(trackedScoreEvent({ winnerSides: "W" }));
+    expectInvalid(result);
+    expect(result.message).toBe("Tracking data is invalid. Only 'G', 'B' and 'N' table sides are allowed");
+  });
+
   it("rejects a negative end delta and a negative correction count", () => {
     const endedAfter = projector.validateScoreGame(trackedScoreEvent({ endedAfter: -1 }));
     expectInvalid(endedAfter);

--- a/frontend/src/client/client-db/event-store/event-types.ts
+++ b/frontend/src/client/client-db/event-store/event-types.ts
@@ -65,6 +65,13 @@ export type GameTracking = {
    */
   firstServers: string;
   /**
+   * Which side of the table the game winner had in each set, one char per set:
+   * "G" = the good side, "B" = the bad side, "N" = the 2 sides are equally
+   * good. The game loser had the other side. Left out when the sides were not
+   * recorded, so an older game keeps the rest of its tracking data.
+   */
+  winnerSides?: string;
+  /**
    * How many points were undone while tracking. A high count means the log was
    * corrected by hand, so its times are less trustworthy.
    */

--- a/frontend/src/client/client-db/event-store/projectors/games-projector.ts
+++ b/frontend/src/client/client-db/event-store/projectors/games-projector.ts
@@ -1,3 +1,4 @@
+import { WINNER_SIDES_PATTERN } from "../../../../common/table-sides";
 import { GameCreated, GameDeleted, GameScore, GameTracking } from "../event-types";
 import { ValidatorResponse } from "./validator-types";
 
@@ -36,6 +37,16 @@ function validateTracking(tracking: GameTracking, pointSequences: string[]): str
   }
   if (/^[WL]*$/.test(tracking.firstServers) === false) {
     return "Tracking data is invalid. Only 'W' and 'L' first servers are allowed";
+  }
+  // The sides of the table are optional, because a game can be tracked without
+  // them. A game that has them must have one side per set.
+  if (tracking.winnerSides !== undefined) {
+    if (tracking.winnerSides.length !== pointSequences.length) {
+      return "Tracking data is invalid. There must be one table side per set";
+    }
+    if (WINNER_SIDES_PATTERN.test(tracking.winnerSides) === false) {
+      return "Tracking data is invalid. Only 'G', 'B' and 'N' table sides are allowed";
+    }
   }
   if (isCount(tracking.endedAfter) === false) {
     return "Tracking data is invalid. Ended after must be a positive whole number";

--- a/frontend/src/common/point-sequences.test.ts
+++ b/frontend/src/common/point-sequences.test.ts
@@ -1,4 +1,5 @@
 import { appendPoint, removeLastPoint, toEventTrackingData, TrackedSet } from "./point-sequences";
+import { BadSide } from "./table-sides";
 
 describe("appendPoint", () => {
   it("appends the player's digit and the time of the point", () => {
@@ -39,6 +40,7 @@ describe("toEventTrackingData", () => {
     completedSets,
     trackedSets,
     firstServers: [1, 2] as (1 | 2)[],
+    badSides: [1, 2] as BadSide[],
     source: "track-game" as const,
     startedAt,
     endedAt: startedAt + 120_000,
@@ -86,6 +88,32 @@ describe("toEventTrackingData", () => {
     expect(toEventTrackingData({ ...params, player1IsGameWinner: false })?.tracking.firstServers).toBe("LW");
   });
 
+  it("encodes the bad side of each set from the game winner's perspective", () => {
+    // Player 1 has the bad side in set 1, player 2 in set 2.
+    expect(toEventTrackingData({ ...params, player1IsGameWinner: true })?.tracking.winnerSides).toBe("BG");
+    expect(toEventTrackingData({ ...params, player1IsGameWinner: false })?.tracking.winnerSides).toBe("GB");
+  });
+
+  it("encodes a set with 2 equally good sides as N", () => {
+    const badSides: BadSide[] = ["neutral", "neutral"];
+    expect(toEventTrackingData({ ...params, badSides, player1IsGameWinner: true })?.tracking.winnerSides).toBe("NN");
+  });
+
+  it("leaves out the sides when a set has none, and keeps the rest of the data", () => {
+    const tracking = toEventTrackingData({ ...params, badSides: [1, null], player1IsGameWinner: true })?.tracking;
+    expect(tracking?.winnerSides).toBeUndefined();
+    expect(tracking?.firstServers).toBe("WL");
+  });
+
+  it("leaves out the sides when they do not count up to the completed sets", () => {
+    expect(
+      toEventTrackingData({ ...params, badSides: [1], player1IsGameWinner: true })?.tracking.winnerSides,
+    ).toBeUndefined();
+    expect(
+      toEventTrackingData({ ...params, badSides: [], player1IsGameWinner: true })?.tracking.winnerSides,
+    ).toBeUndefined();
+  });
+
   it("keeps the source and the correction count", () => {
     const tracking = toEventTrackingData({ ...params, player1IsGameWinner: true })?.tracking;
     expect(tracking?.version).toBe(1);
@@ -95,7 +123,14 @@ describe("toEventTrackingData", () => {
 
   it("returns undefined when there are no completed sets", () => {
     expect(
-      toEventTrackingData({ ...params, completedSets: [], trackedSets: [], firstServers: [], player1IsGameWinner: true }),
+      toEventTrackingData({
+        ...params,
+        completedSets: [],
+        trackedSets: [],
+        firstServers: [],
+        badSides: [],
+        player1IsGameWinner: true,
+      }),
     ).toBeUndefined();
   });
 

--- a/frontend/src/common/point-sequences.ts
+++ b/frontend/src/common/point-sequences.ts
@@ -5,12 +5,14 @@
  * set as a string of "1"/"2" chars — one char per point, in the order the
  * points were scored, naming the player slot that won the point. Next to each
  * sequence the tracker keeps the time of every point, and per set who served
- * first. When the game is saved all of it is re-encoded from the game winner's
- * perspective ("W"/"L") to match how a GAME_SCORE event stores its setPoints.
+ * first and who had the bad side of the table. When the game is saved all of it
+ * is re-encoded from the game winner's perspective ("W"/"L") to match how a
+ * GAME_SCORE event stores its setPoints.
  */
 
 import { GameTracking } from "../client/client-db/event-store/event-types";
 import { Server } from "./serve-tracker";
+import { BadSide, encodeWinnerSides } from "./table-sides";
 
 export type TrackedSetPoints = { player1: number; player2: number };
 
@@ -75,6 +77,11 @@ export function toEventTrackingData(params: {
   trackedSets: TrackedSet[];
   /** Who served the first point of each completed set. */
   firstServers: Server[];
+  /**
+   * Who had the bad side of the table in each completed set. The sides are only
+   * saved when every set has one, because a set without one says nothing.
+   */
+  badSides: BadSide[];
   player1IsGameWinner: boolean;
   source: GameTracking["source"];
   /** Epoch ms tracking started, and when the match was ended. */
@@ -82,7 +89,7 @@ export function toEventTrackingData(params: {
   endedAt: number | null;
   corrections: number;
 }): { pointSequences: string[]; tracking: GameTracking } | undefined {
-  const { completedSets, trackedSets, firstServers, player1IsGameWinner, startedAt, endedAt } = params;
+  const { completedSets, trackedSets, firstServers, badSides, player1IsGameWinner, startedAt, endedAt } = params;
   if (startedAt === null || endedAt === null) return undefined;
   if (completedSets.length === 0) return undefined;
   if (trackedSets.length !== completedSets.length) return undefined;
@@ -114,6 +121,11 @@ export function toEventTrackingData(params: {
     }),
   );
 
+  // One side per set or nothing: a game with a side missing keeps the rest of
+  // its tracking data and drops the sides.
+  const winnerSides =
+    badSides.length === completedSets.length ? encodeWinnerSides(badSides, gameWinnerSlot) : undefined;
+
   return {
     pointSequences,
     tracking: {
@@ -123,6 +135,7 @@ export function toEventTrackingData(params: {
       pointDeltas,
       endedAfter: Math.max(0, Math.round((endedAt - startedAt) / 100) - previousTenths),
       firstServers: firstServers.map((server) => (server === gameWinnerSlot ? "W" : "L")).join(""),
+      ...(winnerSides ? { winnerSides } : {}),
       corrections: params.corrections,
     },
   };

--- a/frontend/src/common/table-sides-display.test.tsx
+++ b/frontend/src/common/table-sides-display.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { BadSide } from "./table-sides";
+import { TableSideSelector } from "./table-sides-display";
+
+function renderSelector(badSide: BadSide, onSelect: (badSide: BadSide) => void) {
+  return render(
+    <TableSideSelector
+      badSide={badSide}
+      player1Name="Ada"
+      player2Name="Bo"
+      player1Color="#112233"
+      player2Color="#445566"
+      onSelect={onSelect}
+    />,
+  );
+}
+
+describe("TableSideSelector", () => {
+  it("selects the player who has the bad side", async () => {
+    const onSelect = jest.fn();
+    renderSelector(null, onSelect);
+
+    await userEvent.click(screen.getByRole("button", { name: "Bo" }));
+    expect(onSelect).toHaveBeenCalledWith(2);
+  });
+
+  it("selects 2 equally good sides", async () => {
+    const onSelect = jest.fn();
+    renderSelector(null, onSelect);
+
+    await userEvent.click(screen.getByRole("button", { name: "Equal" }));
+    expect(onSelect).toHaveBeenCalledWith("neutral");
+  });
+
+  it("removes the record when the selected option is pressed again", async () => {
+    const onSelect = jest.fn();
+    renderSelector(1, onSelect);
+
+    await userEvent.click(screen.getByRole("button", { name: "Ada" }));
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+});

--- a/frontend/src/common/table-sides-display.test.tsx
+++ b/frontend/src/common/table-sides-display.test.tsx
@@ -56,20 +56,20 @@ describe("TableSideDisplay", () => {
     renderDisplay({ badSide: 1, currentSet: { player1: 0, player2: 1 }, onSelect: jest.fn() });
 
     expect(screen.queryAllByRole("button")).toHaveLength(0);
-    expect(screen.getByText("🚧 Ada on the bad side")).toBeInTheDocument();
+    expect(screen.getByText("😵 Ada on the bad side")).toBeInTheDocument();
   });
 
   it("says that a locked set has no side", () => {
     renderDisplay({ badSide: null, currentSet: { player1: 1, player2: 0 }, onSelect: jest.fn() });
 
     expect(screen.queryAllByRole("button")).toHaveLength(0);
-    expect(screen.getByText("🚧 No bad side recorded for this set")).toBeInTheDocument();
+    expect(screen.getByText("😵 No bad side recorded for this set")).toBeInTheDocument();
   });
 
   it("shows no selector at all without a select handler", () => {
     renderDisplay({ badSide: "neutral" });
 
     expect(screen.queryAllByRole("button")).toHaveLength(0);
-    expect(screen.getByText("🚧 Equal sides")).toBeInTheDocument();
+    expect(screen.getByText("😵 Equal sides")).toBeInTheDocument();
   });
 });

--- a/frontend/src/common/table-sides-display.test.tsx
+++ b/frontend/src/common/table-sides-display.test.tsx
@@ -1,25 +1,30 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { BadSide } from "./table-sides";
-import { TableSideSelector } from "./table-sides-display";
+import { TableSideDisplay } from "./table-sides-display";
 
-function renderSelector(badSide: BadSide, onSelect: (badSide: BadSide) => void) {
+function renderDisplay(params: {
+  badSide: BadSide;
+  currentSet?: { player1: number; player2: number };
+  onSelect?: (badSide: BadSide) => void;
+}) {
   return render(
-    <TableSideSelector
-      badSide={badSide}
+    <TableSideDisplay
+      currentSet={params.currentSet ?? { player1: 0, player2: 0 }}
+      badSide={params.badSide}
       player1Name="Ada"
       player2Name="Bo"
       player1Color="#112233"
       player2Color="#445566"
-      onSelect={onSelect}
+      onSelect={params.onSelect}
     />,
   );
 }
 
-describe("TableSideSelector", () => {
+describe("TableSideDisplay", () => {
   it("selects the player who has the bad side", async () => {
     const onSelect = jest.fn();
-    renderSelector(null, onSelect);
+    renderDisplay({ badSide: null, onSelect });
 
     await userEvent.click(screen.getByRole("button", { name: "Bo" }));
     expect(onSelect).toHaveBeenCalledWith(2);
@@ -27,17 +32,44 @@ describe("TableSideSelector", () => {
 
   it("selects 2 equally good sides", async () => {
     const onSelect = jest.fn();
-    renderSelector(null, onSelect);
+    renderDisplay({ badSide: null, onSelect });
 
     await userEvent.click(screen.getByRole("button", { name: "Equal" }));
     expect(onSelect).toHaveBeenCalledWith("neutral");
   });
 
+  it("puts Equal between the 2 players", () => {
+    renderDisplay({ badSide: null, onSelect: jest.fn() });
+
+    expect(screen.getAllByRole("button").map((button) => button.textContent)).toEqual(["Ada", "Equal", "Bo"]);
+  });
+
   it("removes the record when the selected option is pressed again", async () => {
     const onSelect = jest.fn();
-    renderSelector(1, onSelect);
+    renderDisplay({ badSide: 1, onSelect });
 
     await userEvent.click(screen.getByRole("button", { name: "Ada" }));
     expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it("locks the side and names it when the set has a point", () => {
+    renderDisplay({ badSide: 1, currentSet: { player1: 0, player2: 1 }, onSelect: jest.fn() });
+
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+    expect(screen.getByText("🚧 Ada on the bad side")).toBeInTheDocument();
+  });
+
+  it("says that a locked set has no side", () => {
+    renderDisplay({ badSide: null, currentSet: { player1: 1, player2: 0 }, onSelect: jest.fn() });
+
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+    expect(screen.getByText("🚧 No bad side recorded for this set")).toBeInTheDocument();
+  });
+
+  it("shows no selector at all without a select handler", () => {
+    renderDisplay({ badSide: "neutral" });
+
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+    expect(screen.getByText("🚧 Equal sides")).toBeInTheDocument();
   });
 });

--- a/frontend/src/common/table-sides-display.tsx
+++ b/frontend/src/common/table-sides-display.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { classNames } from "./class-names";
+import { fill } from "./player-color-styles";
+import { BadSide } from "./table-sides";
+
+type TableSideSelectorProps = {
+  /** The player who has the bad side of the current set, if it is recorded. */
+  badSide: BadSide;
+  player1Name: string;
+  player2Name: string;
+  /** The players' own colours (`#rrggbb`), which the selected pill is tinted with. */
+  player1Color: string;
+  player2Color: string;
+  onSelect: (badSide: BadSide) => void;
+};
+
+/**
+ * Picks the player who has the bad side of the table in the current set. The
+ * "Equal" option records that the 2 sides are equally good.
+ *
+ * A press on the selected option removes it again, so a set the operator does
+ * not know goes back to no record. The selector stays available for the whole
+ * set, because the players can change sides after the first point is scored.
+ */
+export const TableSideSelector: React.FC<TableSideSelectorProps> = ({
+  badSide,
+  player1Name,
+  player2Name,
+  player1Color,
+  player2Color,
+  onSelect,
+}) => {
+  const toggle = (option: BadSide) => onSelect(badSide === option ? null : option);
+
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-2">
+      <span className="text-xs text-gray-400">🚧 Bad side:</span>
+      <button
+        onClick={() => toggle(1)}
+        title={`${player1Name} has the bad side of the table`}
+        className={classNames(
+          "text-xs px-2.5 py-1 rounded-full font-semibold transition",
+          badSide === 1 ? "hover:brightness-95" : "bg-gray-100 text-gray-500 hover:bg-gray-200",
+        )}
+        style={badSide === 1 ? fill(player1Color) : undefined}
+      >
+        {player1Name}
+      </button>
+      <button
+        onClick={() => toggle(2)}
+        title={`${player2Name} has the bad side of the table`}
+        className={classNames(
+          "text-xs px-2.5 py-1 rounded-full font-semibold transition",
+          badSide === 2 ? "hover:brightness-95" : "bg-gray-100 text-gray-500 hover:bg-gray-200",
+        )}
+        style={badSide === 2 ? fill(player2Color) : undefined}
+      >
+        {player2Name}
+      </button>
+      <button
+        onClick={() => toggle("neutral")}
+        title="Both sides of the table are equally good"
+        className={classNames(
+          "text-xs px-2.5 py-1 rounded-full font-semibold transition",
+          badSide === "neutral"
+            ? "bg-gray-700 text-white hover:brightness-125"
+            : "bg-gray-100 text-gray-500 hover:bg-gray-200",
+        )}
+      >
+        Equal
+      </button>
+    </div>
+  );
+};

--- a/frontend/src/common/table-sides-display.tsx
+++ b/frontend/src/common/table-sides-display.tsx
@@ -49,7 +49,7 @@ export const TableSideDisplay: React.FC<TableSideDisplayProps> = ({
     const toggle = (option: BadSide) => onSelect(badSide === option ? null : option);
     return (
       <div className="flex flex-wrap items-center justify-center gap-2">
-        <span className="text-xs text-gray-400">🚧 Bad side:</span>
+        <span className="text-xs text-gray-400">😵 Bad side:</span>
         <button
           onClick={() => toggle(1)}
           title={`${player1Name} has the bad side of the table`}
@@ -82,7 +82,7 @@ export const TableSideDisplay: React.FC<TableSideDisplayProps> = ({
 
   // The set is locked. Show the side it was given, or say that it has none.
   if (label === null) {
-    return <div className="text-center text-xs text-gray-400">🚧 No bad side recorded for this set</div>;
+    return <div className="text-center text-xs text-gray-400">😵 No bad side recorded for this set</div>;
   }
 
   return (
@@ -91,7 +91,7 @@ export const TableSideDisplay: React.FC<TableSideDisplayProps> = ({
         className={classNames(PILL, badSide === "neutral" && "bg-gray-700 text-white")}
         style={badSide === "neutral" ? undefined : fill(badSide === 1 ? player1Color : player2Color)}
       >
-        🚧 {label}
+        😵 {label}
       </div>
     </div>
   );

--- a/frontend/src/common/table-sides-display.tsx
+++ b/frontend/src/common/table-sides-display.tsx
@@ -1,28 +1,40 @@
 import React from "react";
 import { classNames } from "./class-names";
 import { fill } from "./player-color-styles";
-import { BadSide } from "./table-sides";
+import { BadSide, badSideLabel } from "./table-sides";
 
-type TableSideSelectorProps = {
+const PILL = "text-xs px-2.5 py-1 rounded-full font-semibold transition";
+const UNSELECTED_PILL = "bg-gray-100 text-gray-500 hover:bg-gray-200";
+
+type TableSideDisplayProps = {
+  currentSet: { player1: number; player2: number };
   /** The player who has the bad side of the current set, if it is recorded. */
   badSide: BadSide;
   player1Name: string;
   player2Name: string;
-  /** The players' own colours (`#rrggbb`), which the selected pill is tinted with. */
+  /** The players' own colours (`#rrggbb`), which the tracker is tinted with. */
   player1Color: string;
   player2Color: string;
-  onSelect: (badSide: BadSide) => void;
+  /**
+   * When provided, the players are selectable while the current set is still
+   * 0-0, letting the operator pick who has the bad side. Omit for read-only
+   * displays (e.g. the public scoreboard).
+   */
+  onSelect?: (badSide: BadSide) => void;
 };
 
 /**
- * Picks the player who has the bad side of the table in the current set. The
- * "Equal" option records that the 2 sides are equally good.
+ * Which side of the table the players have in the current set. "Equal" records
+ * that the 2 sides are equally good, and it sits between the 2 players, the
+ * same way the sides of the table do.
  *
- * A press on the selected option removes it again, so a set the operator does
- * not know goes back to no record. The selector stays available for the whole
- * set, because the players can change sides after the first point is scored.
+ * The side locks when the first point of the set is scored, the same as the
+ * first server, because the players keep their side for the whole set. While
+ * the set is 0-0 a press on the selected option removes it again, so a set the
+ * operator does not know goes back to no record.
  */
-export const TableSideSelector: React.FC<TableSideSelectorProps> = ({
+export const TableSideDisplay: React.FC<TableSideDisplayProps> = ({
+  currentSet,
   badSide,
   player1Name,
   player2Name,
@@ -30,45 +42,57 @@ export const TableSideSelector: React.FC<TableSideSelectorProps> = ({
   player2Color,
   onSelect,
 }) => {
-  const toggle = (option: BadSide) => onSelect(badSide === option ? null : option);
+  const isSetEmpty = currentSet.player1 === 0 && currentSet.player2 === 0;
+  const label = badSideLabel(badSide, player1Name, player2Name);
+
+  if (onSelect && isSetEmpty) {
+    const toggle = (option: BadSide) => onSelect(badSide === option ? null : option);
+    return (
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <span className="text-xs text-gray-400">🚧 Bad side:</span>
+        <button
+          onClick={() => toggle(1)}
+          title={`${player1Name} has the bad side of the table`}
+          className={classNames(PILL, badSide === 1 ? "hover:brightness-95" : UNSELECTED_PILL)}
+          style={badSide === 1 ? fill(player1Color) : undefined}
+        >
+          {player1Name}
+        </button>
+        <button
+          onClick={() => toggle("neutral")}
+          title="Both sides of the table are equally good"
+          className={classNames(
+            PILL,
+            badSide === "neutral" ? "bg-gray-700 text-white hover:brightness-125" : UNSELECTED_PILL,
+          )}
+        >
+          Equal
+        </button>
+        <button
+          onClick={() => toggle(2)}
+          title={`${player2Name} has the bad side of the table`}
+          className={classNames(PILL, badSide === 2 ? "hover:brightness-95" : UNSELECTED_PILL)}
+          style={badSide === 2 ? fill(player2Color) : undefined}
+        >
+          {player2Name}
+        </button>
+      </div>
+    );
+  }
+
+  // The set is locked. Show the side it was given, or say that it has none.
+  if (label === null) {
+    return <div className="text-center text-xs text-gray-400">🚧 No bad side recorded for this set</div>;
+  }
 
   return (
-    <div className="flex flex-wrap items-center justify-center gap-2">
-      <span className="text-xs text-gray-400">🚧 Bad side:</span>
-      <button
-        onClick={() => toggle(1)}
-        title={`${player1Name} has the bad side of the table`}
-        className={classNames(
-          "text-xs px-2.5 py-1 rounded-full font-semibold transition",
-          badSide === 1 ? "hover:brightness-95" : "bg-gray-100 text-gray-500 hover:bg-gray-200",
-        )}
-        style={badSide === 1 ? fill(player1Color) : undefined}
+    <div className="flex items-center justify-center">
+      <div
+        className={classNames(PILL, badSide === "neutral" && "bg-gray-700 text-white")}
+        style={badSide === "neutral" ? undefined : fill(badSide === 1 ? player1Color : player2Color)}
       >
-        {player1Name}
-      </button>
-      <button
-        onClick={() => toggle(2)}
-        title={`${player2Name} has the bad side of the table`}
-        className={classNames(
-          "text-xs px-2.5 py-1 rounded-full font-semibold transition",
-          badSide === 2 ? "hover:brightness-95" : "bg-gray-100 text-gray-500 hover:bg-gray-200",
-        )}
-        style={badSide === 2 ? fill(player2Color) : undefined}
-      >
-        {player2Name}
-      </button>
-      <button
-        onClick={() => toggle("neutral")}
-        title="Both sides of the table are equally good"
-        className={classNames(
-          "text-xs px-2.5 py-1 rounded-full font-semibold transition",
-          badSide === "neutral"
-            ? "bg-gray-700 text-white hover:brightness-125"
-            : "bg-gray-100 text-gray-500 hover:bg-gray-200",
-        )}
-      >
-        Equal
-      </button>
+        🚧 {label}
+      </div>
     </div>
   );
 };

--- a/frontend/src/common/table-sides.test.ts
+++ b/frontend/src/common/table-sides.test.ts
@@ -1,4 +1,5 @@
 import {
+  alignBadSides,
   BadSide,
   badSideLabel,
   badSideName,
@@ -63,6 +64,27 @@ describe("badSideLabel", () => {
   it("labels equal sides, and gives no label for an unrecorded set", () => {
     expect(badSideLabel("neutral", "Ada", "Bo")).toBe("Equal sides");
     expect(badSideLabel(null, "Ada", "Bo")).toBe(null);
+  });
+
+  it("gives no label for a set past the end of a side list", () => {
+    // A game tracked before the sides existed has fewer sides than sets.
+    const badSides: BadSide[] = [];
+    expect(badSideLabel(badSides[0], "Ada", "Bo")).toBe(null);
+  });
+});
+
+describe("alignBadSides", () => {
+  it("pads a short side list with a null per set", () => {
+    expect(alignBadSides([], 2)).toEqual([null, null]);
+    expect(alignBadSides([1], 3)).toEqual([1, null, null]);
+  });
+
+  it("keeps a list that already covers every set", () => {
+    expect(alignBadSides([1, "neutral"], 2)).toEqual([1, "neutral"]);
+  });
+
+  it("cuts a list that is longer than the sets", () => {
+    expect(alignBadSides([1, 2], 1)).toEqual([1]);
   });
 });
 

--- a/frontend/src/common/table-sides.test.ts
+++ b/frontend/src/common/table-sides.test.ts
@@ -1,0 +1,89 @@
+import {
+  BadSide,
+  badSideLabel,
+  badSideName,
+  encodeWinnerSides,
+  nextSetBadSide,
+  winnerSideOfSet,
+} from "./table-sides";
+
+describe("nextSetBadSide", () => {
+  it("moves the bad side to the other player", () => {
+    expect(nextSetBadSide(1)).toBe(2);
+    expect(nextSetBadSide(2)).toBe(1);
+  });
+
+  it("keeps a neutral or unrecorded set as it is", () => {
+    expect(nextSetBadSide("neutral")).toBe("neutral");
+    expect(nextSetBadSide(null)).toBe(null);
+  });
+});
+
+describe("encodeWinnerSides", () => {
+  it("encodes the side of the game winner as G or B", () => {
+    // Player 1 has the bad side in set 1 and player 2 in set 2.
+    expect(encodeWinnerSides([1, 2], 1)).toBe("BG");
+    expect(encodeWinnerSides([1, 2], 2)).toBe("GB");
+  });
+
+  it("encodes 2 equally good sides as N", () => {
+    expect(encodeWinnerSides(["neutral", 1, "neutral"], 1)).toBe("NBN");
+  });
+
+  it("returns undefined when a set has no recorded side", () => {
+    expect(encodeWinnerSides([1, null], 1)).toBeUndefined();
+    expect(encodeWinnerSides([null], 1)).toBeUndefined();
+  });
+
+  it("returns undefined for a game with no sets", () => {
+    expect(encodeWinnerSides([], 1)).toBeUndefined();
+  });
+});
+
+describe("winnerSideOfSet", () => {
+  it("reads the side of one set", () => {
+    expect(winnerSideOfSet("GBN", 0)).toBe("G");
+    expect(winnerSideOfSet("GBN", 1)).toBe("B");
+    expect(winnerSideOfSet("GBN", 2)).toBe("N");
+  });
+
+  it("returns undefined for a game or a set without sides", () => {
+    expect(winnerSideOfSet(undefined, 0)).toBeUndefined();
+    expect(winnerSideOfSet("GB", 2)).toBeUndefined();
+    expect(winnerSideOfSet("X", 0)).toBeUndefined();
+  });
+});
+
+describe("badSideLabel", () => {
+  it("names the player who has the bad side", () => {
+    expect(badSideLabel(1, "Ada", "Bo")).toBe("Ada on the bad side");
+    expect(badSideLabel(2, "Ada", "Bo")).toBe("Bo on the bad side");
+  });
+
+  it("labels equal sides, and gives no label for an unrecorded set", () => {
+    expect(badSideLabel("neutral", "Ada", "Bo")).toBe("Equal sides");
+    expect(badSideLabel(null, "Ada", "Bo")).toBe(null);
+  });
+});
+
+describe("badSideName", () => {
+  it("names the player who had the bad side of a stored set", () => {
+    expect(badSideName("B", "Ada", "Bo")).toBe("Ada");
+    expect(badSideName("G", "Ada", "Bo")).toBe("Bo");
+    expect(badSideName("N", "Ada", "Bo")).toBe("Equal");
+  });
+});
+
+describe("a set of sides through the whole flow", () => {
+  it("keeps the side of every set when the players change sides", () => {
+    // The operator records set 1 and the tracker alternates from there.
+    let badSide: BadSide = 1;
+    const sides: BadSide[] = [];
+    for (let set = 0; set < 3; set++) {
+      sides.push(badSide);
+      badSide = nextSetBadSide(badSide);
+    }
+    expect(encodeWinnerSides(sides, 1)).toBe("BGB");
+    expect(encodeWinnerSides(sides, 2)).toBe("GBG");
+  });
+});

--- a/frontend/src/common/table-sides.ts
+++ b/frontend/src/common/table-sides.ts
@@ -1,0 +1,73 @@
+/**
+ * Which side of the table the players had in each set of a tracked game.
+ *
+ * One side of a table is often worse than the other, because of the light, the
+ * space behind it or a draught. The players usually change sides after every
+ * set, but not every pair does it. While a game is tracked the side is kept as
+ * the player slot that has the bad side. When the game is saved it is
+ * re-encoded from the game winner's perspective, the same way the point
+ * sequences are.
+ */
+
+import { Server } from "./serve-tracker";
+
+/**
+ * The player slot that had the bad side of the table in one set: 1 or 2 for
+ * that player, "neutral" when the 2 sides are equally good, and null when
+ * nobody recorded the sides.
+ */
+export type BadSide = 1 | 2 | "neutral" | null;
+
+/**
+ * The side the game winner had in one set, as one char of the `winnerSides`
+ * string of a GAME_SCORE event: "G" = the good side, "B" = the bad side,
+ * "N" = the 2 sides are equally good.
+ */
+export type WinnerSide = "G" | "B" | "N";
+
+/** Every char a stored `winnerSides` string can hold. */
+export const WINNER_SIDES_PATTERN = /^[GBN]*$/;
+
+/**
+ * The bad side of the next set. The players change sides after every set, so
+ * the bad side moves to the other player. A neutral or unrecorded set keeps its
+ * value, because there is nothing to change.
+ */
+export function nextSetBadSide(badSide: BadSide): BadSide {
+  if (badSide === 1) return 2;
+  if (badSide === 2) return 1;
+  return badSide;
+}
+
+/**
+ * Encodes the bad side of every set from the game winner's perspective. Returns
+ * undefined when a set has no recorded side, so the game keeps the rest of its
+ * tracking data instead of storing a side nobody recorded.
+ */
+export function encodeWinnerSides(badSides: BadSide[], gameWinnerSlot: Server): string | undefined {
+  if (badSides.length === 0) return undefined;
+  if (badSides.some((side) => side === null)) return undefined;
+  return badSides.map((side) => (side === "neutral" ? "N" : side === gameWinnerSlot ? "B" : "G")).join("");
+}
+
+/** The side the game winner had in one set, or undefined when it is not recorded. */
+export function winnerSideOfSet(winnerSides: string | undefined, setIndex: number): WinnerSide | undefined {
+  const side = winnerSides?.[setIndex];
+  return side === "G" || side === "B" || side === "N" ? side : undefined;
+}
+
+/**
+ * A label for one tracked set: who has the bad side, or that the sides are
+ * equally good. Null when the set has no recorded side.
+ */
+export function badSideLabel(badSide: BadSide, player1Name: string, player2Name: string): string | null {
+  if (badSide === null) return null;
+  if (badSide === "neutral") return "Equal sides";
+  return `${badSide === 1 ? player1Name : player2Name} on the bad side`;
+}
+
+/** The name of the player who had the bad side, or "Equal" for a neutral set. */
+export function badSideName(side: WinnerSide, gameWinnerName: string, gameLoserName: string): string {
+  if (side === "N") return "Equal";
+  return side === "B" ? gameWinnerName : gameLoserName;
+}

--- a/frontend/src/common/table-sides.ts
+++ b/frontend/src/common/table-sides.ts
@@ -58,12 +58,27 @@ export function winnerSideOfSet(winnerSides: string | undefined, setIndex: numbe
 
 /**
  * A label for one tracked set: who has the bad side, or that the sides are
- * equally good. Null when the set has no recorded side.
+ * equally good. Null when the set has no recorded side — including a set past
+ * the end of a side list, which a game tracked before the sides existed has.
  */
-export function badSideLabel(badSide: BadSide, player1Name: string, player2Name: string): string | null {
-  if (badSide === null) return null;
+export function badSideLabel(
+  badSide: BadSide | undefined,
+  player1Name: string,
+  player2Name: string,
+): string | null {
+  if (badSide === 1) return `${player1Name} on the bad side`;
+  if (badSide === 2) return `${player2Name} on the bad side`;
   if (badSide === "neutral") return "Equal sides";
-  return `${badSide === 1 ? player1Name : player2Name} on the bad side`;
+  return null;
+}
+
+/**
+ * The sides of `setCount` completed sets, with a null for every set that has
+ * none. A game that was tracked before the sides existed has fewer sides than
+ * sets, and padding keeps every later side with its own set.
+ */
+export function alignBadSides(badSides: BadSide[], setCount: number): BadSide[] {
+  return Array.from({ length: setCount }, (_, index) => badSides[index] ?? null);
 }
 
 /** The name of the player who had the bad side, or "Equal" for a neutral set. */

--- a/frontend/src/pages/add-game/track-game.tsx
+++ b/frontend/src/pages/add-game/track-game.tsx
@@ -15,6 +15,8 @@ import { stringToColor } from "../../common/string-to-color";
 import { CARD_SURFACE, fill, panelTint, ROW_SURFACE, softFill, textOn } from "../../common/player-color-styles";
 import { getServeInfo, Server } from "../../common/serve-tracker";
 import { ServeTrackerDisplay } from "../../common/serve-tracker-display";
+import { BadSide, badSideLabel, nextSetBadSide } from "../../common/table-sides";
+import { TableSideSelector } from "../../common/table-sides-display";
 import { LiveGamePredictionCard } from "../live-game/live-game-prediction-card";
 import { computeLiveWinPrediction } from "../live-game/live-game-win-probability";
 import { Predictions } from "../../client/client-db/predictions";
@@ -45,6 +47,8 @@ interface MatchData {
   trackedSets: TrackedSet[];
   /** Who served the first point of each completed set. */
   firstServers: Server[];
+  /** Who had the bad side of the table in each completed set. */
+  badSides: BadSide[];
 }
 
 type Stage = "player-selection" | "scoring" | "summary";
@@ -63,6 +67,7 @@ export const TrackGamePage: React.FC = () => {
     setPoints: [],
     trackedSets: [],
     firstServers: [],
+    badSides: [],
   });
   const [currentSetScore, setCurrentSetScore] = useState<SetPoint>({
     player1: 0,
@@ -71,6 +76,9 @@ export const TrackGamePage: React.FC = () => {
   // The points of the current set, in the order they were scored.
   const [currentTrackedSet, setCurrentTrackedSet] = useState<TrackedSet>(emptyTrackedSet);
   const [firstServer, setFirstServer] = useState<Server>(1);
+  // Who has the bad side of the table in the set being played. Null until the
+  // operator records it, and the sides are only saved when every set has one.
+  const [badSide, setBadSide] = useState<BadSide>(null);
   // Epoch ms the match started, when it was ended, and how many points were
   // undone. Saved with the game so its timeline can be replayed.
   const [startedAt, setStartedAt] = useState<number | null>(null);
@@ -143,12 +151,16 @@ export const TrackGamePage: React.FC = () => {
       setPoints: [...(prev.setPoints || []), newSetPoint],
       trackedSets: [...prev.trackedSets, currentTrackedSet],
       firstServers: [...prev.firstServers, firstServer],
+      badSides: [...prev.badSides, badSide],
     }));
 
     setCurrentSetScore({ player1: 0, player2: 0 });
     setCurrentTrackedSet(emptyTrackedSet);
     // Alternate who serves first in the next set, per table tennis convention.
     setFirstServer((prev) => (prev === 1 ? 2 : 1));
+    // The players change sides after every set, so the bad side moves to the
+    // other player. The operator can correct it if this pair does not change.
+    setBadSide(nextSetBadSide);
   };
 
   const startMatch = () => {
@@ -188,6 +200,7 @@ export const TrackGamePage: React.FC = () => {
       completedSets: setPointsForValidation,
       trackedSets: matchData.trackedSets,
       firstServers: matchData.firstServers,
+      badSides: matchData.badSides,
       player1IsGameWinner: player1 === winner,
       source: "track-game",
       startedAt,
@@ -300,6 +313,8 @@ export const TrackGamePage: React.FC = () => {
         completedSetPointTimes: matchData.trackedSets.map((set) => [...set.pointTimes]),
         completedSetFirstServers: [...matchData.firstServers],
         firstServer,
+        completedSetBadSides: [...matchData.badSides],
+        badSide,
         corrections,
         // Keep the original start so the timeline stays continuous across the
         // handover. Only a match that skipped the scoring screen starts now.
@@ -324,10 +339,12 @@ export const TrackGamePage: React.FC = () => {
       setPoints: [],
       trackedSets: [],
       firstServers: [],
+      badSides: [],
     });
     setCurrentSetScore({ player1: 0, player2: 0 });
     setCurrentTrackedSet(emptyTrackedSet);
     setFirstServer(1);
+    setBadSide(null);
     setStartedAt(null);
     setEndedAt(null);
     setCorrections(0);
@@ -425,6 +442,17 @@ export const TrackGamePage: React.FC = () => {
                   player1Color={player1Color}
                   player2Color={player2Color}
                   onSelectFirstServer={setFirstServer}
+                />
+              </div>
+              {/* Which side of the table the players have this set */}
+              <div className="mt-1.5 tall:mt-2">
+                <TableSideSelector
+                  badSide={badSide}
+                  player1Name={context.playerName(player1)}
+                  player2Name={context.playerName(player2)}
+                  player1Color={player1Color}
+                  player2Color={player2Color}
+                  onSelect={setBadSide}
                 />
               </div>
             </div>
@@ -565,9 +593,17 @@ export const TrackGamePage: React.FC = () => {
               <div className="space-y-2">
                 {matchData.setPoints.map((set, index) => {
                   const setWinner = set.player1 > set.player2 ? 1 : 2;
+                  const sideLabel = badSideLabel(
+                    matchData.badSides[index],
+                    context.playerName(player1),
+                    context.playerName(player2),
+                  );
                   return (
                     <div key={index} className="flex items-center justify-between px-3 py-2 bg-gray-50 rounded-lg text-sm">
-                      <span className="font-semibold text-gray-700">Set {index + 1}</span>
+                      <div className="flex flex-col">
+                        <span className="font-semibold text-gray-700">Set {index + 1}</span>
+                        {sideLabel && <span className="text-xs text-gray-400">🚧 {sideLabel}</span>}
+                      </div>
                       <div className="flex items-center gap-3">
                         <div className="w-5">{setWinner === 1 && "🏆"}</div>
                         <div className="w-16 flex items-center justify-between text-lg">
@@ -680,9 +716,17 @@ export const TrackGamePage: React.FC = () => {
                 <div className="space-y-2">
                   {matchData.setPoints.map((set, index) => {
                     const setWinner = set.player1 > set.player2 ? 1 : 2;
+                    const sideLabel = badSideLabel(
+                      matchData.badSides[index],
+                      context.playerName(player1),
+                      context.playerName(player2),
+                    );
                     return (
                       <div key={index} className="flex items-center justify-between px-3 py-2 bg-gray-50 rounded-lg text-sm">
-                        <span className="font-semibold text-gray-700">Set {index + 1}</span>
+                        <div className="flex flex-col">
+                          <span className="font-semibold text-gray-700">Set {index + 1}</span>
+                          {sideLabel && <span className="text-xs text-gray-400">🚧 {sideLabel}</span>}
+                        </div>
                         <div className="flex items-center gap-3">
                           <div className="w-5">{setWinner === 1 && "🏆"}</div>
                           <div className="w-16 flex items-center justify-between text-lg">

--- a/frontend/src/pages/add-game/track-game.tsx
+++ b/frontend/src/pages/add-game/track-game.tsx
@@ -16,7 +16,7 @@ import { CARD_SURFACE, fill, panelTint, ROW_SURFACE, softFill, textOn } from "..
 import { getServeInfo, Server } from "../../common/serve-tracker";
 import { ServeTrackerDisplay } from "../../common/serve-tracker-display";
 import { BadSide, badSideLabel, nextSetBadSide } from "../../common/table-sides";
-import { TableSideSelector } from "../../common/table-sides-display";
+import { TableSideDisplay } from "../../common/table-sides-display";
 import { LiveGamePredictionCard } from "../live-game/live-game-prediction-card";
 import { computeLiveWinPrediction } from "../live-game/live-game-win-probability";
 import { Predictions } from "../../client/client-db/predictions";
@@ -446,7 +446,8 @@ export const TrackGamePage: React.FC = () => {
               </div>
               {/* Which side of the table the players have this set */}
               <div className="mt-1.5 tall:mt-2">
-                <TableSideSelector
+                <TableSideDisplay
+                  currentSet={currentSetScore}
                   badSide={badSide}
                   player1Name={context.playerName(player1)}
                   player2Name={context.playerName(player2)}

--- a/frontend/src/pages/add-game/track-game.tsx
+++ b/frontend/src/pages/add-game/track-game.tsx
@@ -603,7 +603,7 @@ export const TrackGamePage: React.FC = () => {
                     <div key={index} className="flex items-center justify-between px-3 py-2 bg-gray-50 rounded-lg text-sm">
                       <div className="flex flex-col">
                         <span className="font-semibold text-gray-700">Set {index + 1}</span>
-                        {sideLabel && <span className="text-xs text-gray-400">🚧 {sideLabel}</span>}
+                        {sideLabel && <span className="text-xs text-gray-400">😵 {sideLabel}</span>}
                       </div>
                       <div className="flex items-center gap-3">
                         <div className="w-5">{setWinner === 1 && "🏆"}</div>
@@ -726,7 +726,7 @@ export const TrackGamePage: React.FC = () => {
                       <div key={index} className="flex items-center justify-between px-3 py-2 bg-gray-50 rounded-lg text-sm">
                         <div className="flex flex-col">
                           <span className="font-semibold text-gray-700">Set {index + 1}</span>
-                          {sideLabel && <span className="text-xs text-gray-400">🚧 {sideLabel}</span>}
+                          {sideLabel && <span className="text-xs text-gray-400">😵 {sideLabel}</span>}
                         </div>
                         <div className="flex items-center gap-3">
                           <div className="w-5">{setWinner === 1 && "🏆"}</div>

--- a/frontend/src/pages/game/game-tracking-panels.tsx
+++ b/frontend/src/pages/game/game-tracking-panels.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { GameTracking } from "../../client/client-db/event-store/event-types";
 import { clockTimeString } from "../../common/date-utils";
+import { badSideName } from "../../common/table-sides";
 import { fmtNum } from "../../common/number-utils";
 import {
   durationString,
@@ -56,8 +57,9 @@ export const TrackingStats: React.FC<{
 };
 
 /**
- * Every set of a tracked game: the score, who served the first point, how long
- * the set took, and the break before it started.
+ * Every set of a tracked game: the score, who served the first point, who had
+ * the bad side of the table, how long the set took, and the break before it
+ * started.
  */
 export const SetBreakdownTable: React.FC<{
   tracking: GameTracking;
@@ -67,6 +69,8 @@ export const SetBreakdownTable: React.FC<{
 }> = ({ tracking, pointSequences, winnerName, loserName }) => {
   const sets = setBreakdown(pointSequences, tracking);
   if (sets.length === 0) return null;
+  // Games tracked before the sides were recorded have no side column at all.
+  const hasSides = sets.some((set) => set.winnerSide !== undefined);
 
   return (
     <div className="rounded-lg bg-secondary-background text-secondary-text p-3 overflow-x-auto">
@@ -77,6 +81,7 @@ export const SetBreakdownTable: React.FC<{
             <th className="font-normal pb-1 pr-2">Set</th>
             <th className="font-normal pb-1 pr-2">Score</th>
             <th className="font-normal pb-1 pr-2 whitespace-nowrap">First serve</th>
+            {hasSides && <th className="font-normal pb-1 pr-2 whitespace-nowrap">Bad side</th>}
             <th className="font-normal pb-1 pr-2 text-right">Time</th>
             <th className="font-normal pb-1 pr-2 text-right">Break</th>
             {/* The game's longest pause is in the card above, so a narrow
@@ -94,6 +99,11 @@ export const SetBreakdownTable: React.FC<{
               <td className="py-1.5 pr-2 truncate max-w-[8rem]">
                 {set.firstServer === "W" ? winnerName : loserName}
               </td>
+              {hasSides && (
+                <td className="py-1.5 pr-2 truncate max-w-[8rem]">
+                  {set.winnerSide ? badSideName(set.winnerSide, winnerName, loserName) : "–"}
+                </td>
+              )}
               <td className="py-1.5 pr-2 text-right whitespace-nowrap">{durationString(set.durationMs)}</td>
               <td className="py-1.5 pr-2 text-right whitespace-nowrap">{gapString(set.breakBeforeMs)}</td>
               <td className="py-1.5 text-right whitespace-nowrap hidden sm:table-cell">
@@ -106,6 +116,7 @@ export const SetBreakdownTable: React.FC<{
       <p className="mt-2 text-xs opacity-70">
         The score is from the game winner's side. The break is the time before the first point of the set — for set 1,
         the time from the start of tracking.
+        {hasSides && " The bad side is the worse side of the table, and \"Equal\" means the 2 sides are equally good."}
       </p>
     </div>
   );

--- a/frontend/src/pages/game/game-tracking-stats.test.ts
+++ b/frontend/src/pages/game/game-tracking-stats.test.ts
@@ -73,6 +73,15 @@ describe("setBreakdown", () => {
     expect(setBreakdown(pointSequences, tracking()).map((set) => set.firstServer)).toEqual(["W", "L"]);
   });
 
+  it("reads the table side of each set", () => {
+    const sets = setBreakdown(pointSequences, tracking({ winnerSides: "BN" }));
+    expect(sets.map((set) => set.winnerSide)).toEqual(["B", "N"]);
+  });
+
+  it("gives no table side for a game that does not record the sides", () => {
+    expect(setBreakdown(pointSequences, tracking()).map((set) => set.winnerSide)).toEqual([undefined, undefined]);
+  });
+
   it("returns no rows for a game with no sets", () => {
     expect(setBreakdown([], tracking({ pointDeltas: [], firstServers: "" }))).toEqual([]);
   });

--- a/frontend/src/pages/game/game-tracking-stats.ts
+++ b/frontend/src/pages/game/game-tracking-stats.ts
@@ -8,6 +8,7 @@
 
 import { GameTracking } from "../../client/client-db/event-store/event-types";
 import { getServeInfo, Server } from "../../common/serve-tracker";
+import { WinnerSide, winnerSideOfSet } from "../../common/table-sides";
 
 const TENTH_MS = 100;
 
@@ -51,6 +52,11 @@ export type SetBreakdown = {
   wonByGameWinner: boolean;
   /** Who served the first point of the set. */
   firstServer: "W" | "L";
+  /**
+   * The side of the table the game winner had, or undefined when the game does
+   * not record the sides.
+   */
+  winnerSide: WinnerSide | undefined;
   /** Ms from the first point of the set to its last point. */
   durationMs: number;
   /** Ms between the last point of the previous set and the first of this one. */
@@ -74,6 +80,7 @@ export function setBreakdown(pointSequences: string[], tracking: GameTracking): 
       points: { winner: winnerPoints, loser: sequence.length - winnerPoints },
       wonByGameWinner: winnerPoints > sequence.length - winnerPoints,
       firstServer: tracking.firstServers[index] === "W" ? "W" : "L",
+      winnerSide: winnerSideOfSet(tracking.winnerSides, index),
       durationMs: gaps.reduce((sum, gap) => sum + gap, 0) * TENTH_MS,
       breakBeforeMs: (deltas[0] ?? 0) * TENTH_MS,
       longestPointGapMs: gaps.length === 0 ? 0 : Math.max(...gaps) * TENTH_MS,

--- a/frontend/src/pages/live-game/completed-sets-list.tsx
+++ b/frontend/src/pages/live-game/completed-sets-list.tsx
@@ -1,16 +1,28 @@
 import React from "react";
 import { classNames } from "../../common/class-names";
 import { ROW_SURFACE, textOn } from "../../common/player-color-styles";
+import { BadSide, badSideLabel } from "../../common/table-sides";
 import { LiveGameSetPoint } from "./live-game-types";
 
 type Props = {
   sets: LiveGameSetPoint[];
+  /** Who had the bad side of the table in each set, parallel to `sets`. */
+  badSides: BadSide[];
+  player1Name: string;
+  player2Name: string;
   /** The players' own colours (`#rrggbb`), used to mark who won each set. */
   player1Color: string;
   player2Color: string;
 };
 
-export const CompletedSetsList: React.FC<Props> = ({ sets, player1Color, player2Color }) => {
+export const CompletedSetsList: React.FC<Props> = ({
+  sets,
+  badSides,
+  player1Name,
+  player2Name,
+  player1Color,
+  player2Color,
+}) => {
   if (sets.length === 0) return null;
 
   return (
@@ -19,9 +31,13 @@ export const CompletedSetsList: React.FC<Props> = ({ sets, player1Color, player2
       <div className="space-y-2">
         {sets.map((set, index) => {
           const setWinner = set.player1 > set.player2 ? 1 : 2;
+          const sideLabel = badSideLabel(badSides[index], player1Name, player2Name);
           return (
             <div key={index} className="flex items-center justify-between px-3 py-2 bg-gray-50 rounded-lg text-sm">
-              <span className="font-semibold text-gray-700">Set {index + 1}</span>
+              <div className="flex flex-col">
+                <span className="font-semibold text-gray-700">Set {index + 1}</span>
+                {sideLabel && <span className="text-xs text-gray-400">🚧 {sideLabel}</span>}
+              </div>
               <div className="flex items-center gap-3">
                 <div className="w-5 text-right">{setWinner === 1 && "🏆"}</div>
                 <div className="w-16 flex items-center justify-between text-lg">

--- a/frontend/src/pages/live-game/completed-sets-list.tsx
+++ b/frontend/src/pages/live-game/completed-sets-list.tsx
@@ -36,7 +36,7 @@ export const CompletedSetsList: React.FC<Props> = ({
             <div key={index} className="flex items-center justify-between px-3 py-2 bg-gray-50 rounded-lg text-sm">
               <div className="flex flex-col">
                 <span className="font-semibold text-gray-700">Set {index + 1}</span>
-                {sideLabel && <span className="text-xs text-gray-400">🚧 {sideLabel}</span>}
+                {sideLabel && <span className="text-xs text-gray-400">😵 {sideLabel}</span>}
               </div>
               <div className="flex items-center gap-3">
                 <div className="w-5 text-right">{setWinner === 1 && "🏆"}</div>

--- a/frontend/src/pages/live-game/live-game-admin-page.tsx
+++ b/frontend/src/pages/live-game/live-game-admin-page.tsx
@@ -26,6 +26,8 @@ import { LiveGamePredictionCard } from "./live-game-prediction-card";
 import ConfettiExplosion from "react-confetti-explosion";
 import { Server } from "../../common/serve-tracker";
 import { ServeTrackerDisplay } from "../../common/serve-tracker-display";
+import { BadSide, badSideLabel, nextSetBadSide } from "../../common/table-sides";
+import { TableSideSelector } from "../../common/table-sides-display";
 import { appendPoint, removeLastPoint, toEventTrackingData, trackingNow } from "../../common/point-sequences";
 
 type Stage = "scoring" | "confirm";
@@ -103,6 +105,8 @@ export const LiveGameAdminPage: React.FC = () => {
       completedSetPointTimes: [],
       completedSetFirstServers: [],
       firstServer: localState!.firstServer,
+      completedSetBadSides: [],
+      badSide: localState!.badSide,
       corrections: 0,
       startedAt: trackingNow(),
       endedAt: null,
@@ -113,6 +117,10 @@ export const LiveGameAdminPage: React.FC = () => {
 
   function setFirstServer(player: Server) {
     pushState({ ...localState!, firstServer: player });
+  }
+
+  function setBadSide(badSide: BadSide) {
+    pushState({ ...localState!, badSide });
   }
 
   function addPoint(player: 1 | 2) {
@@ -163,10 +171,14 @@ export const LiveGameAdminPage: React.FC = () => {
       completedSetSequences: [...localState!.completedSetSequences, localState!.currentSetSequence],
       completedSetPointTimes: [...localState!.completedSetPointTimes, localState!.currentSetPointTimes],
       completedSetFirstServers: [...localState!.completedSetFirstServers, localState!.firstServer],
+      completedSetBadSides: [...localState!.completedSetBadSides, localState!.badSide],
       currentSetSequence: "",
       currentSetPointTimes: [],
       // Alternate who serves first in the next set, per table tennis convention.
       firstServer: localState!.firstServer === 1 ? 2 : 1,
+      // The players change sides after every set, so the bad side moves to the
+      // other player. The admin can correct it if this pair does not change.
+      badSide: nextSetBadSide(localState!.badSide),
     });
   }
 
@@ -183,6 +195,8 @@ export const LiveGameAdminPage: React.FC = () => {
       completedSetPointTimes: [],
       completedSetFirstServers: [],
       firstServer: 1,
+      completedSetBadSides: [],
+      badSide: null,
       corrections: 0,
       // The match restarts, so its timeline restarts with it.
       startedAt: trackingNow(),
@@ -243,6 +257,7 @@ export const LiveGameAdminPage: React.FC = () => {
         pointTimes: localState!.completedSetPointTimes[index] ?? [],
       })),
       firstServers: localState!.completedSetFirstServers,
+      badSides: localState!.completedSetBadSides,
       player1IsGameWinner: player1Won,
       source: "live-game",
       startedAt: localState!.startedAt,
@@ -373,6 +388,17 @@ export const LiveGameAdminPage: React.FC = () => {
                 onSelectFirstServer={setFirstServer}
               />
             </div>
+            {/* Which side of the table the players have this set */}
+            <div className="mt-1.5 tall:mt-2">
+              <TableSideSelector
+                badSide={localState.badSide}
+                player1Name={context.playerName(localState.player1Id)}
+                player2Name={context.playerName(localState.player2Id)}
+                player1Color={player1Color}
+                player2Color={player2Color}
+                onSelect={setBadSide}
+              />
+            </div>
 
             <div className="grid grid-cols-2 gap-2 tall:gap-3 mt-2 tall:mt-3">
               <PlayerScoreControls
@@ -422,6 +448,9 @@ export const LiveGameAdminPage: React.FC = () => {
 
           <CompletedSetsList
             sets={localState.completedSets}
+            badSides={localState.completedSetBadSides}
+            player1Name={context.playerName(localState.player1Id)}
+            player2Name={context.playerName(localState.player2Id)}
             player1Color={player1Color}
             player2Color={player2Color}
           />
@@ -582,9 +611,17 @@ const ConfirmView: React.FC<{
             <div className="space-y-2">
               {localState.completedSets.map((set, index) => {
                 const setWinner = set.player1 > set.player2 ? 1 : 2;
+                const sideLabel = badSideLabel(
+                  localState.completedSetBadSides[index],
+                  context.playerName(localState.player1Id),
+                  context.playerName(localState.player2Id),
+                );
                 return (
                   <div key={index} className="flex items-center justify-between px-3 py-2 bg-gray-50 rounded-lg text-sm">
-                    <span className="font-semibold text-gray-700">Set {index + 1}</span>
+                    <div className="flex flex-col">
+                      <span className="font-semibold text-gray-700">Set {index + 1}</span>
+                      {sideLabel && <span className="text-xs text-gray-400">🚧 {sideLabel}</span>}
+                    </div>
                     <div className="flex items-center gap-3">
                       <div className="w-5">{setWinner === 1 && "🏆"}</div>
                       <div className="w-16 flex items-center justify-between text-lg">

--- a/frontend/src/pages/live-game/live-game-admin-page.tsx
+++ b/frontend/src/pages/live-game/live-game-admin-page.tsx
@@ -26,7 +26,7 @@ import { LiveGamePredictionCard } from "./live-game-prediction-card";
 import ConfettiExplosion from "react-confetti-explosion";
 import { Server } from "../../common/serve-tracker";
 import { ServeTrackerDisplay } from "../../common/serve-tracker-display";
-import { BadSide, badSideLabel, nextSetBadSide } from "../../common/table-sides";
+import { alignBadSides, BadSide, badSideLabel, nextSetBadSide } from "../../common/table-sides";
 import { TableSideDisplay } from "../../common/table-sides-display";
 import { appendPoint, removeLastPoint, toEventTrackingData, trackingNow } from "../../common/point-sequences";
 
@@ -171,7 +171,12 @@ export const LiveGameAdminPage: React.FC = () => {
       completedSetSequences: [...localState!.completedSetSequences, localState!.currentSetSequence],
       completedSetPointTimes: [...localState!.completedSetPointTimes, localState!.currentSetPointTimes],
       completedSetFirstServers: [...localState!.completedSetFirstServers, localState!.firstServer],
-      completedSetBadSides: [...localState!.completedSetBadSides, localState!.badSide],
+      // The sides are padded first, because a game that was started before the
+      // sides existed has none for the sets it already played.
+      completedSetBadSides: [
+        ...alignBadSides(localState!.completedSetBadSides, localState!.completedSets.length),
+        localState!.badSide,
+      ],
       currentSetSequence: "",
       currentSetPointTimes: [],
       // Alternate who serves first in the next set, per table tennis convention.

--- a/frontend/src/pages/live-game/live-game-admin-page.tsx
+++ b/frontend/src/pages/live-game/live-game-admin-page.tsx
@@ -621,7 +621,7 @@ const ConfirmView: React.FC<{
                   <div key={index} className="flex items-center justify-between px-3 py-2 bg-gray-50 rounded-lg text-sm">
                     <div className="flex flex-col">
                       <span className="font-semibold text-gray-700">Set {index + 1}</span>
-                      {sideLabel && <span className="text-xs text-gray-400">🚧 {sideLabel}</span>}
+                      {sideLabel && <span className="text-xs text-gray-400">😵 {sideLabel}</span>}
                     </div>
                     <div className="flex items-center gap-3">
                       <div className="w-5">{setWinner === 1 && "🏆"}</div>

--- a/frontend/src/pages/live-game/live-game-admin-page.tsx
+++ b/frontend/src/pages/live-game/live-game-admin-page.tsx
@@ -27,7 +27,7 @@ import ConfettiExplosion from "react-confetti-explosion";
 import { Server } from "../../common/serve-tracker";
 import { ServeTrackerDisplay } from "../../common/serve-tracker-display";
 import { BadSide, badSideLabel, nextSetBadSide } from "../../common/table-sides";
-import { TableSideSelector } from "../../common/table-sides-display";
+import { TableSideDisplay } from "../../common/table-sides-display";
 import { appendPoint, removeLastPoint, toEventTrackingData, trackingNow } from "../../common/point-sequences";
 
 type Stage = "scoring" | "confirm";
@@ -390,7 +390,8 @@ export const LiveGameAdminPage: React.FC = () => {
             </div>
             {/* Which side of the table the players have this set */}
             <div className="mt-1.5 tall:mt-2">
-              <TableSideSelector
+              <TableSideDisplay
+                currentSet={localState.currentSet}
                 badSide={localState.badSide}
                 player1Name={context.playerName(localState.player1Id)}
                 player2Name={context.playerName(localState.player2Id)}

--- a/frontend/src/pages/live-game/live-game-page.tsx
+++ b/frontend/src/pages/live-game/live-game-page.tsx
@@ -11,6 +11,7 @@ import { LiveGamePredictionCard } from "./live-game-prediction-card";
 import { LiveGameSetPoint } from "./live-game-types";
 import { Server } from "../../common/serve-tracker";
 import { ServeTrackerDisplay } from "../../common/serve-tracker-display";
+import { BadSide } from "../../common/table-sides";
 
 // Fallback poll in case the WebSocket drops — primary updates come from
 // the LIVE_GAME broadcast handled in WebSocketRefetcher. The poll also runs
@@ -70,6 +71,7 @@ export const LiveGamePage: React.FC = () => {
           setsWon={state.setsWon}
           currentSet={state.currentSet}
           completedSets={state.completedSets}
+          badSides={state.completedSetBadSides ?? []}
           firstServer={state.firstServer ?? 1}
           player1Name={context.playerName(state.player1Id)}
           player2Name={context.playerName(state.player2Id)}
@@ -82,6 +84,7 @@ export const LiveGamePage: React.FC = () => {
           player2Id={state.player2Id!}
           setsWon={state.setsWon}
           completedSets={state.completedSets}
+          badSides={state.completedSetBadSides ?? []}
           player1Name={context.playerName(state.player1Id)}
           player2Name={context.playerName(state.player2Id)}
         />
@@ -96,6 +99,8 @@ type ScoreboardProps = {
   setsWon: { player1: number; player2: number };
   currentSet: LiveGameSetPoint;
   completedSets: LiveGameSetPoint[];
+  /** Who had the bad side of the table in each completed set. */
+  badSides: BadSide[];
   firstServer: Server;
   player1Name: string;
   player2Name: string;
@@ -107,6 +112,7 @@ const LiveScoreboard: React.FC<ScoreboardProps> = ({
   setsWon,
   currentSet,
   completedSets,
+  badSides,
   firstServer,
   player1Name,
   player2Name,
@@ -187,7 +193,14 @@ const LiveScoreboard: React.FC<ScoreboardProps> = ({
         completedSets={completedSets}
       />
 
-      <CompletedSetsList sets={completedSets} player1Color={player1Color} player2Color={player2Color} />
+      <CompletedSetsList
+        sets={completedSets}
+        badSides={badSides}
+        player1Name={player1Name}
+        player2Name={player2Name}
+        player1Color={player1Color}
+        player2Color={player2Color}
+      />
     </div>
   );
 };
@@ -197,6 +210,8 @@ type FinishedScoreboardProps = {
   player2Id: string;
   setsWon: { player1: number; player2: number };
   completedSets: LiveGameSetPoint[];
+  /** Who had the bad side of the table in each completed set. */
+  badSides: BadSide[];
   player1Name: string;
   player2Name: string;
 };
@@ -206,6 +221,7 @@ const FinishedScoreboard: React.FC<FinishedScoreboardProps> = ({
   player2Id,
   setsWon,
   completedSets,
+  badSides,
   player1Name,
   player2Name,
 }) => {
@@ -258,7 +274,14 @@ const FinishedScoreboard: React.FC<FinishedScoreboardProps> = ({
         </div>
       </div>
 
-      <CompletedSetsList sets={completedSets} player1Color={player1Color} player2Color={player2Color} />
+      <CompletedSetsList
+        sets={completedSets}
+        badSides={badSides}
+        player1Name={player1Name}
+        player2Name={player2Name}
+        player1Color={player1Color}
+        player2Color={player2Color}
+      />
     </div>
   );
 };

--- a/frontend/src/pages/live-game/live-game-types.ts
+++ b/frontend/src/pages/live-game/live-game-types.ts
@@ -1,3 +1,5 @@
+import { BadSide } from "../../common/table-sides";
+
 export type LiveGameSetPoint = {
   player1: number;
   player2: number;
@@ -27,6 +29,13 @@ export type LiveGameState = {
   completedSetFirstServers: (1 | 2)[];
   /** Which player (1 or 2) served the first point of the current set. */
   firstServer: 1 | 2;
+  /** Who had the bad side of the table in each completed set. */
+  completedSetBadSides: BadSide[];
+  /**
+   * Who has the bad side of the table in the current set. Null until somebody
+   * records it, because the sides are not known for every game.
+   */
+  badSide: BadSide;
   /** How many points were undone while tracking this match. */
   corrections: number;
   startedAt: number | null;
@@ -48,6 +57,8 @@ export const emptyLiveGame: LiveGameState = {
   completedSetPointTimes: [],
   completedSetFirstServers: [],
   firstServer: 1,
+  completedSetBadSides: [],
+  badSide: null,
   corrections: 0,
   startedAt: null,
   endedAt: null,


### PR DESCRIPTION
The game tracker and the live game admin page get a selector for the
player who has the bad side of the table: player 1, player 2, or "Equal"
when the two sides are equally good. It sits under the serve tracker and
stays available for the whole set, and a second press on the selected
option removes the record again. After a set the bad side moves to the
other player, since the players usually change sides, and the operator
can correct it for a pair that does not.

A GAME_SCORE event stores the sides in the tracking data as one char per
set from the game winner's perspective: "G" good, "B" bad, "N" neutral.
The field is optional and is only written when every set has a recorded
side, so an older game keeps the rest of its tracking data and a partly
recorded game does not claim sides it does not know.

The game details page shows a Bad side column in the set by set table,
and the completed set lists of both trackers name the side per set.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UmT1HAJG9uGdRFzTfsQMb4