### PR TITLE
Auto-fill alternating table sides from the first side picked on a set

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -56,7 +56,7 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
         "The side locks with the first point of the set, the same as the first server. After each set the tracker moves the bad side to the other player, because the players usually change sides. Correct it at 0-0 when the players keep the same side.",
       ),
       text(
-        "The add game form and the edit score page have the same selector below the points of each set. Select the side for the sets you remember, and leave the other sets empty. The sides do not need the set points — the sets won are enough. An edit that changes only the sides keeps the point log of a tracked game.",
+        "The add game form and the edit score page have the same selector below the points of each set. The first side you select fills all the sets, and the other sets alternate from it. A selection of equal sides fills every set with equal sides. Correct the sets that did not follow the pattern, or remove the sides you do not know. The sides do not need the set points — the sets won are enough. An edit that changes only the sides keeps the point log of a tracked game.",
       ),
       text(
         'The `GAME_SCORE` event stores one side per set in `gameWinnerSides`, from the side of the game winner: "G" for the good side, "B" for the bad side, "N" for 2 equal sides and null for a set nobody recorded. The list is independent of the set points.',

--- a/frontend/src/common/table-sides.test.ts
+++ b/frontend/src/common/table-sides.test.ts
@@ -1,5 +1,6 @@
 import {
   alignBadSides,
+  autoFillBadSides,
   BadSide,
   badSideLabel,
   badSideName,
@@ -17,6 +18,36 @@ describe("nextSetBadSide", () => {
   it("keeps a neutral or unrecorded set as it is", () => {
     expect(nextSetBadSide("neutral")).toBe("neutral");
     expect(nextSetBadSide(null)).toBe(null);
+  });
+});
+
+describe("autoFillBadSides", () => {
+  it("fills every set, alternating from the first picked set", () => {
+    expect(autoFillBadSides([null, null, null], 0, 1)).toEqual([1, 2, 1]);
+    expect(autoFillBadSides([null, null, null], 0, 2)).toEqual([2, 1, 2]);
+  });
+
+  it("alternates backwards as well when a later set is picked first", () => {
+    expect(autoFillBadSides([null, null, null], 1, 1)).toEqual([2, 1, 2]);
+    expect(autoFillBadSides([null, null, null, null], 2, 2)).toEqual([2, 1, 2, 1]);
+  });
+
+  it("fills every set with equal sides when equal is picked first", () => {
+    expect(autoFillBadSides([null, null, null], 1, "neutral")).toEqual(["neutral", "neutral", "neutral"]);
+  });
+
+  it("changes only the picked set once another set has a side", () => {
+    expect(autoFillBadSides([2, null, null], 1, 1)).toEqual([2, 1, null]);
+    expect(autoFillBadSides(["neutral", "neutral", "neutral"], 1, 1)).toEqual(["neutral", 1, "neutral"]);
+  });
+
+  it("fills again when the only set with a side is picked anew", () => {
+    expect(autoFillBadSides([1, null, null], 0, 2)).toEqual([2, 1, 2]);
+  });
+
+  it("removes only the picked set's side, and never fills on removal", () => {
+    expect(autoFillBadSides([1, 2, 1], 1, null)).toEqual([1, null, 1]);
+    expect(autoFillBadSides([1, null, null], 0, null)).toEqual([null, null, null]);
   });
 });
 

--- a/frontend/src/common/table-sides.ts
+++ b/frontend/src/common/table-sides.ts
@@ -37,6 +37,27 @@ export function nextSetBadSide(badSide: BadSide): BadSide {
 }
 
 /**
+ * The sides of every set after one set's side is picked by hand, as on the add
+ * game and edit score forms. The first pick fills the whole game: the players
+ * usually change sides after every set, so the other sets alternate from the
+ * picked set, backwards as well as forwards. "neutral" has nothing to
+ * alternate, so it fills every set. The fill only runs while every other set
+ * is empty — after that a pick changes its own set only, so a correction does
+ * not overwrite the rest. Removing a side (null) never fills.
+ */
+export function autoFillBadSides(sides: BadSide[], setIndex: number, badSide: BadSide): BadSide[] {
+  const otherSetsEmpty = sides.every((side, index) => index === setIndex || side === null);
+  if (badSide === null || otherSetsEmpty === false) {
+    return sides.map((side, index) => (index === setIndex ? badSide : side));
+  }
+  if (badSide === "neutral") {
+    return sides.map(() => "neutral");
+  }
+  const otherPlayer: BadSide = badSide === 1 ? 2 : 1;
+  return sides.map((_, index) => ((index - setIndex) % 2 === 0 ? badSide : otherPlayer));
+}
+
+/**
  * Encodes the bad side of one set from the game winner's perspective, or null
  * when the set has no recorded side. Each set is on its own, so the players
  * can record the sides they remember and leave the rest out.

--- a/frontend/src/pages/add-game/step-add-score.tsx
+++ b/frontend/src/pages/add-game/step-add-score.tsx
@@ -2,7 +2,7 @@ import { useEventDbContext } from "../../wrappers/event-db-context";
 import { ProfilePicture } from "../player/profile-picture";
 import { stringToColor } from "../../common/string-to-color";
 import { classNames } from "../../common/class-names";
-import { BadSide } from "../../common/table-sides";
+import { autoFillBadSides, BadSide } from "../../common/table-sides";
 import { TableSidePicker } from "../../common/table-sides-display";
 
 /**
@@ -90,8 +90,18 @@ const SetPoints: React.FC<{
   const anyPointsSet = setPoints.setPoints.some((set) => set.player1 !== undefined || set.player2 !== undefined);
   const anySideSet = setPoints.setPoints.some((set) => set.badSide !== null);
 
+  // The first side picked fills every set, alternating from the picked one
+  // (equal fills equal everywhere). Once any other set has a side, a pick
+  // changes its own set only.
   function handleSelectSide(setIndex: number, badSide: BadSide) {
-    setPoints.setSetPoints((prev) => prev.map((set, index) => (index === setIndex ? { ...set, badSide } : set)));
+    setPoints.setSetPoints((prev) => {
+      const filled = autoFillBadSides(
+        prev.map((set) => set.badSide),
+        setIndex,
+        badSide,
+      );
+      return prev.map((set, index) => (set.badSide === filled[index] ? set : { ...set, badSide: filled[index] }));
+    });
   }
 
   return (
@@ -118,9 +128,10 @@ const SetPoints: React.FC<{
               <SetPointsInput playerId={player2} playerIndex="player2" setIndex={index} setPoints={setPoints} />
             </div>
             {/* The players often remember who had the worse side of the table.
-                One press per set records it, with or without the set points.
-                The points row overflows its fixed height, so the margin keeps
-                the pills clear of the inputs. */}
+                The first press fills every set, and after that one press per
+                set corrects it, with or without the set points. The points row
+                overflows its fixed height, so the margin keeps the pills clear
+                of the inputs. */}
             <div className="mt-3 pb-1">
               <TableSidePicker
                 badSide={set.badSide}


### PR DESCRIPTION
On the add game and edit score forms, picking the first bad side of a
game now fills every set: the other sets alternate from the picked set,
backwards as well as forwards, and picking equal fills every set with
equal. The fill only runs while every other set is empty, so later
picks correct a single set without overwriting the rest.

The live trackers already alternate on each new set via nextSetBadSide
(equal stays equal, an unset side stays unset), so they are unchanged.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Pe6vfum2QYNS9385a3NouQ