### PR TITLE
Add bad side of the table statistics to the statistics page

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -61,6 +61,9 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
       text(
         "The set by set table on the game details page has a new Bad side column. A game tracked before this change does not show the column.",
       ),
+      text(
+        "The statistics page shows what the bad side costs. The Games tab has a card with the share of the sets and the points that the player on the bad side wins, over all games that record the sides.",
+      ),
     ],
   },
   {

--- a/frontend/src/pages/statistics/games-tab.tsx
+++ b/frontend/src/pages/statistics/games-tab.tsx
@@ -23,6 +23,7 @@ import {
   leaguePace,
   pointLevelStats,
   setLevelStats,
+  tableSideStats,
   trackedLevelStats,
   TrackedLevelStats,
 } from "./statistics-aggregations";
@@ -112,6 +113,7 @@ export const GamesTab: React.FC<{ range: TimeRange; setRange: (range: TimeRange)
   const setLevel = useMemo(() => setLevelStats(gamesInRange), [gamesInRange]);
   const pointLevel = useMemo(() => pointLevelStats(gamesInRange), [gamesInRange]);
   const trackedLevel = useMemo(() => trackedLevelStats(gamesInRange), [gamesInRange]);
+  const tableSides = useMemo(() => tableSideStats(gamesInRange), [gamesInRange]);
 
   return (
     <div className="flex flex-col gap-4">
@@ -386,6 +388,56 @@ export const GamesTab: React.FC<{ range: TimeRange; setRange: (range: TimeRange)
                   note="points undone while tracking, on average"
                 />
               </StatTileRow>
+            )}
+          </ContentCard>
+
+          <ContentCard
+            title="The bad side of the table"
+            description="A tracked game can record which player had the bad side of the table in each set, or that the 2 sides were equal. Every set with a worse side has one player on it, so 50% means the side costs nothing."
+          >
+            {tableSides === undefined ? (
+              <NotEnoughGames what="tracked games with sides" />
+            ) : (
+              <div className="flex flex-col gap-3">
+                {tableSides.setsWonOnTheBadSide !== undefined && (
+                  <StackedShareBar
+                    segments={[
+                      {
+                        label: "The bad side wins the set",
+                        share: tableSides.setsWonOnTheBadSide,
+                        color: SPREAD_COLORS[0],
+                      },
+                      {
+                        label: "The good side wins the set",
+                        share: 100 - tableSides.setsWonOnTheBadSide,
+                        color: SPREAD_COLORS[1],
+                      },
+                    ]}
+                  />
+                )}
+                <StatTileRow>
+                  <StatTile
+                    label="Points won on the bad side"
+                    value={tableSides.pointsWonOnTheBadSide === undefined ? "–" : percentLabel(tableSides.pointsWonOnTheBadSide)}
+                    note="of the points of the sets with a worse side"
+                  />
+                  <StatTile
+                    label="More sets on the bad side, and the game"
+                    value={tableSides.wonWithMoreBadSideSets === undefined ? "–" : percentLabel(tableSides.wonWithMoreBadSideSets)}
+                    note="of the games where one player had the bad side more often, that player won"
+                  />
+                  <StatTile
+                    label="Sets with equal sides"
+                    value={percentLabel(tableSides.neutralSets)}
+                    note="of the sets with recorded sides"
+                  />
+                  <StatTile
+                    label="Games that record the sides"
+                    value={percentLabel(tableSides.sidesRecorded)}
+                    note="of the tracked games in this period"
+                  />
+                </StatTileRow>
+              </div>
             )}
           </ContentCard>
         </DetailLevelSection>

--- a/frontend/src/pages/statistics/statistics-aggregations.test.ts
+++ b/frontend/src/pages/statistics/statistics-aggregations.test.ts
@@ -19,6 +19,7 @@ import {
   pointLevelStats,
   ratingGapDistribution,
   setLevelStats,
+  tableSideStats,
   timeOfDayShares,
   trackedLevelStats,
   upsetRate,
@@ -785,6 +786,107 @@ describe("trackedLevelStats", () => {
     const stats = trackedLevelStats(played)!;
 
     expect(stats.deucePaceRatio).toBeCloseTo(3);
+  });
+});
+
+describe("tableSideStats", () => {
+  /** A tracked game with a recorded side per set, or none when sides is undefined. */
+  function sidedGame(pointSequences: string[], winnerSides?: string): Game {
+    const setPoints = pointSequences.map((sequence) => {
+      const winner = sequence.split("").filter((point) => point === "W").length;
+      return { gameWinner: winner, gameLoser: sequence.length - winner };
+    });
+    const setsWon = setPoints.reduce(
+      (sets, set) =>
+        set.gameWinner > set.gameLoser
+          ? { gameWinner: sets.gameWinner + 1, gameLoser: sets.gameLoser }
+          : { gameWinner: sets.gameWinner, gameLoser: sets.gameLoser + 1 },
+      { gameWinner: 0, gameLoser: 0 },
+    );
+    return game({
+      score: {
+        setsWon,
+        setPoints,
+        pointSequences,
+        tracking: {
+          version: 1,
+          source: "track-game",
+          startedAt: 1,
+          pointDeltas: pointSequences.map((sequence) => new Array(sequence.length).fill(100)),
+          endedAfter: 10,
+          firstServers: "W".repeat(pointSequences.length),
+          winnerSides,
+          corrections: 0,
+        },
+      },
+    });
+  }
+
+  /** 11-2 to the game winner. */
+  const SET_TO_THE_WINNER = "WWWWWWWWWWWLL";
+  /** 11-2 to the game loser. */
+  const SET_TO_THE_LOSER = "LLLLLLLLLLLWW";
+
+  it("stays silent when no tracked game records the sides", () => {
+    expect(tableSideStats([...games(10), sidedGame([SET_TO_THE_WINNER])])).toBeUndefined();
+  });
+
+  it("gives the sets and the points the player on the bad side won", () => {
+    // Set 1: the game winner is on the bad side and takes 11 of 13 points.
+    // Set 2: the game loser is on the bad side and takes 11 of 13 points.
+    // The bad side wins both sets, with 22 of the 26 points.
+    const played = [sidedGame([SET_TO_THE_WINNER, SET_TO_THE_LOSER], "BG")];
+
+    const stats = tableSideStats(played)!;
+
+    expect(stats.setsWonOnTheBadSide).toBe(100);
+    expect(stats.pointsWonOnTheBadSide).toBeCloseTo((22 / 26) * 100);
+  });
+
+  it("counts a neutral set apart, and not as a set with a bad side", () => {
+    const played = [sidedGame([SET_TO_THE_WINNER, SET_TO_THE_LOSER], "NB")];
+
+    const stats = tableSideStats(played)!;
+
+    expect(stats.neutralSets).toBe(50);
+    // Only set 2 has a bad side. The game winner is on it and loses the set.
+    expect(stats.setsWonOnTheBadSide).toBe(0);
+    expect(stats.pointsWonOnTheBadSide).toBeCloseTo((2 / 13) * 100);
+  });
+
+  it("holds every share back when every recorded set is neutral", () => {
+    const stats = tableSideStats([sidedGame([SET_TO_THE_WINNER], "N")])!;
+
+    expect(stats.neutralSets).toBe(100);
+    expect(stats.setsWonOnTheBadSide).toBeUndefined();
+    expect(stats.pointsWonOnTheBadSide).toBeUndefined();
+    expect(stats.wonWithMoreBadSideSets).toBeUndefined();
+  });
+
+  it("finds the games won with more sets on the bad side than the opponent", () => {
+    // The game winner has the bad side in 2 of the 3 sets and wins the game.
+    const uneven = sidedGame([SET_TO_THE_WINNER, SET_TO_THE_LOSER, SET_TO_THE_WINNER], "BGB");
+    // Both players have the bad side once, so the game has no player with more.
+    const even = sidedGame([SET_TO_THE_WINNER, SET_TO_THE_WINNER], "BG");
+
+    expect(tableSideStats([uneven])!.wonWithMoreBadSideSets).toBe(100);
+    expect(tableSideStats([even])!.wonWithMoreBadSideSets).toBeUndefined();
+  });
+
+  it("measures the coverage over the tracked games only", () => {
+    const played = [
+      sidedGame([SET_TO_THE_WINNER], "B"),
+      sidedGame([SET_TO_THE_WINNER]),
+      ...games(10),
+    ];
+
+    expect(tableSideStats(played)!.sidesRecorded).toBe(50);
+  });
+
+  it("reports shares and never a count", () => {
+    const stats = tableSideStats([sidedGame([SET_TO_THE_WINNER], "B")])!;
+
+    expect(Object.values(stats).every((value) => value === undefined || (value >= 0 && value <= 100))).toBe(true);
   });
 });
 

--- a/frontend/src/pages/statistics/statistics-aggregations.ts
+++ b/frontend/src/pages/statistics/statistics-aggregations.ts
@@ -43,6 +43,7 @@ import { Game } from "../../client/client-db/event-store/projectors/games-projec
 import { Player } from "../../client/client-db/event-store/projectors/players-projector";
 import { EventType, EventTypeEnum } from "../../client/client-db/event-store/event-types";
 import { advancePeriod, getPeriodKey, getPeriodStart, getPeriodTimestamp, Period } from "../../common/period-utils";
+import { winnerSideOfSet } from "../../common/table-sides";
 import { gameTimingStats, longestStreaks, serveStats } from "../game/game-tracking-stats";
 
 /** A rating gap bucket with fewer games than this is not plotted. */
@@ -891,6 +892,91 @@ export function trackedLevelStats(games: Game[]): TrackedLevelStats | undefined 
     setPointForTheSetLoser: setsClosed === 0 ? undefined : percent(setsLoserHeldSetPoint, setsClosed),
   };
 }
