### PR TITLE
Record the side of the table on games added by hand

### DIFF
--- a/DenoServer/event-store/event-types.ts
+++ b/DenoServer/event-store/event-types.ts
@@ -67,16 +67,14 @@ export type GameScore = GenericEvent<
   EventTypeEnum.GAME_SCORE,
   {
     setsWon: { gameWinner: number; gameLoser: number };
-    setPoints?: {
-      gameWinner: number;
-      gameLoser: number;
-      /**
-       * Which side of the table the game winner had in this set: "G" = the
-       * good side, "B" = the bad side, "N" = the 2 sides are equally good.
-       * Left out when nobody recorded the side of this set.
-       */
-      gameWinnerSide?: "G" | "B" | "N";
-    }[];
+    setPoints?: { gameWinner: number; gameLoser: number }[];
+    /**
+     * Which side of the table the game winner had in each set, one entry per
+     * set in the order the sets were played: "G" = the good side, "B" = the
+     * bad side, "N" = the 2 sides are equally good, null = not recorded.
+     * Independent of `setPoints`. Left out when no set has a recorded side.
+     */
+    gameWinnerSides?: ("G" | "B" | "N" | null)[];
     /**
      * Point-by-point log, one string per set in the order the sets were played.
      * Each char is one point in the order it was scored: "W" = point to the game

--- a/DenoServer/event-store/event-types.ts
+++ b/DenoServer/event-store/event-types.ts
@@ -59,12 +59,6 @@ export type GameTracking = {
   endedAfter: number;
   /** Who served the first point of each set: "W" = game winner, "L" = game loser. */
   firstServers: string;
-  /**
-   * The old location of the table sides, one char per set: "G", "B" or "N"
-   * from the game winner's perspective. New events store the side of each set
-   * on its `setPoints` entry as `gameWinnerSide` instead.
-   */
-  winnerSides?: string;
   /** How many points were undone while tracking. */
   corrections: number;
 };

--- a/DenoServer/event-store/event-types.ts
+++ b/DenoServer/event-store/event-types.ts
@@ -60,9 +60,9 @@ export type GameTracking = {
   /** Who served the first point of each set: "W" = game winner, "L" = game loser. */
   firstServers: string;
   /**
-   * Which side of the table the game winner had in each set: "G" = the good
-   * side, "B" = the bad side, "N" = the 2 sides are equally good. Left out when
-   * the sides were not recorded.
+   * The old location of the table sides, one char per set: "G", "B" or "N"
+   * from the game winner's perspective. New events store the side of each set
+   * on its `setPoints` entry as `gameWinnerSide` instead.
    */
   winnerSides?: string;
   /** How many points were undone while tracking. */
@@ -73,7 +73,16 @@ export type GameScore = GenericEvent<
   EventTypeEnum.GAME_SCORE,
   {
     setsWon: { gameWinner: number; gameLoser: number };
-    setPoints?: { gameWinner: number; gameLoser: number }[];
+    setPoints?: {
+      gameWinner: number;
+      gameLoser: number;
+      /**
+       * Which side of the table the game winner had in this set: "G" = the
+       * good side, "B" = the bad side, "N" = the 2 sides are equally good.
+       * Left out when nobody recorded the side of this set.
+       */
+      gameWinnerSide?: "G" | "B" | "N";
+    }[];
     /**
      * Point-by-point log, one string per set in the order the sets were played.
      * Each char is one point in the order it was scored: "W" = point to the game

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -43,11 +43,11 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
     slug: "table-sides-on-tracked-games",
-    title: "Tracked games record the side of the table",
+    title: "Games record the side of the table",
     date: "2026-08-20",
     tags: ["feature-update", "technical"],
     summary:
-      "A tracked game records the player who has the bad side of the table in each set. The game details page shows the side of every set.",
+      "A game records the player who has the bad side of the table in each set. The trackers record it live, and the add game form takes it with the set points.",
     body: [
       text(
         "The game tracker and the live game admin page have a selector below the serve tracker. It gives 3 options: the first player has the bad side, the 2 sides are equally good, or the second player has the bad side.",
@@ -56,13 +56,13 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
         "The side locks with the first point of the set, the same as the first server. After each set the tracker moves the bad side to the other player, because the players usually change sides. Correct it at 0-0 when the players keep the same side.",
       ),
       text(
-        'The `GAME_SCORE` event stores one char per set, from the side of the game winner: "G" for the good side, "B" for the bad side and "N" for 2 equal sides. A game stores the sides only when every set has one.',
+        "The add game form has the same selector below the points of each set. Select the side for the sets you remember, and leave the other sets empty. The sides need the individual set points.",
       ),
       text(
-        "The set by set table on the game details page has a new Bad side column. A game tracked before this change does not show the column.",
+        'The `GAME_SCORE` event stores the side of each set on its `setPoints` entry, as `gameWinnerSide`: "G" for the good side, "B" for the bad side and "N" for 2 equal sides. A set without a recorded side stores nothing.',
       ),
       text(
-        "The statistics page shows what the bad side costs. The Games tab has a card with the share of the sets and the points that the player on the bad side wins, over all games that record the sides.",
+        "The game details page shows the side of every set, also for a game without tracking data. The statistics page shows what the bad side costs: the Games tab has a card with the share of the sets and the points that the player on the bad side wins, over all games that record the sides.",
       ),
     ],
   },

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -56,7 +56,7 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
         "The side locks with the first point of the set, the same as the first server. After each set the tracker moves the bad side to the other player, because the players usually change sides. Correct it at 0-0 when the players keep the same side.",
       ),
       text(
-        "The add game form has the same selector below the points of each set. Select the side for the sets you remember, and leave the other sets empty. The sides do not need the set points — the sets won are enough.",
+        "The add game form and the edit score page have the same selector below the points of each set. Select the side for the sets you remember, and leave the other sets empty. The sides do not need the set points — the sets won are enough. An edit that changes only the sides keeps the point log of a tracked game.",
       ),
       text(
         'The `GAME_SCORE` event stores one side per set in `gameWinnerSides`, from the side of the game winner: "G" for the good side, "B" for the bad side, "N" for 2 equal sides and null for a set nobody recorded. The list is independent of the set points.',

--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -56,10 +56,10 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
         "The side locks with the first point of the set, the same as the first server. After each set the tracker moves the bad side to the other player, because the players usually change sides. Correct it at 0-0 when the players keep the same side.",
       ),
       text(
-        "The add game form has the same selector below the points of each set. Select the side for the sets you remember, and leave the other sets empty. The sides need the individual set points.",
+        "The add game form has the same selector below the points of each set. Select the side for the sets you remember, and leave the other sets empty. The sides do not need the set points — the sets won are enough.",
       ),
       text(
-        'The `GAME_SCORE` event stores the side of each set on its `setPoints` entry, as `gameWinnerSide`: "G" for the good side, "B" for the bad side and "N" for 2 equal sides. A set without a recorded side stores nothing.',
+        'The `GAME_SCORE` event stores one side per set in `gameWinnerSides`, from the side of the game winner: "G" for the good side, "B" for the bad side, "N" for 2 equal sides and null for a set nobody recorded. The list is independent of the set points.',
       ),
       text(
         "The game details page shows the side of every set, also for a game without tracking data. The statistics page shows what the bad side costs: the Games tab has a card with the share of the sets and the points that the player on the bad side wins, over all games that record the sides.",

--- a/frontend/src/client/client-db/__tests__/event-store/games-projector.test.ts
+++ b/frontend/src/client/client-db/__tests__/event-store/games-projector.test.ts
@@ -96,28 +96,6 @@ describe("GamesProjector projection", () => {
     expect(projector.getGameById("game-1")!.score).toEqual(score);
   });
 
-  it("moves the table sides of an old event onto its setPoints entries", () => {
-    const projector = new GamesProjector();
-    projector.createGame(createEvent("game-1", 1000, "player-1", "player-2"));
-    projector.setScore(
-      scoreEvent("game-1", {
-        setsWon: { gameWinner: 2, gameLoser: 1 },
-        setPoints: [
-          { gameWinner: 11, gameLoser: 5 },
-          { gameWinner: 9, gameLoser: 11 },
-          { gameWinner: 11, gameLoser: 7 },
-        ],
-        pointSequences: ["W", "L", "W"],
-        tracking: tracking(["W", "L", "W"], { winnerSides: "GNB" }),
-      }),
-    );
-
-    expect(projector.getGameById("game-1")!.score!.setPoints).toEqual([
-      { gameWinner: 11, gameLoser: 5, gameWinnerSide: "G" },
-      { gameWinner: 9, gameLoser: 11, gameWinnerSide: "N" },
-      { gameWinner: 11, gameLoser: 7, gameWinnerSide: "B" },
-    ]);
-  });
 });
 
 describe("validateCreateGame", () => {
@@ -463,31 +441,6 @@ describe("validateScoreGame", () => {
     const result = projector.validateScoreGame(trackedScoreEvent({ firstServers: "1" }));
     expectInvalid(result);
     expect(result.message).toBe("Tracking data is invalid. Only 'W' and 'L' first servers are allowed");
-  });
-
-  it("accepts tracking data without table sides", () => {
-    expect(projector.validateScoreGame(trackedScoreEvent({ winnerSides: undefined })).valid).toBe(true);
-  });
-
-  it("accepts a table side for every set", () => {
-    for (const winnerSides of ["G", "B", "N"]) {
-      expect(projector.validateScoreGame(trackedScoreEvent({ winnerSides })).valid).toBe(true);
-    }
-  });
-
-  it("rejects a table side list that does not cover every set", () => {
-    const result = projector.validateScoreGame(trackedScoreEvent({ winnerSides: "GB" }));
-    expectInvalid(result);
-    expect(result.message).toBe("Tracking data is invalid. There must be one table side per set");
-    const empty = projector.validateScoreGame(trackedScoreEvent({ winnerSides: "" }));
-    expectInvalid(empty);
-    expect(empty.message).toBe("Tracking data is invalid. There must be one table side per set");
-  });
-
-  it("rejects a table side that is not G, B or N", () => {
-    const result = projector.validateScoreGame(trackedScoreEvent({ winnerSides: "W" }));
-    expectInvalid(result);
-    expect(result.message).toBe("Tracking data is invalid. Only 'G', 'B' and 'N' table sides are allowed");
   });
 
   it("rejects a negative end delta and a negative correction count", () => {

--- a/frontend/src/client/client-db/__tests__/event-store/games-projector.test.ts
+++ b/frontend/src/client/client-db/__tests__/event-store/games-projector.test.ts
@@ -81,21 +81,17 @@ describe("GamesProjector projection", () => {
     expect(projector.getGameById("game-2")).toBeUndefined();
   });
 
-  it("keeps the table sides of a new event on its setPoints entries", () => {
+  it("keeps the table sides of a score as they are stored", () => {
     const projector = new GamesProjector();
     projector.createGame(createEvent("game-1", 1000, "player-1", "player-2"));
     const score: GameScore["data"] = {
       setsWon: { gameWinner: 2, gameLoser: 0 },
-      setPoints: [
-        { gameWinner: 11, gameLoser: 5, gameWinnerSide: "B" },
-        { gameWinner: 11, gameLoser: 7 },
-      ],
+      gameWinnerSides: ["B", null],
     };
 
     projector.setScore(scoreEvent("game-1", score));
     expect(projector.getGameById("game-1")!.score).toEqual(score);
   });
-
 });
 
 describe("validateCreateGame", () => {
@@ -213,28 +209,61 @@ describe("validateScoreGame", () => {
     expect(result.message).toBe("Points are invalid. No sets can be tied");
   });
 
-  it("accepts a table side on a setPoints entry, and a set without one", () => {
+  it("accepts table sides without set points, with a null for a set nobody recorded", () => {
     const result = projector.validateScoreGame(
       scoreEvent("game-1", {
-        setsWon: { gameWinner: 2, gameLoser: 0 },
-        setPoints: [
-          { gameWinner: 11, gameLoser: 5, gameWinnerSide: "B" },
-          { gameWinner: 11, gameLoser: 7 },
-        ],
+        setsWon: { gameWinner: 2, gameLoser: 1 },
+        gameWinnerSides: ["B", null, "G"],
       }),
     );
     expect(result).toEqual({ valid: true });
   });
 
-  it("rejects a setPoints table side that is not G, B or N", () => {
+  it("accepts table sides together with set points", () => {
     const result = projector.validateScoreGame(
       scoreEvent("game-1", {
-        setsWon: { gameWinner: 1, gameLoser: 0 },
-        setPoints: [{ gameWinner: 11, gameLoser: 5, gameWinnerSide: "W" as "G" }],
+        setsWon: { gameWinner: 2, gameLoser: 0 },
+        setPoints: [
+          { gameWinner: 11, gameLoser: 5 },
+          { gameWinner: 11, gameLoser: 7 },
+        ],
+        gameWinnerSides: ["B", "N"],
+      }),
+    );
+    expect(result).toEqual({ valid: true });
+  });
+
+  it("rejects a table side list that does not cover every set", () => {
+    const result = projector.validateScoreGame(
+      scoreEvent("game-1", {
+        setsWon: { gameWinner: 2, gameLoser: 1 },
+        gameWinnerSides: ["B", "G"],
       }),
     );
     expectInvalid(result);
-    expect(result.message).toBe("Table sides are invalid. Only 'G', 'B' and 'N' sides are allowed");
+    expect(result.message).toBe("Table sides are invalid. There must be one side per set");
+  });
+
+  it("rejects a table side that is not G, B, N or null", () => {
+    const result = projector.validateScoreGame(
+      scoreEvent("game-1", {
+        setsWon: { gameWinner: 1, gameLoser: 0 },
+        gameWinnerSides: ["W" as "G"],
+      }),
+    );
+    expectInvalid(result);
+    expect(result.message).toBe("Table sides are invalid. Only 'G', 'B', 'N' and null sides are allowed");
+  });
+
+  it("rejects a table side list where no set has a side", () => {
+    const result = projector.validateScoreGame(
+      scoreEvent("game-1", {
+        setsWon: { gameWinner: 1, gameLoser: 0 },
+        gameWinnerSides: [null],
+      }),
+    );
+    expectInvalid(result);
+    expect(result.message).toBe("If no sides are recorded, the gameWinnerSides should not be included in the event data");
   });
 
   it("rejects set points where the loser wins as many sets as the winner", () => {

--- a/frontend/src/client/client-db/__tests__/event-store/games-projector.test.ts
+++ b/frontend/src/client/client-db/__tests__/event-store/games-projector.test.ts
@@ -80,6 +80,44 @@ describe("GamesProjector projection", () => {
     projector.setScore(scoreEvent("game-2", score));
     expect(projector.getGameById("game-2")).toBeUndefined();
   });
+
+  it("keeps the table sides of a new event on its setPoints entries", () => {
+    const projector = new GamesProjector();
+    projector.createGame(createEvent("game-1", 1000, "player-1", "player-2"));
+    const score: GameScore["data"] = {
+      setsWon: { gameWinner: 2, gameLoser: 0 },
+      setPoints: [
+        { gameWinner: 11, gameLoser: 5, gameWinnerSide: "B" },
+        { gameWinner: 11, gameLoser: 7 },
+      ],
+    };
+
+    projector.setScore(scoreEvent("game-1", score));
+    expect(projector.getGameById("game-1")!.score).toEqual(score);
+  });
+
+  it("moves the table sides of an old event onto its setPoints entries", () => {
+    const projector = new GamesProjector();
+    projector.createGame(createEvent("game-1", 1000, "player-1", "player-2"));
+    projector.setScore(
+      scoreEvent("game-1", {
+        setsWon: { gameWinner: 2, gameLoser: 1 },
+        setPoints: [
+          { gameWinner: 11, gameLoser: 5 },
+          { gameWinner: 9, gameLoser: 11 },
+          { gameWinner: 11, gameLoser: 7 },
+        ],
+        pointSequences: ["W", "L", "W"],
+        tracking: tracking(["W", "L", "W"], { winnerSides: "GNB" }),
+      }),
+    );
+
+    expect(projector.getGameById("game-1")!.score!.setPoints).toEqual([
+      { gameWinner: 11, gameLoser: 5, gameWinnerSide: "G" },
+      { gameWinner: 9, gameLoser: 11, gameWinnerSide: "N" },
+      { gameWinner: 11, gameLoser: 7, gameWinnerSide: "B" },
+    ]);
+  });
 });
 
 describe("validateCreateGame", () => {
@@ -195,6 +233,30 @@ describe("validateScoreGame", () => {
     );
     expectInvalid(result);
     expect(result.message).toBe("Points are invalid. No sets can be tied");
+  });
+
+  it("accepts a table side on a setPoints entry, and a set without one", () => {
+    const result = projector.validateScoreGame(
+      scoreEvent("game-1", {
+        setsWon: { gameWinner: 2, gameLoser: 0 },
+        setPoints: [
+          { gameWinner: 11, gameLoser: 5, gameWinnerSide: "B" },
+          { gameWinner: 11, gameLoser: 7 },
+        ],
+      }),
+    );
+    expect(result).toEqual({ valid: true });
+  });
+
+  it("rejects a setPoints table side that is not G, B or N", () => {
+    const result = projector.validateScoreGame(
+      scoreEvent("game-1", {
+        setsWon: { gameWinner: 1, gameLoser: 0 },
+        setPoints: [{ gameWinner: 11, gameLoser: 5, gameWinnerSide: "W" as "G" }],
+      }),
+    );
+    expectInvalid(result);
+    expect(result.message).toBe("Table sides are invalid. Only 'G', 'B' and 'N' sides are allowed");
   });
 
   it("rejects set points where the loser wins as many sets as the winner", () => {

--- a/frontend/src/client/client-db/event-store/event-types.ts
+++ b/frontend/src/client/client-db/event-store/event-types.ts
@@ -77,17 +77,16 @@ export type GameScore = GenericEvent<
   EventTypeEnum.GAME_SCORE,
   {
     setsWon: { gameWinner: number; gameLoser: number };
-    setPoints?: {
-      gameWinner: number;
-      gameLoser: number;
-      /**
-       * Which side of the table the game winner had in this set: "G" = the
-       * good side, "B" = the bad side, "N" = the 2 sides are equally good. The
-       * game loser had the other side. Left out when nobody recorded the side
-       * of this set — the players enter what they remember, set by set.
-       */
-      gameWinnerSide?: WinnerSide;
-    }[];
+    setPoints?: { gameWinner: number; gameLoser: number }[];
+    /**
+     * Which side of the table the game winner had in each set, one entry per
+     * set in the order the sets were played: "G" = the good side, "B" = the
+     * bad side, "N" = the 2 sides are equally good, null = nobody recorded
+     * the side of that set. The game loser had the other side. Independent of
+     * `setPoints`, so a game can record the sides without the points of each
+     * set. Left out when no set has a recorded side.
+     */
+    gameWinnerSides?: (WinnerSide | null)[];
     /**
      * Point-by-point log, one string per set in the order the sets were played.
      * Each char is one point in the order it was scored: "W" = point to the game

--- a/frontend/src/client/client-db/event-store/event-types.ts
+++ b/frontend/src/client/client-db/event-store/event-types.ts
@@ -67,15 +67,6 @@ export type GameTracking = {
    */
   firstServers: string;
   /**
-   * The old location of the table sides, one char per set: "G", "B" or "N"
-   * from the game winner's perspective. New events store the side of each set
-   * on its `setPoints` entry as `gameWinnerSide` instead, so any game with set
-   * points can record the sides, not only a tracked one. Kept because stored
-   * events are immutable — the projector moves it onto `setPoints` when it
-   * projects an old event.
-   */
-  winnerSides?: string;
-  /**
    * How many points were undone while tracking. A high count means the log was
    * corrected by hand, so its times are less trustworthy.
    */

--- a/frontend/src/client/client-db/event-store/event-types.ts
+++ b/frontend/src/client/client-db/event-store/event-types.ts
@@ -1,3 +1,5 @@
+import { WinnerSide } from "../../../common/table-sides";
+
 export enum EventTypeEnum {
   // Player events
   PLAYER_CREATED = "PLAYER_CREATED",
@@ -65,10 +67,12 @@ export type GameTracking = {
    */
   firstServers: string;
   /**
-   * Which side of the table the game winner had in each set, one char per set:
-   * "G" = the good side, "B" = the bad side, "N" = the 2 sides are equally
-   * good. The game loser had the other side. Left out when the sides were not
-   * recorded, so an older game keeps the rest of its tracking data.
+   * The old location of the table sides, one char per set: "G", "B" or "N"
+   * from the game winner's perspective. New events store the side of each set
+   * on its `setPoints` entry as `gameWinnerSide` instead, so any game with set
+   * points can record the sides, not only a tracked one. Kept because stored
+   * events are immutable — the projector moves it onto `setPoints` when it
+   * projects an old event.
    */
   winnerSides?: string;
   /**
@@ -82,7 +86,17 @@ export type GameScore = GenericEvent<
   EventTypeEnum.GAME_SCORE,
   {
     setsWon: { gameWinner: number; gameLoser: number };
-    setPoints?: { gameWinner: number; gameLoser: number }[];
+    setPoints?: {
+      gameWinner: number;
+      gameLoser: number;
+      /**
+       * Which side of the table the game winner had in this set: "G" = the
+       * good side, "B" = the bad side, "N" = the 2 sides are equally good. The
+       * game loser had the other side. Left out when nobody recorded the side
+       * of this set — the players enter what they remember, set by set.
+       */
+      gameWinnerSide?: WinnerSide;
+    }[];
     /**
      * Point-by-point log, one string per set in the order the sets were played.
      * Each char is one point in the order it was scored: "W" = point to the game

--- a/frontend/src/client/client-db/event-store/projectors/games-projector.ts
+++ b/frontend/src/client/client-db/event-store/projectors/games-projector.ts
@@ -1,4 +1,4 @@
-import { WINNER_SIDES_PATTERN } from "../../../../common/table-sides";
+import { WINNER_SIDES_PATTERN, winnerSideOfSet } from "../../../../common/table-sides";
 import { GameCreated, GameDeleted, GameScore, GameTracking } from "../event-types";
 import { ValidatorResponse } from "./validator-types";
 
@@ -38,8 +38,9 @@ function validateTracking(tracking: GameTracking, pointSequences: string[]): str
   if (/^[WL]*$/.test(tracking.firstServers) === false) {
     return "Tracking data is invalid. Only 'W' and 'L' first servers are allowed";
   }
-  // The sides of the table are optional, because a game can be tracked without
-  // them. A game that has them must have one side per set.
+  // The legacy location of the table sides. New events store the side of each
+  // set on its setPoints entry, but an old event that has the string must
+  // still hold one side per set.
   if (tracking.winnerSides !== undefined) {
     if (tracking.winnerSides.length !== pointSequences.length) {
       return "Tracking data is invalid. There must be one table side per set";
@@ -58,6 +59,24 @@ function validateTracking(tracking: GameTracking, pointSequences: string[]): str
 }
 
 export type Game = { id: string; playedAt: number; winner: string; loser: string; score?: GameScore["data"] };
+
+/**
+ * Moves the table sides of an old event onto its `setPoints` entries. Events
+ * written before the sides moved store them as one string on the tracking
+ * data, and stored events are immutable — so the projection carries the side
+ * of each set where every reader looks for it: `setPoints[i].gameWinnerSide`.
+ */
+function scoreWithUpliftedSides(score: GameScore["data"]): GameScore["data"] {
+  const legacySides = score.tracking?.winnerSides;
+  if (legacySides === undefined || score.setPoints === undefined) return score;
+  return {
+    ...score,
+    setPoints: score.setPoints.map((set, setIndex) => {
+      const side = winnerSideOfSet(legacySides, setIndex);
+      return side === undefined ? set : { gameWinnerSide: side, ...set };
+    }),
+  };
+}
 
 export class GamesProjector {
   #gamesMap = new Map<string, Game>();
@@ -83,7 +102,7 @@ export class GamesProjector {
 
   setScore(event: GameScore) {
     if (this.#gamesMap.has(event.stream)) {
-      this.#gamesMap.get(event.stream)!.score = event.data;
+      this.#gamesMap.get(event.stream)!.score = scoreWithUpliftedSides(event.data);
     }
   }
 
@@ -127,6 +146,16 @@ export class GamesProjector {
 
     if (event.data.setPoints && event.data.setPoints.some((set) => set.gameWinner === set.gameLoser)) {
       return { valid: false, message: "Points are invalid. No sets can be tied" };
+    }
+
+    // The side of the table is optional per set: a player records the sets
+    // they remember and leaves the rest out.
+    if (
+      event.data.setPoints?.some(
+        (set) => set.gameWinnerSide !== undefined && /^[GBN]$/.test(set.gameWinnerSide) === false,
+      )
+    ) {
+      return { valid: false, message: "Table sides are invalid. Only 'G', 'B' and 'N' sides are allowed" };
     }
 
     const gameWinnerSetPointsWins = event.data.setPoints?.reduce((wins, set) => {

--- a/frontend/src/client/client-db/event-store/projectors/games-projector.ts
+++ b/frontend/src/client/client-db/event-store/projectors/games-projector.ts
@@ -1,4 +1,3 @@
-import { WINNER_SIDES_PATTERN, winnerSideOfSet } from "../../../../common/table-sides";
 import { GameCreated, GameDeleted, GameScore, GameTracking } from "../event-types";
 import { ValidatorResponse } from "./validator-types";
 
@@ -38,17 +37,6 @@ function validateTracking(tracking: GameTracking, pointSequences: string[]): str
   if (/^[WL]*$/.test(tracking.firstServers) === false) {
     return "Tracking data is invalid. Only 'W' and 'L' first servers are allowed";
   }
-  // The legacy location of the table sides. New events store the side of each
-  // set on its setPoints entry, but an old event that has the string must
-  // still hold one side per set.
-  if (tracking.winnerSides !== undefined) {
-    if (tracking.winnerSides.length !== pointSequences.length) {
-      return "Tracking data is invalid. There must be one table side per set";
-    }
-    if (WINNER_SIDES_PATTERN.test(tracking.winnerSides) === false) {
-      return "Tracking data is invalid. Only 'G', 'B' and 'N' table sides are allowed";
-    }
-  }
   if (isCount(tracking.endedAfter) === false) {
     return "Tracking data is invalid. Ended after must be a positive whole number";
   }
@@ -59,24 +47,6 @@ function validateTracking(tracking: GameTracking, pointSequences: string[]): str
 }
 
 export type Game = { id: string; playedAt: number; winner: string; loser: string; score?: GameScore["data"] };
-
-/**
- * Moves the table sides of an old event onto its `setPoints` entries. Events
- * written before the sides moved store them as one string on the tracking
- * data, and stored events are immutable — so the projection carries the side
- * of each set where every reader looks for it: `setPoints[i].gameWinnerSide`.
- */
-function scoreWithUpliftedSides(score: GameScore["data"]): GameScore["data"] {
-  const legacySides = score.tracking?.winnerSides;
-  if (legacySides === undefined || score.setPoints === undefined) return score;
-  return {
-    ...score,
-    setPoints: score.setPoints.map((set, setIndex) => {
-      const side = winnerSideOfSet(legacySides, setIndex);
-      return side === undefined ? set : { gameWinnerSide: side, ...set };
-    }),
-  };
-}
 
 export class GamesProjector {
   #gamesMap = new Map<string, Game>();
@@ -102,7 +72,7 @@ export class GamesProjector {
 
   setScore(event: GameScore) {
     if (this.#gamesMap.has(event.stream)) {
-      this.#gamesMap.get(event.stream)!.score = scoreWithUpliftedSides(event.data);
+      this.#gamesMap.get(event.stream)!.score = event.data;
     }
   }
 

--- a/frontend/src/client/client-db/event-store/projectors/games-projector.ts
+++ b/frontend/src/client/client-db/event-store/projectors/games-projector.ts
@@ -118,14 +118,23 @@ export class GamesProjector {
       return { valid: false, message: "Points are invalid. No sets can be tied" };
     }
 
-    // The side of the table is optional per set: a player records the sets
-    // they remember and leaves the rest out.
-    if (
-      event.data.setPoints?.some(
-        (set) => set.gameWinnerSide !== undefined && /^[GBN]$/.test(set.gameWinnerSide) === false,
-      )
-    ) {
-      return { valid: false, message: "Table sides are invalid. Only 'G', 'B' and 'N' sides are allowed" };
+    // The sides of the table are independent of the set points: a player can
+    // record the sides they remember with only the sets won. One entry per
+    // set, and null for a set nobody recorded.
+    if (event.data.gameWinnerSides !== undefined) {
+      const totalSets = event.data.setsWon.gameWinner + event.data.setsWon.gameLoser;
+      if (event.data.gameWinnerSides.length !== totalSets) {
+        return { valid: false, message: "Table sides are invalid. There must be one side per set" };
+      }
+      if (event.data.gameWinnerSides.some((side) => side !== null && /^[GBN]$/.test(side) === false)) {
+        return { valid: false, message: "Table sides are invalid. Only 'G', 'B', 'N' and null sides are allowed" };
+      }
+      if (event.data.gameWinnerSides.every((side) => side === null)) {
+        return {
+          valid: false,
+          message: "If no sides are recorded, the gameWinnerSides should not be included in the event data",
+        };
+      }
     }
 
     const gameWinnerSetPointsWins = event.data.setPoints?.reduce((wins, set) => {

--- a/frontend/src/common/point-sequences.test.ts
+++ b/frontend/src/common/point-sequences.test.ts
@@ -1,5 +1,4 @@
 import { appendPoint, removeLastPoint, toEventTrackingData, TrackedSet } from "./point-sequences";
-import { BadSide } from "./table-sides";
 
 describe("appendPoint", () => {
   it("appends the player's digit and the time of the point", () => {
@@ -40,7 +39,6 @@ describe("toEventTrackingData", () => {
     completedSets,
     trackedSets,
     firstServers: [1, 2] as (1 | 2)[],
-    badSides: [1, 2] as BadSide[],
     source: "track-game" as const,
     startedAt,
     endedAt: startedAt + 120_000,
@@ -88,32 +86,6 @@ describe("toEventTrackingData", () => {
     expect(toEventTrackingData({ ...params, player1IsGameWinner: false })?.tracking.firstServers).toBe("LW");
   });
 
-  it("encodes the bad side of each set from the game winner's perspective", () => {
-    // Player 1 has the bad side in set 1, player 2 in set 2.
-    expect(toEventTrackingData({ ...params, player1IsGameWinner: true })?.tracking.winnerSides).toBe("BG");
-    expect(toEventTrackingData({ ...params, player1IsGameWinner: false })?.tracking.winnerSides).toBe("GB");
-  });
-
-  it("encodes a set with 2 equally good sides as N", () => {
-    const badSides: BadSide[] = ["neutral", "neutral"];
-    expect(toEventTrackingData({ ...params, badSides, player1IsGameWinner: true })?.tracking.winnerSides).toBe("NN");
-  });
-
-  it("leaves out the sides when a set has none, and keeps the rest of the data", () => {
-    const tracking = toEventTrackingData({ ...params, badSides: [1, null], player1IsGameWinner: true })?.tracking;
-    expect(tracking?.winnerSides).toBeUndefined();
-    expect(tracking?.firstServers).toBe("WL");
-  });
-
-  it("leaves out the sides when they do not count up to the completed sets", () => {
-    expect(
-      toEventTrackingData({ ...params, badSides: [1], player1IsGameWinner: true })?.tracking.winnerSides,
-    ).toBeUndefined();
-    expect(
-      toEventTrackingData({ ...params, badSides: [], player1IsGameWinner: true })?.tracking.winnerSides,
-    ).toBeUndefined();
-  });
-
   it("keeps the source and the correction count", () => {
     const tracking = toEventTrackingData({ ...params, player1IsGameWinner: true })?.tracking;
     expect(tracking?.version).toBe(1);
@@ -128,7 +100,6 @@ describe("toEventTrackingData", () => {
         completedSets: [],
         trackedSets: [],
         firstServers: [],
-        badSides: [],
         player1IsGameWinner: true,
       }),
     ).toBeUndefined();

--- a/frontend/src/common/point-sequences.ts
+++ b/frontend/src/common/point-sequences.ts
@@ -5,14 +5,14 @@
  * set as a string of "1"/"2" chars — one char per point, in the order the
  * points were scored, naming the player slot that won the point. Next to each
  * sequence the tracker keeps the time of every point, and per set who served
- * first and who had the bad side of the table. When the game is saved all of it
- * is re-encoded from the game winner's perspective ("W"/"L") to match how a
- * GAME_SCORE event stores its setPoints.
+ * first. When the game is saved all of it is re-encoded from the game winner's
+ * perspective ("W"/"L") to match how a GAME_SCORE event stores its setPoints.
+ * The side of the table travels separately, on the setPoints entries — see
+ * `gameWinnerSideOfBadSide`.
  */
 
 import { GameTracking } from "../client/client-db/event-store/event-types";
 import { Server } from "./serve-tracker";
-import { BadSide, encodeWinnerSides } from "./table-sides";
 
 export type TrackedSetPoints = { player1: number; player2: number };
 
@@ -77,11 +77,6 @@ export function toEventTrackingData(params: {
   trackedSets: TrackedSet[];
   /** Who served the first point of each completed set. */
   firstServers: Server[];
-  /**
-   * Who had the bad side of the table in each completed set. The sides are only
-   * saved when every set has one, because a set without one says nothing.
-   */
-  badSides: BadSide[];
   player1IsGameWinner: boolean;
   source: GameTracking["source"];
   /** Epoch ms tracking started, and when the match was ended. */
@@ -89,7 +84,7 @@ export function toEventTrackingData(params: {
   endedAt: number | null;
   corrections: number;
 }): { pointSequences: string[]; tracking: GameTracking } | undefined {
-  const { completedSets, trackedSets, firstServers, badSides, player1IsGameWinner, startedAt, endedAt } = params;
+  const { completedSets, trackedSets, firstServers, player1IsGameWinner, startedAt, endedAt } = params;
   if (startedAt === null || endedAt === null) return undefined;
   if (completedSets.length === 0) return undefined;
   if (trackedSets.length !== completedSets.length) return undefined;
@@ -121,11 +116,6 @@ export function toEventTrackingData(params: {
     }),
   );
 
-  // One side per set or nothing: a game with a side missing keeps the rest of
-  // its tracking data and drops the sides.
-  const winnerSides =
-    badSides.length === completedSets.length ? encodeWinnerSides(badSides, gameWinnerSlot) : undefined;
-
   return {
     pointSequences,
     tracking: {
@@ -135,7 +125,6 @@ export function toEventTrackingData(params: {
       pointDeltas,
       endedAfter: Math.max(0, Math.round((endedAt - startedAt) / 100) - previousTenths),
       firstServers: firstServers.map((server) => (server === gameWinnerSlot ? "W" : "L")).join(""),
-      ...(winnerSides ? { winnerSides } : {}),
       corrections: params.corrections,
     },
   };

--- a/frontend/src/common/table-sides-display.tsx
+++ b/frontend/src/common/table-sides-display.tsx
@@ -33,6 +33,54 @@ type TableSideDisplayProps = {
  * the set is 0-0 a press on the selected option removes it again, so a set the
  * operator does not know goes back to no record.
  */
+/**
+ * The selectable pill row on its own: who has the bad side, "Equal" for 2
+ * equally good sides, and a press on the selected option to remove it again.
+ * The trackers show it while the current set is 0-0, and the add game form
+ * shows it for every set the players enter by hand.
+ */
+export const TableSidePicker: React.FC<{
+  badSide: BadSide;
+  player1Name: string;
+  player2Name: string;
+  player1Color: string;
+  player2Color: string;
+  onSelect: (badSide: BadSide) => void;
+}> = ({ badSide, player1Name, player2Name, player1Color, player2Color, onSelect }) => {
+  const toggle = (option: BadSide) => onSelect(badSide === option ? null : option);
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-2">
+      <span className="text-xs text-gray-400">😵 Bad side:</span>
+      <button
+        onClick={() => toggle(1)}
+        title={`${player1Name} has the bad side of the table`}
+        className={classNames(PILL, badSide === 1 ? "hover:brightness-95" : UNSELECTED_PILL)}
+        style={badSide === 1 ? fill(player1Color) : undefined}
+      >
+        {player1Name}
+      </button>
+      <button
+        onClick={() => toggle("neutral")}
+        title="Both sides of the table are equally good"
+        className={classNames(
+          PILL,
+          badSide === "neutral" ? "bg-gray-700 text-white hover:brightness-125" : UNSELECTED_PILL,
+        )}
+      >
+        Equal
+      </button>
+      <button
+        onClick={() => toggle(2)}
+        title={`${player2Name} has the bad side of the table`}
+        className={classNames(PILL, badSide === 2 ? "hover:brightness-95" : UNSELECTED_PILL)}
+        style={badSide === 2 ? fill(player2Color) : undefined}
+      >
+        {player2Name}
+      </button>
+    </div>
+  );
+};
+
 export const TableSideDisplay: React.FC<TableSideDisplayProps> = ({
   currentSet,
   badSide,
@@ -46,37 +94,15 @@ export const TableSideDisplay: React.FC<TableSideDisplayProps> = ({
   const label = badSideLabel(badSide, player1Name, player2Name);
 
   if (onSelect && isSetEmpty) {
-    const toggle = (option: BadSide) => onSelect(badSide === option ? null : option);
     return (
-      <div className="flex flex-wrap items-center justify-center gap-2">
-        <span className="text-xs text-gray-400">😵 Bad side:</span>
-        <button
-          onClick={() => toggle(1)}
-          title={`${player1Name} has the bad side of the table`}
-          className={classNames(PILL, badSide === 1 ? "hover:brightness-95" : UNSELECTED_PILL)}
-          style={badSide === 1 ? fill(player1Color) : undefined}
-        >
-          {player1Name}
-        </button>
-        <button
-          onClick={() => toggle("neutral")}
-          title="Both sides of the table are equally good"
-          className={classNames(
-            PILL,
-            badSide === "neutral" ? "bg-gray-700 text-white hover:brightness-125" : UNSELECTED_PILL,
-          )}
-        >
-          Equal
-        </button>
-        <button
-          onClick={() => toggle(2)}
-          title={`${player2Name} has the bad side of the table`}
-          className={classNames(PILL, badSide === 2 ? "hover:brightness-95" : UNSELECTED_PILL)}
-          style={badSide === 2 ? fill(player2Color) : undefined}
-        >
-          {player2Name}
-        </button>
-      </div>
+      <TableSidePicker
+        badSide={badSide}
+        player1Name={player1Name}
+        player2Name={player2Name}
+        player1Color={player1Color}
+        player2Color={player2Color}
+        onSelect={onSelect}
+      />
     );
   }
 

--- a/frontend/src/common/table-sides.test.ts
+++ b/frontend/src/common/table-sides.test.ts
@@ -33,9 +33,9 @@ describe("gameWinnerSideOfBadSide", () => {
     expect(gameWinnerSideOfBadSide("neutral", 2)).toBe("N");
   });
 
-  it("returns undefined for a set with no recorded side", () => {
-    expect(gameWinnerSideOfBadSide(null, 1)).toBeUndefined();
-    expect(gameWinnerSideOfBadSide(null, 2)).toBeUndefined();
+  it("returns null for a set with no recorded side", () => {
+    expect(gameWinnerSideOfBadSide(null, 1)).toBeNull();
+    expect(gameWinnerSideOfBadSide(null, 2)).toBeNull();
   });
 });
 

--- a/frontend/src/common/table-sides.test.ts
+++ b/frontend/src/common/table-sides.test.ts
@@ -6,7 +6,6 @@ import {
   badSideOfGameWinnerSide,
   gameWinnerSideOfBadSide,
   nextSetBadSide,
-  winnerSideOfSet,
 } from "./table-sides";
 
 describe("nextSetBadSide", () => {
@@ -48,20 +47,6 @@ describe("badSideOfGameWinnerSide", () => {
         expect(badSideOfGameWinnerSide(gameWinnerSideOfBadSide(side, slot), slot)).toBe(side);
       }
     }
-  });
-});
-
-describe("winnerSideOfSet", () => {
-  it("reads the side of one set", () => {
-    expect(winnerSideOfSet("GBN", 0)).toBe("G");
-    expect(winnerSideOfSet("GBN", 1)).toBe("B");
-    expect(winnerSideOfSet("GBN", 2)).toBe("N");
-  });
-
-  it("returns undefined for a game or a set without sides", () => {
-    expect(winnerSideOfSet(undefined, 0)).toBeUndefined();
-    expect(winnerSideOfSet("GB", 2)).toBeUndefined();
-    expect(winnerSideOfSet("X", 0)).toBeUndefined();
   });
 });
 

--- a/frontend/src/common/table-sides.test.ts
+++ b/frontend/src/common/table-sides.test.ts
@@ -3,7 +3,8 @@ import {
   BadSide,
   badSideLabel,
   badSideName,
-  encodeWinnerSides,
+  badSideOfGameWinnerSide,
+  gameWinnerSideOfBadSide,
   nextSetBadSide,
   winnerSideOfSet,
 } from "./table-sides";
@@ -20,24 +21,33 @@ describe("nextSetBadSide", () => {
   });
 });
 
-describe("encodeWinnerSides", () => {
+describe("gameWinnerSideOfBadSide", () => {
   it("encodes the side of the game winner as G or B", () => {
-    // Player 1 has the bad side in set 1 and player 2 in set 2.
-    expect(encodeWinnerSides([1, 2], 1)).toBe("BG");
-    expect(encodeWinnerSides([1, 2], 2)).toBe("GB");
+    expect(gameWinnerSideOfBadSide(1, 1)).toBe("B");
+    expect(gameWinnerSideOfBadSide(2, 1)).toBe("G");
+    expect(gameWinnerSideOfBadSide(1, 2)).toBe("G");
+    expect(gameWinnerSideOfBadSide(2, 2)).toBe("B");
   });
 
   it("encodes 2 equally good sides as N", () => {
-    expect(encodeWinnerSides(["neutral", 1, "neutral"], 1)).toBe("NBN");
+    expect(gameWinnerSideOfBadSide("neutral", 1)).toBe("N");
+    expect(gameWinnerSideOfBadSide("neutral", 2)).toBe("N");
   });
 
-  it("returns undefined when a set has no recorded side", () => {
-    expect(encodeWinnerSides([1, null], 1)).toBeUndefined();
-    expect(encodeWinnerSides([null], 1)).toBeUndefined();
+  it("returns undefined for a set with no recorded side", () => {
+    expect(gameWinnerSideOfBadSide(null, 1)).toBeUndefined();
+    expect(gameWinnerSideOfBadSide(null, 2)).toBeUndefined();
   });
+});
 
-  it("returns undefined for a game with no sets", () => {
-    expect(encodeWinnerSides([], 1)).toBeUndefined();
+describe("badSideOfGameWinnerSide", () => {
+  it("is the inverse of gameWinnerSideOfBadSide for every side and slot", () => {
+    const sides: BadSide[] = [1, 2, "neutral", null];
+    for (const slot of [1, 2] as const) {
+      for (const side of sides) {
+        expect(badSideOfGameWinnerSide(gameWinnerSideOfBadSide(side, slot), slot)).toBe(side);
+      }
+    }
   });
 });
 
@@ -105,7 +115,7 @@ describe("a set of sides through the whole flow", () => {
       sides.push(badSide);
       badSide = nextSetBadSide(badSide);
     }
-    expect(encodeWinnerSides(sides, 1)).toBe("BGB");
-    expect(encodeWinnerSides(sides, 2)).toBe("GBG");
+    expect(sides.map((side) => gameWinnerSideOfBadSide(side, 1))).toEqual(["B", "G", "B"]);
+    expect(sides.map((side) => gameWinnerSideOfBadSide(side, 2))).toEqual(["G", "B", "G"]);
   });
 });

--- a/frontend/src/common/table-sides.ts
+++ b/frontend/src/common/table-sides.ts
@@ -6,7 +6,7 @@
  * set, but not every pair does it. While a game is tracked or entered the side
  * is kept as the player slot that has the bad side. When the game is saved each
  * set's side is re-encoded from the game winner's perspective, the same way the
- * point sequences are, onto the set's `setPoints` entry.
+ * point sequences are, into the `gameWinnerSides` list of the GAME_SCORE event.
  */
 
 import { Server } from "./serve-tracker";
@@ -19,9 +19,9 @@ import { Server } from "./serve-tracker";
 export type BadSide = 1 | 2 | "neutral" | null;
 
 /**
- * The side the game winner had in one set, as the `gameWinnerSide` of a
- * `setPoints` entry of a GAME_SCORE event: "G" = the good side, "B" = the bad
- * side, "N" = the 2 sides are equally good.
+ * The side the game winner had in one set, as one entry of the
+ * `gameWinnerSides` list of a GAME_SCORE event: "G" = the good side, "B" = the
+ * bad side, "N" = the 2 sides are equally good.
  */
 export type WinnerSide = "G" | "B" | "N";
 
@@ -37,19 +37,19 @@ export function nextSetBadSide(badSide: BadSide): BadSide {
 }
 
 /**
- * Encodes the bad side of one set from the game winner's perspective, or
- * undefined when the set has no recorded side. Each set is on its own, so the
- * players can record the sides they remember and leave the rest out.
+ * Encodes the bad side of one set from the game winner's perspective, or null
+ * when the set has no recorded side. Each set is on its own, so the players
+ * can record the sides they remember and leave the rest out.
  */
-export function gameWinnerSideOfBadSide(badSide: BadSide, gameWinnerSlot: Server): WinnerSide | undefined {
-  if (badSide === null) return undefined;
+export function gameWinnerSideOfBadSide(badSide: BadSide, gameWinnerSlot: Server): WinnerSide | null {
+  if (badSide === null) return null;
   if (badSide === "neutral") return "N";
   return badSide === gameWinnerSlot ? "B" : "G";
 }
 
 /** The inverse of `gameWinnerSideOfBadSide`: the player slot that had the bad side. */
-export function badSideOfGameWinnerSide(side: WinnerSide | undefined, gameWinnerSlot: Server): BadSide {
-  if (side === undefined) return null;
+export function badSideOfGameWinnerSide(side: WinnerSide | null | undefined, gameWinnerSlot: Server): BadSide {
+  if (side === null || side === undefined) return null;
   if (side === "N") return "neutral";
   const gameLoserSlot: Server = gameWinnerSlot === 1 ? 2 : 1;
   return side === "B" ? gameWinnerSlot : gameLoserSlot;

--- a/frontend/src/common/table-sides.ts
+++ b/frontend/src/common/table-sides.ts
@@ -25,9 +25,6 @@ export type BadSide = 1 | 2 | "neutral" | null;
  */
 export type WinnerSide = "G" | "B" | "N";
 
-/** Every char a legacy `winnerSides` string can hold. */
-export const WINNER_SIDES_PATTERN = /^[GBN]*$/;
-
 /**
  * The bad side of the next set. The players change sides after every set, so
  * the bad side moves to the other player. A neutral or unrecorded set keeps its
@@ -56,16 +53,6 @@ export function badSideOfGameWinnerSide(side: WinnerSide | undefined, gameWinner
   if (side === "N") return "neutral";
   const gameLoserSlot: Server = gameWinnerSlot === 1 ? 2 : 1;
   return side === "B" ? gameWinnerSlot : gameLoserSlot;
-}
-
-/**
- * The side the game winner had in one set of a legacy `winnerSides` string, or
- * undefined when it is not recorded. Only the projector reads the string — it
- * moves each char onto the set's `setPoints` entry when it projects the event.
- */
-export function winnerSideOfSet(winnerSides: string | undefined, setIndex: number): WinnerSide | undefined {
-  const side = winnerSides?.[setIndex];
-  return side === "G" || side === "B" || side === "N" ? side : undefined;
 }
 
 /**

--- a/frontend/src/common/table-sides.ts
+++ b/frontend/src/common/table-sides.ts
@@ -1,12 +1,12 @@
 /**
- * Which side of the table the players had in each set of a tracked game.
+ * Which side of the table the players had in each set of a game.
  *
  * One side of a table is often worse than the other, because of the light, the
  * space behind it or a draught. The players usually change sides after every
- * set, but not every pair does it. While a game is tracked the side is kept as
- * the player slot that has the bad side. When the game is saved it is
- * re-encoded from the game winner's perspective, the same way the point
- * sequences are.
+ * set, but not every pair does it. While a game is tracked or entered the side
+ * is kept as the player slot that has the bad side. When the game is saved each
+ * set's side is re-encoded from the game winner's perspective, the same way the
+ * point sequences are, onto the set's `setPoints` entry.
  */
 
 import { Server } from "./serve-tracker";
@@ -19,13 +19,13 @@ import { Server } from "./serve-tracker";
 export type BadSide = 1 | 2 | "neutral" | null;
 
 /**
- * The side the game winner had in one set, as one char of the `winnerSides`
- * string of a GAME_SCORE event: "G" = the good side, "B" = the bad side,
- * "N" = the 2 sides are equally good.
+ * The side the game winner had in one set, as the `gameWinnerSide` of a
+ * `setPoints` entry of a GAME_SCORE event: "G" = the good side, "B" = the bad
+ * side, "N" = the 2 sides are equally good.
  */
 export type WinnerSide = "G" | "B" | "N";
 
-/** Every char a stored `winnerSides` string can hold. */
+/** Every char a legacy `winnerSides` string can hold. */
 export const WINNER_SIDES_PATTERN = /^[GBN]*$/;
 
 /**
@@ -40,17 +40,29 @@ export function nextSetBadSide(badSide: BadSide): BadSide {
 }
 
 /**
- * Encodes the bad side of every set from the game winner's perspective. Returns
- * undefined when a set has no recorded side, so the game keeps the rest of its
- * tracking data instead of storing a side nobody recorded.
+ * Encodes the bad side of one set from the game winner's perspective, or
+ * undefined when the set has no recorded side. Each set is on its own, so the
+ * players can record the sides they remember and leave the rest out.
  */
-export function encodeWinnerSides(badSides: BadSide[], gameWinnerSlot: Server): string | undefined {
-  if (badSides.length === 0) return undefined;
-  if (badSides.some((side) => side === null)) return undefined;
-  return badSides.map((side) => (side === "neutral" ? "N" : side === gameWinnerSlot ? "B" : "G")).join("");
+export function gameWinnerSideOfBadSide(badSide: BadSide, gameWinnerSlot: Server): WinnerSide | undefined {
+  if (badSide === null) return undefined;
+  if (badSide === "neutral") return "N";
+  return badSide === gameWinnerSlot ? "B" : "G";
 }
 
-/** The side the game winner had in one set, or undefined when it is not recorded. */
+/** The inverse of `gameWinnerSideOfBadSide`: the player slot that had the bad side. */
+export function badSideOfGameWinnerSide(side: WinnerSide | undefined, gameWinnerSlot: Server): BadSide {
+  if (side === undefined) return null;
+  if (side === "N") return "neutral";
+  const gameLoserSlot: Server = gameWinnerSlot === 1 ? 2 : 1;
+  return side === "B" ? gameWinnerSlot : gameLoserSlot;
+}
+
+/**
+ * The side the game winner had in one set of a legacy `winnerSides` string, or
+ * undefined when it is not recorded. Only the projector reads the string — it
+ * moves each char onto the set's `setPoints` entry when it projects the event.
+ */
 export function winnerSideOfSet(winnerSides: string | undefined, setIndex: number): WinnerSide | undefined {
   const side = winnerSides?.[setIndex];
   return side === "G" || side === "B" || side === "N" ? side : undefined;

--- a/frontend/src/pages/add-game/add-game-page.tsx
+++ b/frontend/src/pages/add-game/add-game-page.tsx
@@ -91,11 +91,8 @@ export const AddGamePageV2: React.FC = () => {
       return;
     }
 
-    // The side of a set is stored on its set points, so it cannot travel alone.
-    if (setPointsAreSet === false && setPoints.some((set) => set.badSide !== null)) {
-      setValidationError("The table sides need the individual set points. Add the points or remove the sides.");
-      return;
-    }
+    // The sides are independent of the points: only the sets won are needed.
+    const sidesAreSet = setPoints.some((set) => set.badSide !== null);
 
     const gameScoreEvent: GameScore = {
       type: EventTypeEnum.GAME_SCORE,
@@ -110,8 +107,10 @@ export const AddGamePageV2: React.FC = () => {
           ? setPoints.map((set) => ({
               gameWinner: player1 === winner ? set.player1! : set.player2!,
               gameLoser: player1 === winner ? set.player2! : set.player1!,
-              gameWinnerSide: gameWinnerSideOfBadSide(set.badSide, player1 === winner ? 1 : 2),
             }))
+          : undefined,
+        gameWinnerSides: sidesAreSet
+          ? setPoints.map((set) => gameWinnerSideOfBadSide(set.badSide, player1 === winner ? 1 : 2))
           : undefined,
       },
     };

--- a/frontend/src/pages/add-game/add-game-page.tsx
+++ b/frontend/src/pages/add-game/add-game-page.tsx
@@ -5,7 +5,8 @@ import { StepIndicator } from "./step-indicator";
 import { StepNavigator } from "./step-navigator";
 import { useEventDbContext } from "../../wrappers/event-db-context";
 import { StepSelectWinner } from "./step-select-winner";
-import { StepAddScore } from "./step-add-score";
+import { ManualSetPoints, StepAddScore } from "./step-add-score";
+import { gameWinnerSideOfBadSide } from "../../common/table-sides";
 import { EventTypeEnum, GameCreated, GameScore } from "../../client/client-db/event-store/event-types";
 import { newId } from "../../common/nani-id";
 import { useEventMutation } from "../../hooks/use-event-mutation";
@@ -30,7 +31,7 @@ export const AddGamePageV2: React.FC = () => {
   const [winner, setWinner] = useState<string | null>(null);
   const [player1Sets, setPlayer1Sets] = useState(0);
   const [player2Sets, setPlayer2Sets] = useState(0);
-  const [setPoints, setSetPoints] = useState<{ player1?: number; player2?: number }[]>([]);
+  const [setPoints, setSetPoints] = useState<ManualSetPoints[]>([]);
   const [gameSuccessfullyAdded, setGameSuccessfullyAdded] = useState(false);
   const [validationError, setValidationError] = useState("");
 
@@ -90,6 +91,12 @@ export const AddGamePageV2: React.FC = () => {
       return;
     }
 
+    // The side of a set is stored on its set points, so it cannot travel alone.
+    if (setPointsAreSet === false && setPoints.some((set) => set.badSide !== null)) {
+      setValidationError("The table sides need the individual set points. Add the points or remove the sides.");
+      return;
+    }
+
     const gameScoreEvent: GameScore = {
       type: EventTypeEnum.GAME_SCORE,
       time: gameCreatedEvent.time + 1,
@@ -103,6 +110,7 @@ export const AddGamePageV2: React.FC = () => {
           ? setPoints.map((set) => ({
               gameWinner: player1 === winner ? set.player1! : set.player2!,
               gameLoser: player1 === winner ? set.player2! : set.player1!,
+              gameWinnerSide: gameWinnerSideOfBadSide(set.badSide, player1 === winner ? 1 : 2),
             }))
           : undefined,
       },
@@ -151,9 +159,10 @@ export const AddGamePageV2: React.FC = () => {
     } else if (setPoints.length < totalSets) {
       // Set added
       const setsAdded = totalSets - setPoints.length;
-      const newSets = new Array<{ player1?: number; player2?: number }>(setsAdded).fill({
+      const newSets = new Array<ManualSetPoints>(setsAdded).fill({
         player1: undefined,
         player2: undefined,
+        badSide: null,
       });
       setSetPoints((prev) => [...prev, ...newSets]);
     } else if (setPoints.length > totalSets) {

--- a/frontend/src/pages/add-game/step-add-score.tsx
+++ b/frontend/src/pages/add-game/step-add-score.tsx
@@ -2,14 +2,24 @@ import { useEventDbContext } from "../../wrappers/event-db-context";
 import { ProfilePicture } from "../player/profile-picture";
 import { stringToColor } from "../../common/string-to-color";
 import { classNames } from "../../common/class-names";
+import { BadSide } from "../../common/table-sides";
+import { TableSidePicker } from "../../common/table-sides-display";
+
+/**
+ * One set as the add game form collects it: the points of both players, and
+ * who had the bad side of the table — null when the players do not remember.
+ */
+export type ManualSetPoints = { player1?: number; player2?: number; badSide: BadSide };
+
+type SetPointsState = {
+  setPoints: ManualSetPoints[];
+  setSetPoints: React.Dispatch<React.SetStateAction<ManualSetPoints[]>>;
+};
 
 export const StepAddScore: React.FC<{
   player1: { id: string; sets: number; setSets: (sets: number) => void };
   player2: { id: string; sets: number; setSets: (sets: number) => void };
-  setPoints: {
-    setPoints: { player1?: number; player2?: number }[];
-    setSetPoints: React.Dispatch<React.SetStateAction<{ player1?: number; player2?: number }[]>>;
-  };
+  setPoints: SetPointsState;
   winner: string;
   invalidScore: boolean;
 }> = ({ player1, player2, setPoints, winner, invalidScore }) => {
@@ -40,10 +50,7 @@ const SetPointsInput: React.FC<{
   playerId: string;
   setIndex: number;
   playerIndex: "player1" | "player2";
-  setPoints: {
-    setPoints: { player1?: number; player2?: number }[];
-    setSetPoints: React.Dispatch<React.SetStateAction<{ player1?: number; player2?: number }[]>>;
-  };
+  setPoints: SetPointsState;
 }> = ({ playerId, setIndex, playerIndex, setPoints: { setPoints, setSetPoints } }) => {
   const context = useEventDbContext();
   const currentPoints = setPoints[setIndex][playerIndex];
@@ -77,22 +84,25 @@ const SetPointsInput: React.FC<{
 const SetPoints: React.FC<{
   player1: string;
   player2: string;
-  setPoints: {
-    setPoints: { player1?: number; player2?: number }[];
-    setSetPoints: React.Dispatch<React.SetStateAction<{ player1?: number; player2?: number }[]>>;
-  };
+  setPoints: SetPointsState;
 }> = ({ player1, player2, setPoints }) => {
+  const context = useEventDbContext();
   const anyPointsSet = setPoints.setPoints.some((set) => set.player1 !== undefined || set.player2 !== undefined);
+  const anySideSet = setPoints.setPoints.some((set) => set.badSide !== null);
+
+  function handleSelectSide(setIndex: number, badSide: BadSide) {
+    setPoints.setSetPoints((prev) => prev.map((set, index) => (index === setIndex ? { ...set, badSide } : set)));
+  }
 
   return (
     <div className="text-primary-text">
       <div className="grid grid-cols-1 gap-2">
-        {setPoints.setPoints.map((_, index) => (
+        {setPoints.setPoints.map((set, index) => (
           <div
             key={index}
             className={classNames(
               "bg-secondary-background text-secondary-text rounded-lg px-4 py-2",
-              anyPointsSet === false && "opacity-50",
+              anyPointsSet === false && anySideSet === false && "opacity-50",
             )}
           >
             {index === 0 && (
@@ -106,6 +116,18 @@ const SetPoints: React.FC<{
               <SetPointsInput playerId={player1} playerIndex="player1" setIndex={index} setPoints={setPoints} />
               <span className="text-2xl font-bold text-secondary-text mt-5">-</span>
               <SetPointsInput playerId={player2} playerIndex="player2" setIndex={index} setPoints={setPoints} />
+            </div>
+            {/* The players often remember who had the worse side of the table.
+                One press per set records it, and it needs the set points. */}
+            <div className="pb-1">
+              <TableSidePicker
+                badSide={set.badSide}
+                player1Name={context.playerName(player1)}
+                player2Name={context.playerName(player2)}
+                player1Color={stringToColor(player1)}
+                player2Color={stringToColor(player2)}
+                onSelect={(badSide) => handleSelectSide(index, badSide)}
+              />
             </div>
           </div>
         ))}

--- a/frontend/src/pages/add-game/step-add-score.tsx
+++ b/frontend/src/pages/add-game/step-add-score.tsx
@@ -118,8 +118,10 @@ const SetPoints: React.FC<{
               <SetPointsInput playerId={player2} playerIndex="player2" setIndex={index} setPoints={setPoints} />
             </div>
             {/* The players often remember who had the worse side of the table.
-                One press per set records it, and it needs the set points. */}
-            <div className="pb-1">
+                One press per set records it, with or without the set points.
+                The points row overflows its fixed height, so the margin keeps
+                the pills clear of the inputs. */}
+            <div className="mt-3 pb-1">
               <TableSidePicker
                 badSide={set.badSide}
                 player1Name={context.playerName(player1)}

--- a/frontend/src/pages/add-game/track-game.tsx
+++ b/frontend/src/pages/add-game/track-game.tsx
@@ -15,7 +15,7 @@ import { stringToColor } from "../../common/string-to-color";
 import { CARD_SURFACE, fill, panelTint, ROW_SURFACE, softFill, textOn } from "../../common/player-color-styles";
 import { getServeInfo, Server } from "../../common/serve-tracker";
 import { ServeTrackerDisplay } from "../../common/serve-tracker-display";
-import { BadSide, badSideLabel, nextSetBadSide } from "../../common/table-sides";
+import { BadSide, badSideLabel, gameWinnerSideOfBadSide, nextSetBadSide } from "../../common/table-sides";
 import { TableSideDisplay } from "../../common/table-sides-display";
 import { LiveGamePredictionCard } from "../live-game/live-game-prediction-card";
 import { computeLiveWinPrediction } from "../live-game/live-game-win-probability";
@@ -200,7 +200,6 @@ export const TrackGamePage: React.FC = () => {
       completedSets: setPointsForValidation,
       trackedSets: matchData.trackedSets,
       firstServers: matchData.firstServers,
-      badSides: matchData.badSides,
       player1IsGameWinner: player1 === winner,
       source: "track-game",
       startedAt,
@@ -219,9 +218,10 @@ export const TrackGamePage: React.FC = () => {
         },
         setPoints:
           setPointsForValidation.length > 0
-            ? setPointsForValidation.map((set) => ({
+            ? setPointsForValidation.map((set, index) => ({
                 gameWinner: player1 === winner ? set.player1 : set.player2,
                 gameLoser: player1 === winner ? set.player2 : set.player1,
+                gameWinnerSide: gameWinnerSideOfBadSide(matchData.badSides[index] ?? null, player1 === winner ? 1 : 2),
               }))
             : undefined,
         pointSequences: trackingData?.pointSequences,

--- a/frontend/src/pages/add-game/track-game.tsx
+++ b/frontend/src/pages/add-game/track-game.tsx
@@ -218,12 +218,16 @@ export const TrackGamePage: React.FC = () => {
         },
         setPoints:
           setPointsForValidation.length > 0
-            ? setPointsForValidation.map((set, index) => ({
+            ? setPointsForValidation.map((set) => ({
                 gameWinner: player1 === winner ? set.player1 : set.player2,
                 gameLoser: player1 === winner ? set.player2 : set.player1,
-                gameWinnerSide: gameWinnerSideOfBadSide(matchData.badSides[index] ?? null, player1 === winner ? 1 : 2),
               }))
             : undefined,
+        gameWinnerSides: matchData.badSides.some((side) => side !== null)
+          ? setPointsForValidation.map((_, index) =>
+              gameWinnerSideOfBadSide(matchData.badSides[index] ?? null, player1 === winner ? 1 : 2),
+            )
+          : undefined,
         pointSequences: trackingData?.pointSequences,
         tracking: trackingData?.tracking,
       },

--- a/frontend/src/pages/edit-game-score.tsx
+++ b/frontend/src/pages/edit-game-score.tsx
@@ -32,16 +32,22 @@ export const EditGameSore: React.FC = () => {
   const [validationError, setValidationError] = useState("");
 
   const invalidScore = (winnerSets === loserSets && winnerSets > 0) || loserSets > winnerSets;
-  const unchangedScore =
+  // The form has no point-level detail, so an edit can only keep the stored
+  // point-by-point log while the sets and points it describes are unchanged.
+  // An edit that only changes the sides keeps the log of a tracked game.
+  const pointDataUnchanged =
     winnerSets === game?.score?.setsWon.gameWinner &&
     loserSets === game?.score?.setsWon.gameLoser &&
-    setPoints.every(({ player1, player2, badSide }, index) => {
-      return (
+    setPoints.every(
+      ({ player1, player2 }, index) =>
         game.score?.setPoints?.[index]?.gameWinner === player1 &&
-        game.score?.setPoints?.[index]?.gameLoser === player2 &&
-        (game.score?.gameWinnerSides?.[index] ?? null) === gameWinnerSideOfBadSide(badSide, 1)
-      );
-    });
+        game.score?.setPoints?.[index]?.gameLoser === player2,
+    );
+  const unchangedScore =
+    pointDataUnchanged &&
+    setPoints.every(
+      ({ badSide }, index) => (game?.score?.gameWinnerSides?.[index] ?? null) === gameWinnerSideOfBadSide(badSide, 1),
+    );
 
   async function submitScore() {
     setValidationError("");
@@ -72,6 +78,8 @@ export const EditGameSore: React.FC = () => {
           ? setPoints.map((set) => ({ gameWinner: set.player1!, gameLoser: set.player2! }))
           : undefined,
         gameWinnerSides: sidesAreSet ? setPoints.map((set) => gameWinnerSideOfBadSide(set.badSide, 1)) : undefined,
+        pointSequences: pointDataUnchanged ? game.score?.pointSequences : undefined,
+        tracking: pointDataUnchanged ? game.score?.tracking : undefined,
       },
     };
 
@@ -115,9 +123,10 @@ export const EditGameSore: React.FC = () => {
     }
   }, [winnerSets, loserSets, setPoints.length]);
 
-  // Editing replaces the score event, and the edit form has no point-level
-  // detail — so a point-by-point log from live tracking is lost on save.
+  // Editing replaces the score event. The stored point-by-point log survives
+  // only while the sets and points are unchanged, so warn when they are not.
   const hasPointSequences = (game?.score?.pointSequences?.length ?? 0) > 0;
+  const discardsPointLog = hasPointSequences && pointDataUnchanged === false;
 
   if (!game) return null;
   return (
@@ -147,10 +156,10 @@ export const EditGameSore: React.FC = () => {
         {validationError && <div className="bg-black text-red-500 text-center">Error: {validationError}</div>}
       </div>
       <div className="p-6 bg-secondary-background">
-        {hasPointSequences && (
+        {discardsPointLog && (
           <div className="mb-3 p-3 bg-amber-100 border border-amber-400 text-amber-800 rounded-lg text-sm">
-            ⚠️ This game was tracked live, point by point. If you save an edited score, the point-by-point data of
-            this game is discarded.
+            ⚠️ This game was tracked live, point by point. If you save a changed score, the point-by-point data of
+            this game is discarded. A change to only the table sides keeps it.
           </div>
         )}
         <div className="flex space-x-3">

--- a/frontend/src/pages/edit-game-score.tsx
+++ b/frontend/src/pages/edit-game-score.tsx
@@ -20,14 +20,15 @@ export const EditGameSore: React.FC = () => {
   const [winnerSets, setWinnerSets] = useState(game?.score?.setsWon.gameWinner ?? 0);
   const [loserSets, setLoserSets] = useState(game?.score?.setsWon.gameLoser ?? 0);
   // Player 1 of the form is the game winner, so the winner's side decodes
-  // against slot 1.
-  const [setPoints, setSetPoints] = useState<ManualSetPoints[]>(
-    game?.score?.setPoints?.map(({ gameWinner, gameLoser, gameWinnerSide }) => ({
-      player1: gameWinner,
-      player2: gameLoser,
-      badSide: badSideOfGameWinnerSide(gameWinnerSide, 1),
-    })) ?? [],
-  );
+  // against slot 1. The sides list covers every set, with or without points.
+  const [setPoints, setSetPoints] = useState<ManualSetPoints[]>(() => {
+    const totalSets = (game?.score?.setsWon.gameWinner ?? 0) + (game?.score?.setsWon.gameLoser ?? 0);
+    return Array.from({ length: totalSets }, (_, index) => ({
+      player1: game?.score?.setPoints?.[index]?.gameWinner,
+      player2: game?.score?.setPoints?.[index]?.gameLoser,
+      badSide: badSideOfGameWinnerSide(game?.score?.gameWinnerSides?.[index], 1),
+    }));
+  });
   const [validationError, setValidationError] = useState("");
 
   const invalidScore = (winnerSets === loserSets && winnerSets > 0) || loserSets > winnerSets;
@@ -36,10 +37,9 @@ export const EditGameSore: React.FC = () => {
     loserSets === game?.score?.setsWon.gameLoser &&
     setPoints.every(({ player1, player2, badSide }, index) => {
       return (
-        game.score?.setPoints &&
-        game.score.setPoints[index].gameWinner === player1 &&
-        game.score.setPoints[index].gameLoser === player2 &&
-        game.score.setPoints[index].gameWinnerSide === gameWinnerSideOfBadSide(badSide, 1)
+        game.score?.setPoints?.[index]?.gameWinner === player1 &&
+        game.score?.setPoints?.[index]?.gameLoser === player2 &&
+        (game.score?.gameWinnerSides?.[index] ?? null) === gameWinnerSideOfBadSide(badSide, 1)
       );
     });
 
@@ -59,11 +59,8 @@ export const EditGameSore: React.FC = () => {
       return;
     }
 
-    // The side of a set is stored on its set points, so it cannot travel alone.
-    if (setPointsAreSet === false && setPoints.some((set) => set.badSide !== null)) {
-      setValidationError("The table sides need the individual set points. Add the points or remove the sides.");
-      return;
-    }
+    // The sides are independent of the points: only the sets won are needed.
+    const sidesAreSet = setPoints.some((set) => set.badSide !== null);
 
     const gameScoreEvent: GameScore = {
       type: EventTypeEnum.GAME_SCORE,
@@ -72,12 +69,9 @@ export const EditGameSore: React.FC = () => {
       data: {
         setsWon: { gameWinner: winnerSets, gameLoser: loserSets },
         setPoints: setPointsAreSet
-          ? setPoints.map((set) => ({
-              gameWinner: set.player1!,
-              gameLoser: set.player2!,
-              gameWinnerSide: gameWinnerSideOfBadSide(set.badSide, 1),
-            }))
+          ? setPoints.map((set) => ({ gameWinner: set.player1!, gameLoser: set.player2! }))
           : undefined,
+        gameWinnerSides: sidesAreSet ? setPoints.map((set) => gameWinnerSideOfBadSide(set.badSide, 1)) : undefined,
       },
     };
 

--- a/frontend/src/pages/edit-game-score.tsx
+++ b/frontend/src/pages/edit-game-score.tsx
@@ -2,8 +2,9 @@ import { useEffect, useState } from "react";
 import { classNames } from "../common/class-names";
 import { useTennisParams } from "../hooks/use-tennis-params";
 import { useEventDbContext } from "../wrappers/event-db-context";
-import { StepAddScore } from "./add-game/step-add-score";
+import { ManualSetPoints, StepAddScore } from "./add-game/step-add-score";
 import { EventTypeEnum, GameScore } from "../client/client-db/event-store/event-types";
+import { badSideOfGameWinnerSide, gameWinnerSideOfBadSide } from "../common/table-sides";
 import { useEventMutation } from "../hooks/use-event-mutation";
 import { queryClient } from "../common/query-client";
 import { useNavigate } from "react-router-dom";
@@ -18,8 +19,14 @@ export const EditGameSore: React.FC = () => {
 
   const [winnerSets, setWinnerSets] = useState(game?.score?.setsWon.gameWinner ?? 0);
   const [loserSets, setLoserSets] = useState(game?.score?.setsWon.gameLoser ?? 0);
-  const [setPoints, setSetPoints] = useState<{ player1?: number; player2?: number }[]>(
-    game?.score?.setPoints?.map(({ gameWinner, gameLoser }) => ({ player1: gameWinner, player2: gameLoser })) ?? [],
+  // Player 1 of the form is the game winner, so the winner's side decodes
+  // against slot 1.
+  const [setPoints, setSetPoints] = useState<ManualSetPoints[]>(
+    game?.score?.setPoints?.map(({ gameWinner, gameLoser, gameWinnerSide }) => ({
+      player1: gameWinner,
+      player2: gameLoser,
+      badSide: badSideOfGameWinnerSide(gameWinnerSide, 1),
+    })) ?? [],
   );
   const [validationError, setValidationError] = useState("");
 
@@ -27,11 +34,12 @@ export const EditGameSore: React.FC = () => {
   const unchangedScore =
     winnerSets === game?.score?.setsWon.gameWinner &&
     loserSets === game?.score?.setsWon.gameLoser &&
-    setPoints.every(({ player1, player2 }, index) => {
+    setPoints.every(({ player1, player2, badSide }, index) => {
       return (
         game.score?.setPoints &&
         game.score.setPoints[index].gameWinner === player1 &&
-        game.score.setPoints[index].gameLoser === player2
+        game.score.setPoints[index].gameLoser === player2 &&
+        game.score.setPoints[index].gameWinnerSide === gameWinnerSideOfBadSide(badSide, 1)
       );
     });
 
@@ -51,6 +59,12 @@ export const EditGameSore: React.FC = () => {
       return;
     }
 
+    // The side of a set is stored on its set points, so it cannot travel alone.
+    if (setPointsAreSet === false && setPoints.some((set) => set.badSide !== null)) {
+      setValidationError("The table sides need the individual set points. Add the points or remove the sides.");
+      return;
+    }
+
     const gameScoreEvent: GameScore = {
       type: EventTypeEnum.GAME_SCORE,
       time: now,
@@ -58,7 +72,11 @@ export const EditGameSore: React.FC = () => {
       data: {
         setsWon: { gameWinner: winnerSets, gameLoser: loserSets },
         setPoints: setPointsAreSet
-          ? setPoints.map((set) => ({ gameWinner: set.player1!, gameLoser: set.player2! }))
+          ? setPoints.map((set) => ({
+              gameWinner: set.player1!,
+              gameLoser: set.player2!,
+              gameWinnerSide: gameWinnerSideOfBadSide(set.badSide, 1),
+            }))
           : undefined,
       },
     };
@@ -89,9 +107,10 @@ export const EditGameSore: React.FC = () => {
     } else if (setPoints.length < totalSets) {
       // Set added
       const setsAdded = totalSets - setPoints.length;
-      const newSets = new Array<{ player1?: number; player2?: number }>(setsAdded).fill({
+      const newSets = new Array<ManualSetPoints>(setsAdded).fill({
         player1: undefined,
         player2: undefined,
+        badSide: null,
       });
       setSetPoints((prev) => [...prev, ...newSets]);
     } else if (setPoints.length > totalSets) {

--- a/frontend/src/pages/game/game-details-page.tsx
+++ b/frontend/src/pages/game/game-details-page.tsx
@@ -188,18 +188,19 @@ export const GameDetailsPage: React.FC = () => {
               <SetBreakdownTable
                 tracking={game.score.tracking}
                 pointSequences={game.score.pointSequences}
-                setPoints={game.score.setPoints}
+                gameWinnerSides={game.score.gameWinnerSides}
                 winnerName={context.playerName(game.winner)}
                 loserName={context.playerName(game.loser)}
               />
             </div>
           )}
 
-          {/* A game entered by hand can still record the sides of the table
-              next to its set points */}
-          {!game.score?.tracking && game.score?.setPoints && (
+          {/* A game entered by hand can still record the sides of the table,
+              with or without the points of each set */}
+          {!game.score?.tracking && game.score?.gameWinnerSides && (
             <div className="px-2 xs:px-4 pb-3">
               <SetSidesTable
+                gameWinnerSides={game.score.gameWinnerSides}
                 setPoints={game.score.setPoints}
                 winnerName={context.playerName(game.winner)}
                 loserName={context.playerName(game.loser)}

--- a/frontend/src/pages/game/game-details-page.tsx
+++ b/frontend/src/pages/game/game-details-page.tsx
@@ -11,7 +11,7 @@ import { Fraction } from "../../client/client-db/predictions";
 import { WinPercentGraph } from "../add-game/win-percent-graph";
 import { replayWinPercentHistory } from "./game-win-replay";
 import { pointSituations, setProgressions } from "./game-tracking-stats";
-import { SetBreakdownTable, TrackingStats } from "./game-tracking-panels";
+import { SetBreakdownTable, SetSidesTable, TrackingStats } from "./game-tracking-panels";
 import { SetScoreGraphs } from "./set-score-graphs";
 import { PointSituationRadar } from "./point-situation-radar";
 
@@ -188,6 +188,19 @@ export const GameDetailsPage: React.FC = () => {
               <SetBreakdownTable
                 tracking={game.score.tracking}
                 pointSequences={game.score.pointSequences}
+                setPoints={game.score.setPoints}
+                winnerName={context.playerName(game.winner)}
+                loserName={context.playerName(game.loser)}
+              />
+            </div>
+          )}
+
+          {/* A game entered by hand can still record the sides of the table
+              next to its set points */}
+          {!game.score?.tracking && game.score?.setPoints && (
+            <div className="px-2 xs:px-4 pb-3">
+              <SetSidesTable
+                setPoints={game.score.setPoints}
                 winnerName={context.playerName(game.winner)}
                 loserName={context.playerName(game.loser)}
               />

--- a/frontend/src/pages/game/game-tracking-panels.tsx
+++ b/frontend/src/pages/game/game-tracking-panels.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { GameTracking } from "../../client/client-db/event-store/event-types";
+import { GameScore, GameTracking } from "../../client/client-db/event-store/event-types";
 import { clockTimeString } from "../../common/date-utils";
 import { badSideName } from "../../common/table-sides";
 import { fmtNum } from "../../common/number-utils";
@@ -64,10 +64,11 @@ export const TrackingStats: React.FC<{
 export const SetBreakdownTable: React.FC<{
   tracking: GameTracking;
   pointSequences: string[];
+  setPoints: GameScore["data"]["setPoints"];
   winnerName: string;
   loserName: string;
-}> = ({ tracking, pointSequences, winnerName, loserName }) => {
-  const sets = setBreakdown(pointSequences, tracking);
+}> = ({ tracking, pointSequences, setPoints, winnerName, loserName }) => {
+  const sets = setBreakdown(pointSequences, tracking, setPoints);
   if (sets.length === 0) return null;
   // Games tracked before the sides were recorded have no side column at all.
   const hasSides = sets.some((set) => set.winnerSide !== undefined);
@@ -117,6 +118,51 @@ export const SetBreakdownTable: React.FC<{
         The score is from the game winner's side. The break is the time before the first point of the set — for set 1,
         the time from the start of tracking.
         {hasSides && " The bad side is the worse side of the table, and \"Equal\" means the 2 sides are equally good."}
+      </p>
+    </div>
+  );
+};
+
+/**
+ * Every set of a game that records the sides but has no tracking data: the
+ * score and who had the bad side of the table. A game entered by hand can
+ * record the sides next to its set points, and this is all it knows per set.
+ */
+export const SetSidesTable: React.FC<{
+  setPoints: NonNullable<GameScore["data"]["setPoints"]>;
+  winnerName: string;
+  loserName: string;
+}> = ({ setPoints, winnerName, loserName }) => {
+  if (setPoints.every((set) => set.gameWinnerSide === undefined)) return null;
+
+  return (
+    <div className="rounded-lg bg-secondary-background text-secondary-text p-3 overflow-x-auto">
+      <h2 className="text-sm font-semibold mb-2">Set by set</h2>
+      <table className="w-full text-xs md:text-sm">
+        <thead className="opacity-70">
+          <tr className="text-left">
+            <th className="font-normal pb-1 pr-2">Set</th>
+            <th className="font-normal pb-1 pr-2">Score</th>
+            <th className="font-normal pb-1 whitespace-nowrap">Bad side</th>
+          </tr>
+        </thead>
+        <tbody>
+          {setPoints.map((set, index) => (
+            <tr key={index} className="border-t border-secondary-text/20">
+              <td className="py-1.5 pr-2">{index + 1}</td>
+              <td className="py-1.5 pr-2 font-semibold whitespace-nowrap">
+                {set.gameWinner}-{set.gameLoser} {set.gameWinner > set.gameLoser ? "🏆" : ""}
+              </td>
+              <td className="py-1.5 truncate max-w-[8rem]">
+                {set.gameWinnerSide ? badSideName(set.gameWinnerSide, winnerName, loserName) : "–"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p className="mt-2 text-xs opacity-70">
+        The score is from the game winner's side. The bad side is the worse side of the table, and "Equal" means the 2
+        sides are equally good.
       </p>
     </div>
   );

--- a/frontend/src/pages/game/game-tracking-panels.tsx
+++ b/frontend/src/pages/game/game-tracking-panels.tsx
@@ -64,11 +64,11 @@ export const TrackingStats: React.FC<{
 export const SetBreakdownTable: React.FC<{
   tracking: GameTracking;
   pointSequences: string[];
-  setPoints: GameScore["data"]["setPoints"];
+  gameWinnerSides: GameScore["data"]["gameWinnerSides"];
   winnerName: string;
   loserName: string;
-}> = ({ tracking, pointSequences, setPoints, winnerName, loserName }) => {
-  const sets = setBreakdown(pointSequences, tracking, setPoints);
+}> = ({ tracking, pointSequences, gameWinnerSides, winnerName, loserName }) => {
+  const sets = setBreakdown(pointSequences, tracking, gameWinnerSides);
   if (sets.length === 0) return null;
   // Games tracked before the sides were recorded have no side column at all.
   const hasSides = sets.some((set) => set.winnerSide !== undefined);
@@ -124,16 +124,18 @@ export const SetBreakdownTable: React.FC<{
 };
 
 /**
- * Every set of a game that records the sides but has no tracking data: the
- * score and who had the bad side of the table. A game entered by hand can
- * record the sides next to its set points, and this is all it knows per set.
+ * Every set of a game that records the sides but has no tracking data: who had
+ * the bad side of the table, and the score of the set when the game records
+ * its set points. A game entered by hand can record the sides with only the
+ * sets won, so the score column is there only when there is a score to show.
  */
 export const SetSidesTable: React.FC<{
-  setPoints: NonNullable<GameScore["data"]["setPoints"]>;
+  gameWinnerSides: NonNullable<GameScore["data"]["gameWinnerSides"]>;
+  setPoints: GameScore["data"]["setPoints"];
   winnerName: string;
   loserName: string;
-}> = ({ setPoints, winnerName, loserName }) => {
-  if (setPoints.every((set) => set.gameWinnerSide === undefined)) return null;
+}> = ({ gameWinnerSides, setPoints, winnerName, loserName }) => {
+  const hasPoints = setPoints !== undefined;
 
   return (
     <div className="rounded-lg bg-secondary-background text-secondary-text p-3 overflow-x-auto">
@@ -142,27 +144,33 @@ export const SetSidesTable: React.FC<{
         <thead className="opacity-70">
           <tr className="text-left">
             <th className="font-normal pb-1 pr-2">Set</th>
-            <th className="font-normal pb-1 pr-2">Score</th>
+            {hasPoints && <th className="font-normal pb-1 pr-2">Score</th>}
             <th className="font-normal pb-1 whitespace-nowrap">Bad side</th>
           </tr>
         </thead>
         <tbody>
-          {setPoints.map((set, index) => (
+          {gameWinnerSides.map((side, index) => (
             <tr key={index} className="border-t border-secondary-text/20">
               <td className="py-1.5 pr-2">{index + 1}</td>
-              <td className="py-1.5 pr-2 font-semibold whitespace-nowrap">
-                {set.gameWinner}-{set.gameLoser} {set.gameWinner > set.gameLoser ? "🏆" : ""}
-              </td>
+              {hasPoints && (
+                <td className="py-1.5 pr-2 font-semibold whitespace-nowrap">
+                  {setPoints[index]
+                    ? `${setPoints[index].gameWinner}-${setPoints[index].gameLoser} ${
+                        setPoints[index].gameWinner > setPoints[index].gameLoser ? "🏆" : ""
+                      }`
+                    : "–"}
+                </td>
+              )}
               <td className="py-1.5 truncate max-w-[8rem]">
-                {set.gameWinnerSide ? badSideName(set.gameWinnerSide, winnerName, loserName) : "–"}
+                {side ? badSideName(side, winnerName, loserName) : "–"}
               </td>
             </tr>
           ))}
         </tbody>
       </table>
       <p className="mt-2 text-xs opacity-70">
-        The score is from the game winner's side. The bad side is the worse side of the table, and "Equal" means the 2
-        sides are equally good.
+        {hasPoints && "The score is from the game winner's side. "}
+        The bad side is the worse side of the table, and "Equal" means the 2 sides are equally good.
       </p>
     </div>
   );

--- a/frontend/src/pages/game/game-tracking-stats.test.ts
+++ b/frontend/src/pages/game/game-tracking-stats.test.ts
@@ -51,13 +51,9 @@ describe("gameTimingStats", () => {
 describe("setBreakdown", () => {
   // 4 points in set 1, 4 in set 2, matching the deltas of the tracking above.
   const pointSequences = ["WWLW", "LWLL"];
-  const setPoints = [
-    { gameWinner: 3, gameLoser: 1 },
-    { gameWinner: 1, gameLoser: 3 },
-  ];
 
   it("reads the score and the winner of each set from the winner's side", () => {
-    const sets = setBreakdown(pointSequences, tracking(), setPoints);
+    const sets = setBreakdown(pointSequences, tracking(), undefined);
     expect(sets.map((set) => set.points)).toEqual([
       { winner: 3, loser: 1 },
       { winner: 1, loser: 3 },
@@ -66,7 +62,7 @@ describe("setBreakdown", () => {
   });
 
   it("splits the first delta of a set off as the break before it", () => {
-    const sets = setBreakdown(pointSequences, tracking(), setPoints);
+    const sets = setBreakdown(pointSequences, tracking(), undefined);
     // Set 1 starts 100 tenths in and runs 50 + 70 + 60 tenths.
     expect(sets[0]).toMatchObject({ breakBeforeMs: 10_000, durationMs: 18_000, longestPointGapMs: 7_000 });
     // Set 2 starts after a 600 tenth break and runs 55 + 200 + 45 tenths.
@@ -74,27 +70,27 @@ describe("setBreakdown", () => {
   });
 
   it("reads the first server of each set", () => {
-    expect(setBreakdown(pointSequences, tracking(), setPoints).map((set) => set.firstServer)).toEqual(["W", "L"]);
+    expect(setBreakdown(pointSequences, tracking(), undefined).map((set) => set.firstServer)).toEqual(["W", "L"]);
   });
 
-  it("reads the table side of each set from its setPoints entry", () => {
-    const sided = [
-      { ...setPoints[0], gameWinnerSide: "B" as const },
-      { ...setPoints[1], gameWinnerSide: "N" as const },
-    ];
-    const sets = setBreakdown(pointSequences, tracking(), sided);
+  it("reads the table side of each set from the gameWinnerSides list", () => {
+    const sets = setBreakdown(pointSequences, tracking(), ["B", "N"]);
     expect(sets.map((set) => set.winnerSide)).toEqual(["B", "N"]);
   });
 
-  it("gives no table side for a game that does not record the sides", () => {
-    expect(setBreakdown(pointSequences, tracking(), setPoints).map((set) => set.winnerSide)).toEqual([
+  it("gives no table side for a game or a set that does not record the sides", () => {
+    expect(setBreakdown(pointSequences, tracking(), undefined).map((set) => set.winnerSide)).toEqual([
       undefined,
+      undefined,
+    ]);
+    expect(setBreakdown(pointSequences, tracking(), ["B", null]).map((set) => set.winnerSide)).toEqual([
+      "B",
       undefined,
     ]);
   });
 
   it("returns no rows for a game with no sets", () => {
-    expect(setBreakdown([], tracking({ pointDeltas: [], firstServers: "" }), [])).toEqual([]);
+    expect(setBreakdown([], tracking({ pointDeltas: [], firstServers: "" }), undefined)).toEqual([]);
   });
 });
 

--- a/frontend/src/pages/game/game-tracking-stats.test.ts
+++ b/frontend/src/pages/game/game-tracking-stats.test.ts
@@ -51,9 +51,13 @@ describe("gameTimingStats", () => {
 describe("setBreakdown", () => {
   // 4 points in set 1, 4 in set 2, matching the deltas of the tracking above.
   const pointSequences = ["WWLW", "LWLL"];
+  const setPoints = [
+    { gameWinner: 3, gameLoser: 1 },
+    { gameWinner: 1, gameLoser: 3 },
+  ];
 
   it("reads the score and the winner of each set from the winner's side", () => {
-    const sets = setBreakdown(pointSequences, tracking());
+    const sets = setBreakdown(pointSequences, tracking(), setPoints);
     expect(sets.map((set) => set.points)).toEqual([
       { winner: 3, loser: 1 },
       { winner: 1, loser: 3 },
@@ -62,7 +66,7 @@ describe("setBreakdown", () => {
   });
 
   it("splits the first delta of a set off as the break before it", () => {
-    const sets = setBreakdown(pointSequences, tracking());
+    const sets = setBreakdown(pointSequences, tracking(), setPoints);
     // Set 1 starts 100 tenths in and runs 50 + 70 + 60 tenths.
     expect(sets[0]).toMatchObject({ breakBeforeMs: 10_000, durationMs: 18_000, longestPointGapMs: 7_000 });
     // Set 2 starts after a 600 tenth break and runs 55 + 200 + 45 tenths.
@@ -70,20 +74,27 @@ describe("setBreakdown", () => {
   });
 
   it("reads the first server of each set", () => {
-    expect(setBreakdown(pointSequences, tracking()).map((set) => set.firstServer)).toEqual(["W", "L"]);
+    expect(setBreakdown(pointSequences, tracking(), setPoints).map((set) => set.firstServer)).toEqual(["W", "L"]);
   });
 
-  it("reads the table side of each set", () => {
-    const sets = setBreakdown(pointSequences, tracking({ winnerSides: "BN" }));
+  it("reads the table side of each set from its setPoints entry", () => {
+    const sided = [
+      { ...setPoints[0], gameWinnerSide: "B" as const },
+      { ...setPoints[1], gameWinnerSide: "N" as const },
+    ];
+    const sets = setBreakdown(pointSequences, tracking(), sided);
     expect(sets.map((set) => set.winnerSide)).toEqual(["B", "N"]);
   });
 
   it("gives no table side for a game that does not record the sides", () => {
-    expect(setBreakdown(pointSequences, tracking()).map((set) => set.winnerSide)).toEqual([undefined, undefined]);
+    expect(setBreakdown(pointSequences, tracking(), setPoints).map((set) => set.winnerSide)).toEqual([
+      undefined,
+      undefined,
+    ]);
   });
 
   it("returns no rows for a game with no sets", () => {
-    expect(setBreakdown([], tracking({ pointDeltas: [], firstServers: "" }))).toEqual([]);
+    expect(setBreakdown([], tracking({ pointDeltas: [], firstServers: "" }), [])).toEqual([]);
   });
 });
 

--- a/frontend/src/pages/game/game-tracking-stats.ts
+++ b/frontend/src/pages/game/game-tracking-stats.ts
@@ -6,9 +6,9 @@
  * previous point, so anything absolute is rebuilt by summing them.
  */
 
-import { GameTracking } from "../../client/client-db/event-store/event-types";
+import { GameScore, GameTracking } from "../../client/client-db/event-store/event-types";
 import { getServeInfo, Server } from "../../common/serve-tracker";
-import { WinnerSide, winnerSideOfSet } from "../../common/table-sides";
+import { WinnerSide } from "../../common/table-sides";
 
 const TENTH_MS = 100;
 
@@ -68,9 +68,14 @@ export type SetBreakdown = {
 /**
  * One row per set: the score, who served it first, and how long it took. The
  * first delta of a set is the break before it, so it is the break time and not
- * part of the duration of the set.
+ * part of the duration of the set. The side of each set comes from its
+ * `setPoints` entry, where the projector puts it for old and new games alike.
  */
-export function setBreakdown(pointSequences: string[], tracking: GameTracking): SetBreakdown[] {
+export function setBreakdown(
+  pointSequences: string[],
+  tracking: GameTracking,
+  setPoints: GameScore["data"]["setPoints"],
+): SetBreakdown[] {
   return pointSequences.map((sequence, index) => {
     const deltas = tracking.pointDeltas[index] ?? [];
     const gaps = deltas.slice(1);
@@ -80,7 +85,7 @@ export function setBreakdown(pointSequences: string[], tracking: GameTracking): 
       points: { winner: winnerPoints, loser: sequence.length - winnerPoints },
       wonByGameWinner: winnerPoints > sequence.length - winnerPoints,
       firstServer: tracking.firstServers[index] === "W" ? "W" : "L",
-      winnerSide: winnerSideOfSet(tracking.winnerSides, index),
+      winnerSide: setPoints?.[index]?.gameWinnerSide,
       durationMs: gaps.reduce((sum, gap) => sum + gap, 0) * TENTH_MS,
       breakBeforeMs: (deltas[0] ?? 0) * TENTH_MS,
       longestPointGapMs: gaps.length === 0 ? 0 : Math.max(...gaps) * TENTH_MS,

--- a/frontend/src/pages/game/game-tracking-stats.ts
+++ b/frontend/src/pages/game/game-tracking-stats.ts
@@ -69,7 +69,7 @@ export type SetBreakdown = {
  * One row per set: the score, who served it first, and how long it took. The
  * first delta of a set is the break before it, so it is the break time and not
  * part of the duration of the set. The side of each set comes from its
- * `setPoints` entry, where the projector puts it for old and new games alike.
+ * `setPoints` entry.
  */
 export function setBreakdown(
   pointSequences: string[],

--- a/frontend/src/pages/game/game-tracking-stats.ts
+++ b/frontend/src/pages/game/game-tracking-stats.ts
@@ -68,13 +68,13 @@ export type SetBreakdown = {
 /**
  * One row per set: the score, who served it first, and how long it took. The
  * first delta of a set is the break before it, so it is the break time and not
- * part of the duration of the set. The side of each set comes from its
- * `setPoints` entry.
+ * part of the duration of the set. The side of each set comes from the
+ * `gameWinnerSides` list of the score.
  */
 export function setBreakdown(
   pointSequences: string[],
   tracking: GameTracking,
-  setPoints: GameScore["data"]["setPoints"],
+  gameWinnerSides: GameScore["data"]["gameWinnerSides"],
 ): SetBreakdown[] {
   return pointSequences.map((sequence, index) => {
     const deltas = tracking.pointDeltas[index] ?? [];
@@ -85,7 +85,7 @@ export function setBreakdown(
       points: { winner: winnerPoints, loser: sequence.length - winnerPoints },
       wonByGameWinner: winnerPoints > sequence.length - winnerPoints,
       firstServer: tracking.firstServers[index] === "W" ? "W" : "L",
-      winnerSide: setPoints?.[index]?.gameWinnerSide,
+      winnerSide: gameWinnerSides?.[index] ?? undefined,
       durationMs: gaps.reduce((sum, gap) => sum + gap, 0) * TENTH_MS,
       breakBeforeMs: (deltas[0] ?? 0) * TENTH_MS,
       longestPointGapMs: gaps.length === 0 ? 0 : Math.max(...gaps) * TENTH_MS,

--- a/frontend/src/pages/live-game/live-game-admin-page.tsx
+++ b/frontend/src/pages/live-game/live-game-admin-page.tsx
@@ -26,7 +26,7 @@ import { LiveGamePredictionCard } from "./live-game-prediction-card";
 import ConfettiExplosion from "react-confetti-explosion";
 import { Server } from "../../common/serve-tracker";
 import { ServeTrackerDisplay } from "../../common/serve-tracker-display";
-import { alignBadSides, BadSide, badSideLabel, nextSetBadSide } from "../../common/table-sides";
+import { alignBadSides, BadSide, badSideLabel, gameWinnerSideOfBadSide, nextSetBadSide } from "../../common/table-sides";
 import { TableSideDisplay } from "../../common/table-sides-display";
 import { appendPoint, removeLastPoint, toEventTrackingData, trackingNow } from "../../common/point-sequences";
 
@@ -262,7 +262,6 @@ export const LiveGameAdminPage: React.FC = () => {
         pointTimes: localState!.completedSetPointTimes[index] ?? [],
       })),
       firstServers: localState!.completedSetFirstServers,
-      badSides: localState!.completedSetBadSides,
       player1IsGameWinner: player1Won,
       source: "live-game",
       startedAt: localState!.startedAt,
@@ -278,9 +277,13 @@ export const LiveGameAdminPage: React.FC = () => {
         setsWon: { gameWinner: winnerSets, gameLoser: loserSets },
         setPoints:
           localState!.completedSets.length > 0
-            ? localState!.completedSets.map((set) => ({
+            ? localState!.completedSets.map((set, index) => ({
                 gameWinner: player1Won ? set.player1 : set.player2,
                 gameLoser: player1Won ? set.player2 : set.player1,
+                gameWinnerSide: gameWinnerSideOfBadSide(
+                  localState!.completedSetBadSides[index] ?? null,
+                  player1Won ? 1 : 2,
+                ),
               }))
             : undefined,
         pointSequences: trackingData?.pointSequences,

--- a/frontend/src/pages/live-game/live-game-admin-page.tsx
+++ b/frontend/src/pages/live-game/live-game-admin-page.tsx
@@ -277,15 +277,16 @@ export const LiveGameAdminPage: React.FC = () => {
         setsWon: { gameWinner: winnerSets, gameLoser: loserSets },
         setPoints:
           localState!.completedSets.length > 0
-            ? localState!.completedSets.map((set, index) => ({
+            ? localState!.completedSets.map((set) => ({
                 gameWinner: player1Won ? set.player1 : set.player2,
                 gameLoser: player1Won ? set.player2 : set.player1,
-                gameWinnerSide: gameWinnerSideOfBadSide(
-                  localState!.completedSetBadSides[index] ?? null,
-                  player1Won ? 1 : 2,
-                ),
               }))
             : undefined,
+        gameWinnerSides: localState!.completedSetBadSides.some((side) => side !== null)
+          ? localState!.completedSets.map((_, index) =>
+              gameWinnerSideOfBadSide(localState!.completedSetBadSides[index] ?? null, player1Won ? 1 : 2),
+            )
+          : undefined,
         pointSequences: trackingData?.pointSequences,
         tracking: trackingData?.tracking,
       },

--- a/frontend/src/pages/statistics/games-tab.tsx
+++ b/frontend/src/pages/statistics/games-tab.tsx
@@ -323,6 +323,56 @@ export const GamesTab: React.FC<{ range: TimeRange; setRange: (range: TimeRange)
               </div>
             )}
           </ContentCard>
+
+          <ContentCard
+            title="The bad side of the table"
+            description="A game that records its set points can record which player had the bad side of the table in each set, or that the 2 sides were equal. Every set with a worse side has one player on it, so 50% means the side costs nothing."
+          >
+            {tableSides === undefined ? (
+              <NotEnoughGames what="games with sides" />
+            ) : (
+              <div className="flex flex-col gap-3">
+                {tableSides.setsWonOnTheBadSide !== undefined && (
+                  <StackedShareBar
+                    segments={[
+                      {
+                        label: "The bad side wins the set",
+                        share: tableSides.setsWonOnTheBadSide,
+                        color: SPREAD_COLORS[0],
+                      },
+                      {
+                        label: "The good side wins the set",
+                        share: 100 - tableSides.setsWonOnTheBadSide,
+                        color: SPREAD_COLORS[1],
+                      },
+                    ]}
+                  />
+                )}
+                <StatTileRow>
+                  <StatTile
+                    label="Points won on the bad side"
+                    value={tableSides.pointsWonOnTheBadSide === undefined ? "–" : percentLabel(tableSides.pointsWonOnTheBadSide)}
+                    note="of the points of the sets with a worse side"
+                  />
+                  <StatTile
+                    label="More sets on the bad side, and the game"
+                    value={tableSides.wonWithMoreBadSideSets === undefined ? "–" : percentLabel(tableSides.wonWithMoreBadSideSets)}
+                    note="of the games where one player had the bad side more often, that player won"
+                  />
+                  <StatTile
+                    label="Sets with equal sides"
+                    value={percentLabel(tableSides.neutralSets)}
+                    note="of the sets with recorded sides"
+                  />
+                  <StatTile
+                    label="Games that record the sides"
+                    value={percentLabel(tableSides.sidesRecorded)}
+                    note="of the games with set points in this period"
+                  />
+                </StatTileRow>
+              </div>
+            )}
+          </ContentCard>
         </DetailLevelSection>
 
         <DetailLevelSection
@@ -388,56 +438,6 @@ export const GamesTab: React.FC<{ range: TimeRange; setRange: (range: TimeRange)
                   note="points undone while tracking, on average"
                 />
               </StatTileRow>
-            )}
-          </ContentCard>
-
-          <ContentCard
-            title="The bad side of the table"
-            description="A tracked game can record which player had the bad side of the table in each set, or that the 2 sides were equal. Every set with a worse side has one player on it, so 50% means the side costs nothing."
-          >
-            {tableSides === undefined ? (
-              <NotEnoughGames what="tracked games with sides" />
-            ) : (
-              <div className="flex flex-col gap-3">
-                {tableSides.setsWonOnTheBadSide !== undefined && (
-                  <StackedShareBar
-                    segments={[
-                      {
-                        label: "The bad side wins the set",
-                        share: tableSides.setsWonOnTheBadSide,
-                        color: SPREAD_COLORS[0],
-                      },
-                      {
-                        label: "The good side wins the set",
-                        share: 100 - tableSides.setsWonOnTheBadSide,
-                        color: SPREAD_COLORS[1],
-                      },
-                    ]}
-                  />
-                )}
-                <StatTileRow>
-                  <StatTile
-                    label="Points won on the bad side"
-                    value={tableSides.pointsWonOnTheBadSide === undefined ? "–" : percentLabel(tableSides.pointsWonOnTheBadSide)}
-                    note="of the points of the sets with a worse side"
-                  />
-                  <StatTile
-                    label="More sets on the bad side, and the game"
-                    value={tableSides.wonWithMoreBadSideSets === undefined ? "–" : percentLabel(tableSides.wonWithMoreBadSideSets)}
-                    note="of the games where one player had the bad side more often, that player won"
-                  />
-                  <StatTile
-                    label="Sets with equal sides"
-                    value={percentLabel(tableSides.neutralSets)}
-                    note="of the sets with recorded sides"
-                  />
-                  <StatTile
-                    label="Games that record the sides"
-                    value={percentLabel(tableSides.sidesRecorded)}
-                    note="of the tracked games in this period"
-                  />
-                </StatTileRow>
-              </div>
             )}
           </ContentCard>
         </DetailLevelSection>

--- a/frontend/src/pages/statistics/games-tab.tsx
+++ b/frontend/src/pages/statistics/games-tab.tsx
@@ -233,6 +233,56 @@ export const GamesTab: React.FC<{ range: TimeRange; setRange: (range: TimeRange)
               </div>
             )}
           </ContentCard>
+
+          <ContentCard
+            title="The bad side of the table"
+            description="A game with a score can record which player had the bad side of the table in each set, or that the 2 sides were equal. Every set with a worse side has one player on it, so 50% means the side costs nothing."
+          >
+            {tableSides === undefined ? (
+              <NotEnoughGames what="games with sides" />
+            ) : (
+              <div className="flex flex-col gap-3">
+                {tableSides.setsWonOnTheBadSide !== undefined && (
+                  <StackedShareBar
+                    segments={[
+                      {
+                        label: "The bad side wins the set",
+                        share: tableSides.setsWonOnTheBadSide,
+                        color: SPREAD_COLORS[0],
+                      },
+                      {
+                        label: "The good side wins the set",
+                        share: 100 - tableSides.setsWonOnTheBadSide,
+                        color: SPREAD_COLORS[1],
+                      },
+                    ]}
+                  />
+                )}
+                <StatTileRow>
+                  <StatTile
+                    label="Points won on the bad side"
+                    value={tableSides.pointsWonOnTheBadSide === undefined ? "–" : percentLabel(tableSides.pointsWonOnTheBadSide)}
+                    note="of the points of the sets with a worse side"
+                  />
+                  <StatTile
+                    label="More sets on the bad side, and the game"
+                    value={tableSides.wonWithMoreBadSideSets === undefined ? "–" : percentLabel(tableSides.wonWithMoreBadSideSets)}
+                    note="of the games where one player had the bad side more often, that player won"
+                  />
+                  <StatTile
+                    label="Sets with equal sides"
+                    value={percentLabel(tableSides.neutralSets)}
+                    note="of the sets with recorded sides"
+                  />
+                  <StatTile
+                    label="Games that record the sides"
+                    value={percentLabel(tableSides.sidesRecorded)}
+                    note="of the games with a score in this period"
+                  />
+                </StatTileRow>
+              </div>
+            )}
+          </ContentCard>
         </DetailLevelSection>
 
         <DetailLevelSection
@@ -320,56 +370,6 @@ export const GamesTab: React.FC<{ range: TimeRange; setRange: (range: TimeRange)
                 <p className="text-xs text-primary-text/60 text-center">
                   The share of the games at each total of points, with the median marked.
                 </p>
-              </div>
-            )}
-          </ContentCard>
-
-          <ContentCard
-            title="The bad side of the table"
-            description="A game that records its set points can record which player had the bad side of the table in each set, or that the 2 sides were equal. Every set with a worse side has one player on it, so 50% means the side costs nothing."
-          >
-            {tableSides === undefined ? (
-              <NotEnoughGames what="games with sides" />
-            ) : (
-              <div className="flex flex-col gap-3">
-                {tableSides.setsWonOnTheBadSide !== undefined && (
-                  <StackedShareBar
-                    segments={[
-                      {
-                        label: "The bad side wins the set",
-                        share: tableSides.setsWonOnTheBadSide,
-                        color: SPREAD_COLORS[0],
-                      },
-                      {
-                        label: "The good side wins the set",
-                        share: 100 - tableSides.setsWonOnTheBadSide,
-                        color: SPREAD_COLORS[1],
-                      },
-                    ]}
-                  />
-                )}
-                <StatTileRow>
-                  <StatTile
-                    label="Points won on the bad side"
-                    value={tableSides.pointsWonOnTheBadSide === undefined ? "–" : percentLabel(tableSides.pointsWonOnTheBadSide)}
-                    note="of the points of the sets with a worse side"
-                  />
-                  <StatTile
-                    label="More sets on the bad side, and the game"
-                    value={tableSides.wonWithMoreBadSideSets === undefined ? "–" : percentLabel(tableSides.wonWithMoreBadSideSets)}
-                    note="of the games where one player had the bad side more often, that player won"
-                  />
-                  <StatTile
-                    label="Sets with equal sides"
-                    value={percentLabel(tableSides.neutralSets)}
-                    note="of the sets with recorded sides"
-                  />
-                  <StatTile
-                    label="Games that record the sides"
-                    value={percentLabel(tableSides.sidesRecorded)}
-                    note="of the games with set points in this period"
-                  />
-                </StatTileRow>
               </div>
             )}
           </ContentCard>

--- a/frontend/src/pages/statistics/statistics-aggregations.test.ts
+++ b/frontend/src/pages/statistics/statistics-aggregations.test.ts
@@ -790,11 +790,20 @@ describe("trackedLevelStats", () => {
 });
 
 describe("tableSideStats", () => {
-  /** A tracked game with a recorded side per set, or none when sides is undefined. */
+  /**
+   * A game with per-set points and a recorded side per set — one char of
+   * `winnerSides` per set, or no side where the string ends. The game has no
+   * tracking data, the way a game entered by hand records its sides.
+   */
   function sidedGame(pointSequences: string[], winnerSides?: string): Game {
-    const setPoints = pointSequences.map((sequence) => {
+    const setPoints = pointSequences.map((sequence, index) => {
       const winner = sequence.split("").filter((point) => point === "W").length;
-      return { gameWinner: winner, gameLoser: sequence.length - winner };
+      const side = winnerSides?.[index] as "G" | "B" | "N" | undefined;
+      return {
+        gameWinner: winner,
+        gameLoser: sequence.length - winner,
+        ...(side ? { gameWinnerSide: side } : {}),
+      };
     });
     const setsWon = setPoints.reduce(
       (sets, set) =>
@@ -803,23 +812,7 @@ describe("tableSideStats", () => {
           : { gameWinner: sets.gameWinner, gameLoser: sets.gameLoser + 1 },
       { gameWinner: 0, gameLoser: 0 },
     );
-    return game({
-      score: {
-        setsWon,
-        setPoints,
-        pointSequences,
-        tracking: {
-          version: 1,
-          source: "track-game",
-          startedAt: 1,
-          pointDeltas: pointSequences.map((sequence) => new Array(sequence.length).fill(100)),
-          endedAfter: 10,
-          firstServers: "W".repeat(pointSequences.length),
-          winnerSides,
-          corrections: 0,
-        },
-      },
-    });
+    return game({ score: { setsWon, setPoints } });
   }
 
   /** 11-2 to the game winner. */
@@ -827,7 +820,7 @@ describe("tableSideStats", () => {
   /** 11-2 to the game loser. */
   const SET_TO_THE_LOSER = "LLLLLLLLLLLWW";
 
-  it("stays silent when no tracked game records the sides", () => {
+  it("stays silent when no game records the sides", () => {
     expect(tableSideStats([...games(10), sidedGame([SET_TO_THE_WINNER])])).toBeUndefined();
   });
 
@@ -873,7 +866,17 @@ describe("tableSideStats", () => {
     expect(tableSideStats([even])!.wonWithMoreBadSideSets).toBeUndefined();
   });
 
-  it("measures the coverage over the tracked games only", () => {
+  it("counts only the sets with a recorded side when a game records some", () => {
+    // Only set 1 has a side: the game winner is on the bad side and wins it.
+    const played = [sidedGame([SET_TO_THE_WINNER, SET_TO_THE_LOSER], "B")];
+
+    const stats = tableSideStats(played)!;
+
+    expect(stats.setsWonOnTheBadSide).toBe(100);
+    expect(stats.pointsWonOnTheBadSide).toBeCloseTo((11 / 13) * 100);
+  });
+
+  it("measures the coverage over the games with set points only", () => {
     const played = [
       sidedGame([SET_TO_THE_WINNER], "B"),
       sidedGame([SET_TO_THE_WINNER]),

--- a/frontend/src/pages/statistics/statistics-aggregations.test.ts
+++ b/frontend/src/pages/statistics/statistics-aggregations.test.ts
@@ -792,18 +792,13 @@ describe("trackedLevelStats", () => {
 describe("tableSideStats", () => {
   /**
    * A game with per-set points and a recorded side per set — one char of
-   * `winnerSides` per set, or no side where the string ends. The game has no
+   * `winnerSides` per set, or a null where the string ends. The game has no
    * tracking data, the way a game entered by hand records its sides.
    */
   function sidedGame(pointSequences: string[], winnerSides?: string): Game {
-    const setPoints = pointSequences.map((sequence, index) => {
+    const setPoints = pointSequences.map((sequence) => {
       const winner = sequence.split("").filter((point) => point === "W").length;
-      const side = winnerSides?.[index] as "G" | "B" | "N" | undefined;
-      return {
-        gameWinner: winner,
-        gameLoser: sequence.length - winner,
-        ...(side ? { gameWinnerSide: side } : {}),
-      };
+      return { gameWinner: winner, gameLoser: sequence.length - winner };
     });
     const setsWon = setPoints.reduce(
       (sets, set) =>
@@ -812,7 +807,16 @@ describe("tableSideStats", () => {
           : { gameWinner: sets.gameWinner, gameLoser: sets.gameLoser + 1 },
       { gameWinner: 0, gameLoser: 0 },
     );
-    return game({ score: { setsWon, setPoints } });
+    const gameWinnerSides = pointSequences.map(
+      (_, index) => (winnerSides?.[index] as "G" | "B" | "N" | undefined) ?? null,
+    );
+    return game({
+      score: {
+        setsWon,
+        setPoints,
+        gameWinnerSides: winnerSides === undefined ? undefined : gameWinnerSides,
+      },
+    });
   }
 
   /** 11-2 to the game winner. */
@@ -876,7 +880,24 @@ describe("tableSideStats", () => {
     expect(stats.pointsWonOnTheBadSide).toBeCloseTo((11 / 13) * 100);
   });
 
-  it("measures the coverage over the games with set points only", () => {
+  it("counts a game that records the sides without the set points", () => {
+    // Sets won 2-1 with sides but no points: the game-level share works, and
+    // the set and point shares have nothing to read.
+    const noPoints = game({
+      score: { setsWon: { gameWinner: 2, gameLoser: 1 }, gameWinnerSides: ["B", "G", "B"] },
+    });
+
+    const stats = tableSideStats([noPoints])!;
+
+    expect(stats.sidesRecorded).toBe(100);
+    expect(stats.neutralSets).toBe(0);
+    expect(stats.setsWonOnTheBadSide).toBeUndefined();
+    expect(stats.pointsWonOnTheBadSide).toBeUndefined();
+    // The game winner had the bad side in 2 of the 3 sets and won the game.
+    expect(stats.wonWithMoreBadSideSets).toBe(100);
+  });
+
+  it("measures the coverage over the games with a score only", () => {
     const played = [
       sidedGame([SET_TO_THE_WINNER], "B"),
       sidedGame([SET_TO_THE_WINNER]),

--- a/frontend/src/pages/statistics/statistics-aggregations.ts
+++ b/frontend/src/pages/statistics/statistics-aggregations.ts
@@ -43,7 +43,6 @@ import { Game } from "../../client/client-db/event-store/projectors/games-projec
 import { Player } from "../../client/client-db/event-store/projectors/players-projector";
 import { EventType, EventTypeEnum } from "../../client/client-db/event-store/event-types";
 import { advancePeriod, getPeriodKey, getPeriodStart, getPeriodTimestamp, Period } from "../../common/period-utils";
-import { winnerSideOfSet } from "../../common/table-sides";
 import { gameTimingStats, longestStreaks, serveStats } from "../game/game-tracking-stats";
 
 /** A rating gap bucket with fewer games than this is not plotted. */
@@ -893,7 +892,7 @@ export function trackedLevelStats(games: Game[]): TrackedLevelStats | undefined 
   };
 }
 export type TableSideStats = {
-  /** Share of the tracked games of the period that record the sides. */
+  /** Share of the games of the period with set points that record the sides. */
   sidesRecorded: number;
   /** Share of the recorded sets where the 2 sides are equally good. */
   neutralSets: number;
@@ -913,16 +912,20 @@ export type TableSideStats = {
 /**
  * What playing on the bad side of the table costs.
  *
- * A tracked game can record which player had the bad side in each set, or that
- * the 2 sides were equally good. Every set with a worse side has exactly one
- * player on it, so 50% is the neutral reading of the set and point shares: a
- * lower share means the bad side really costs sets or points.
+ * Any game that records its set points can record which player had the bad
+ * side in each set, or that the 2 sides were equally good — a tracker does it
+ * live, and the add game form takes what the players remember. Every set with
+ * a worse side has exactly one player on it, so 50% is the neutral reading of
+ * the set and point shares: a lower share means the bad side really costs sets
+ * or points.
  *
  * A neutral set holds no bad side, so it only counts towards `neutralSets`.
  */
 export function tableSideStats(games: Game[]): TableSideStats | undefined {
-  const tracked = games.filter(isTrackedGame);
-  const withSides = tracked.filter((game) => game.score?.tracking?.winnerSides !== undefined);
+  const withSetPoints = games.filter((game) => game.score?.setPoints !== undefined);
+  const withSides = withSetPoints.filter((game) =>
+    game.score!.setPoints!.some((set) => set.gameWinnerSide !== undefined),
+  );
   if (withSides.length === 0) return undefined;
 
   let recordedSets = 0;
@@ -935,14 +938,11 @@ export function tableSideStats(games: Game[]): TableSideStats | undefined {
   let unevenGamesToTheBadSide = 0;
 
   for (const game of withSides) {
-    const score = game.score!;
-    const sides = score.tracking!.winnerSides;
     const badSideSets = { winner: 0, loser: 0 };
 
-    for (let setIndex = 0; setIndex < score.pointSequences!.length; setIndex++) {
-      const sequence = score.pointSequences![setIndex];
-      const side = winnerSideOfSet(sides, setIndex);
-      if (side === undefined || sequence.length === 0) continue;
+    for (const set of game.score!.setPoints!) {
+      const side = set.gameWinnerSide;
+      if (side === undefined) continue;
 
       recordedSets++;
       if (side === "N") {
@@ -951,13 +951,11 @@ export function tableSideStats(games: Game[]): TableSideStats | undefined {
       }
 
       const gameWinnerOnTheBadSide = side === "B";
-      const winnerPoints = sequence.split("").filter((point) => point === "W").length;
-      const loserPoints = sequence.length - winnerPoints;
 
       unequalSets++;
-      unequalPoints += sequence.length;
-      pointsToTheBadSide += gameWinnerOnTheBadSide ? winnerPoints : loserPoints;
-      if ((winnerPoints > loserPoints) === gameWinnerOnTheBadSide) setsToTheBadSide++;
+      unequalPoints += set.gameWinner + set.gameLoser;
+      pointsToTheBadSide += gameWinnerOnTheBadSide ? set.gameWinner : set.gameLoser;
+      if ((set.gameWinner > set.gameLoser) === gameWinnerOnTheBadSide) setsToTheBadSide++;
       if (gameWinnerOnTheBadSide) badSideSets.winner++;
       else badSideSets.loser++;
     }
@@ -969,7 +967,7 @@ export function tableSideStats(games: Game[]): TableSideStats | undefined {
   }
 
   return {
-    sidesRecorded: percent(withSides.length, tracked.length),
+    sidesRecorded: percent(withSides.length, withSetPoints.length),
     neutralSets: percent(neutralSets, recordedSets),
     setsWonOnTheBadSide: unequalSets === 0 ? undefined : percent(setsToTheBadSide, unequalSets),
     pointsWonOnTheBadSide: unequalPoints === 0 ? undefined : percent(pointsToTheBadSide, unequalPoints),

--- a/frontend/src/pages/statistics/statistics-aggregations.ts
+++ b/frontend/src/pages/statistics/statistics-aggregations.ts
@@ -892,7 +892,7 @@ export function trackedLevelStats(games: Game[]): TrackedLevelStats | undefined 
   };
 }
 export type TableSideStats = {
-  /** Share of the games of the period with set points that record the sides. */
+  /** Share of the games of the period with a score that record the sides. */
   sidesRecorded: number;
   /** Share of the recorded sets where the 2 sides are equally good. */
   neutralSets: number;
@@ -912,20 +912,20 @@ export type TableSideStats = {
 /**
  * What playing on the bad side of the table costs.
  *
- * Any game that records its set points can record which player had the bad
- * side in each set, or that the 2 sides were equally good — a tracker does it
- * live, and the add game form takes what the players remember. Every set with
- * a worse side has exactly one player on it, so 50% is the neutral reading of
- * the set and point shares: a lower share means the bad side really costs sets
- * or points.
+ * Any game with a score can record which player had the bad side in each set,
+ * or that the 2 sides were equally good — a tracker does it live, and the add
+ * game form takes what the players remember, with or without the points of
+ * each set. Every set with a worse side has exactly one player on it, so 50%
+ * is the neutral reading of the set and point shares: a lower share means the
+ * bad side really costs sets or points.
  *
  * A neutral set holds no bad side, so it only counts towards `neutralSets`.
+ * The set and point shares need the points of the set, so a set with a side
+ * but no points counts only towards the game-level share.
  */
 export function tableSideStats(games: Game[]): TableSideStats | undefined {
-  const withSetPoints = games.filter((game) => game.score?.setPoints !== undefined);
-  const withSides = withSetPoints.filter((game) =>
-    game.score!.setPoints!.some((set) => set.gameWinnerSide !== undefined),
-  );
+  const withScore = games.filter((game) => game.score !== undefined);
+  const withSides = withScore.filter((game) => game.score!.gameWinnerSides?.some((side) => side !== null));
   if (withSides.length === 0) return undefined;
 
   let recordedSets = 0;
@@ -940,9 +940,10 @@ export function tableSideStats(games: Game[]): TableSideStats | undefined {
   for (const game of withSides) {
     const badSideSets = { winner: 0, loser: 0 };
 
-    for (const set of game.score!.setPoints!) {
-      const side = set.gameWinnerSide;
-      if (side === undefined) continue;
+    const sides = game.score!.gameWinnerSides!;
+    for (let setIndex = 0; setIndex < sides.length; setIndex++) {
+      const side = sides[setIndex];
+      if (side === null) continue;
 
       recordedSets++;
       if (side === "N") {
@@ -951,13 +952,18 @@ export function tableSideStats(games: Game[]): TableSideStats | undefined {
       }
 
       const gameWinnerOnTheBadSide = side === "B";
+      if (gameWinnerOnTheBadSide) badSideSets.winner++;
+      else badSideSets.loser++;
+
+      // Who won the set, and its points, are only known when the game
+      // records the points of each set.
+      const set = game.score!.setPoints?.[setIndex];
+      if (set === undefined) continue;
 
       unequalSets++;
       unequalPoints += set.gameWinner + set.gameLoser;
       pointsToTheBadSide += gameWinnerOnTheBadSide ? set.gameWinner : set.gameLoser;
       if ((set.gameWinner > set.gameLoser) === gameWinnerOnTheBadSide) setsToTheBadSide++;
-      if (gameWinnerOnTheBadSide) badSideSets.winner++;
-      else badSideSets.loser++;
     }
 
     if (badSideSets.winner !== badSideSets.loser) {
@@ -967,7 +973,7 @@ export function tableSideStats(games: Game[]): TableSideStats | undefined {
   }
 
   return {
-    sidesRecorded: percent(withSides.length, withSetPoints.length),
+    sidesRecorded: percent(withSides.length, withScore.length),
     neutralSets: percent(neutralSets, recordedSets),
     setsWonOnTheBadSide: unequalSets === 0 ? undefined : percent(setsToTheBadSide, unequalSets),
     pointsWonOnTheBadSide: unequalPoints === 0 ? undefined : percent(pointsToTheBadSide, unequalPoints),

--- a/frontend/src/pages/statistics/statistics-page.test.tsx
+++ b/frontend/src/pages/statistics/statistics-page.test.tsx
@@ -63,7 +63,10 @@ function buildEvents(gameCount = 120): EventType[] {
           index % 4 === 0
             ? {
                 setsWon: { gameWinner: 1, gameLoser: 0 },
-                setPoints: [{ gameWinner: 11, gameLoser: 4 }],
+                // Half of the tracked games record the side of the table.
+                setPoints: [
+                  { gameWinner: 11, gameLoser: 4, gameWinnerSide: index % 8 === 0 ? ("B" as const) : undefined },
+                ],
                 pointSequences: ["WWWWLWWWWLWWLWL"],
                 tracking: {
                   version: 1,
@@ -72,8 +75,6 @@ function buildEvents(gameCount = 120): EventType[] {
                   pointDeltas: [new Array(15).fill(80)],
                   endedAfter: 20,
                   firstServers: "W",
-                  // Half of the tracked games record the side of the table.
-                  winnerSides: index % 8 === 0 ? "B" : undefined,
                   corrections: 0,
                 },
               }

--- a/frontend/src/pages/statistics/statistics-page.test.tsx
+++ b/frontend/src/pages/statistics/statistics-page.test.tsx
@@ -63,10 +63,9 @@ function buildEvents(gameCount = 120): EventType[] {
           index % 4 === 0
             ? {
                 setsWon: { gameWinner: 1, gameLoser: 0 },
+                setPoints: [{ gameWinner: 11, gameLoser: 4 }],
                 // Half of the tracked games record the side of the table.
-                setPoints: [
-                  { gameWinner: 11, gameLoser: 4, gameWinnerSide: index % 8 === 0 ? ("B" as const) : undefined },
-                ],
+                gameWinnerSides: index % 8 === 0 ? ["B" as const] : undefined,
                 pointSequences: ["WWWWLWWWWLWWLWL"],
                 tracking: {
                   version: 1,


### PR DESCRIPTION
## What

Any game with a score can now record which player had the bad side of the table in each set — not only live-tracked games. The players often remember the sides when they enter a game after the match, and the sides do not need the individual set points: sets won 2-1 plus the sides alone is a valid game. The sides can also be edited afterwards on the edit score page.

## Data structure

The side of each set is stored in its own list on the `GAME_SCORE` event, independent of `setPoints`:

```ts
setPoints?: { gameWinner: number; gameLoser: number }[];
gameWinnerSides?: ("G" | "B" | "N" | null)[]; // one per set, null = not recorded
```

- Independent of `setPoints`, so sides can be stored with only the sets won. `setPoints` keeps its strict number shape for every existing consumer (WHR, predictions, seasons, achievements, stats).
- Sides are per set: a game keeps the sets the players remember and leaves the rest `null`.
- A live game whose point log does not line up (tracking dropped) still keeps its sides.
- `tracking.winnerSides` from the original tracked-games implementation is removed entirely — no stored event carries it, so there is no legacy data to migrate.
- The `DenoServer` mirror of `event-types.ts` is updated to match.

## Validation

`gameWinnerSides` must have one entry per set (`setsWon` total), each `G`, `B`, `N` or `null`, and at least one recorded side (an all-null list is rejected, like all-zero set points).

## UI

- **Add game form**: each set block in "Individual points pr. set" gets the same bad-side pill row the trackers use (`TableSidePicker`, extracted from `TableSideDisplay`). Tap to select, tap again to clear. Works with or without the points. A small margin keeps the pills clear of the points inputs.
- **Edit score page**: same picker, pre-loaded with the game's stored sides. An edit that changes only the sides keeps the point-by-point log of a tracked game — the log is dropped only when the sets or points change, and the discard warning now shows only in that case.
- **Game details**: a game with sides but no tracking data gets a small "Set by set" table — with a score column when the game has set points, without one when it only has the sides.
- **Statistics**: the bad-side card moved to the "Set level" section and covers every game with a score. The set/point shares still need the set points; a set with a side but no points counts only towards the game-level share.

## Verified

- 1085 Jest tests pass, ESLint clean, production build compiles, DenoServer types check.
- Mobile (390px) verified with Playwright against a mock event API: the pill spacing, the sets-2-1-plus-sides-without-points submit (accepted, event stored with `gameWinnerSides` and no `setPoints`), the sides-only game details table, and the edit flows — a side edit on a plain game saves the new list, and a sides-only edit of a tracked game saves with `pointSequences` and `tracking` intact while a point change shows the discard warning.

The changelog post `table-sides-on-tracked-games` is edited to describe the feature as it now works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XAXYycgWL3hMpKA89X5kKn