+export type TableSideStats = {
+  /** Share of the tracked games of the period that record the sides. */
+  sidesRecorded: number;
+  /** Share of the recorded sets where the 2 sides are equally good. */
+  neutralSets: number;
+  /** Share of the sets with a worse side won by the player on it. */
+  setsWonOnTheBadSide?: number;
+  /** Share of the points of those sets won by the player on the bad side. */
+  pointsWonOnTheBadSide?: number;
+  /**
+   * Share of the games won by the player who had the bad side in more sets
+   * than their opponent. A game where both players had it equally often, which
+   * every game with an even number of unequal sets is, has no such player and
+   * is left out.
+   */
+  wonWithMoreBadSideSets?: number;
+};
+
+/**
+ * What playing on the bad side of the table costs.
+ *
+ * A tracked game can record which player had the bad side in each set, or that
+ * the 2 sides were equally good. Every set with a worse side has exactly one
+ * player on it, so 50% is the neutral reading of the set and point shares: a
+ * lower share means the bad side really costs sets or points.
+ *
+ * A neutral set holds no bad side, so it only counts towards `neutralSets`.
+ */
+export function tableSideStats(games: Game[]): TableSideStats | undefined {
+  const tracked = games.filter(isTrackedGame);
+  const withSides = tracked.filter((game) => game.score?.tracking?.winnerSides !== undefined);
+  if (withSides.length === 0) return undefined;
+
+  let recordedSets = 0;
+  let neutralSets = 0;
+  let unequalSets = 0;
+  let setsToTheBadSide = 0;
+  let unequalPoints = 0;
+  let pointsToTheBadSide = 0;
+  let unevenGames = 0;
+  let unevenGamesToTheBadSide = 0;
+
+  for (const game of withSides) {
+    const score = game.score!;
+    const sides = score.tracking!.winnerSides;
+    const badSideSets = { winner: 0, loser: 0 };
+
+    for (let setIndex = 0; setIndex < score.pointSequences!.length; setIndex++) {
+      const sequence = score.pointSequences![setIndex];
+      const side = winnerSideOfSet(sides, setIndex);
+      if (side === undefined || sequence.length === 0) continue;
+
+      recordedSets++;
+      if (side === "N") {
+        neutralSets++;
+        continue;
+      }
+
+      const gameWinnerOnTheBadSide = side === "B";
+      const winnerPoints = sequence.split("").filter((point) => point === "W").length;
+      const loserPoints = sequence.length - winnerPoints;
+
+      unequalSets++;
+      unequalPoints += sequence.length;
+      pointsToTheBadSide += gameWinnerOnTheBadSide ? winnerPoints : loserPoints;
+      if ((winnerPoints > loserPoints) === gameWinnerOnTheBadSide) setsToTheBadSide++;
+      if (gameWinnerOnTheBadSide) badSideSets.winner++;
+      else badSideSets.loser++;
+    }
+
+    if (badSideSets.winner !== badSideSets.loser) {
+      unevenGames++;
+      if (badSideSets.winner > badSideSets.loser) unevenGamesToTheBadSide++;
+    }
+  }
+
+  return {
+    sidesRecorded: percent(withSides.length, tracked.length),
+    neutralSets: percent(neutralSets, recordedSets),
+    setsWonOnTheBadSide: unequalSets === 0 ? undefined : percent(setsToTheBadSide, unequalSets),
+    pointsWonOnTheBadSide: unequalPoints === 0 ? undefined : percent(pointsToTheBadSide, unequalPoints),
+    wonWithMoreBadSideSets: unevenGames === 0 ? undefined : percent(unevenGamesToTheBadSide, unevenGames),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Matchups: who plays whom, and who wins
 // ---------------------------------------------------------------------------

--- a/frontend/src/pages/statistics/statistics-page.test.tsx
+++ b/frontend/src/pages/statistics/statistics-page.test.tsx
@@ -72,6 +72,8 @@ function buildEvents(gameCount = 120): EventType[] {
                   pointDeltas: [new Array(15).fill(80)],
                   endedAfter: 20,
                   firstServers: "W",
+                  // Half of the tracked games record the side of the table.
+                  winnerSides: index % 8 === 0 ? "B" : undefined,
                   corrections: 0,
                 },
               }
@@ -145,6 +147,7 @@ describe("StatisticsPage", () => {
     expect(screen.getByText("Median points in a set")).toBeInTheDocument();
     expect(screen.getByText("Median game length")).toBeInTheDocument();
     expect(screen.getByText("To close a set")).toBeInTheDocument();
+    expect(screen.getByText("Points won on the bad side")).toBeInTheDocument();
     expect(screen.queryByText(/Not enough/)).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
The Games tab's tracked level gets a card built from the recorded table
sides: the share of the sets and of the points won by the player on the
bad side, the share of games won by the player who had the bad side in
more sets, the share of neutral sets, and how many tracked games record
the sides at all. Everything is a share, per the privacy rule of the
aggregations file.

The extension lands in the table-sides changelog post, which shipped
the same day.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014yCboW9XGuDdueHsKwP6Du