### PR TITLE
Add 6-month trailing average lines to activity charts

### DIFF
--- a/frontend/src/common/trailing-average.test.ts
+++ b/frontend/src/common/trailing-average.test.ts
@@ -1,0 +1,15 @@
+import { trailingAverage } from "./trailing-average";
+
+describe("trailingAverage", () => {
+  it("averages the last `window` values at every point", () => {
+    expect(trailingAverage([2, 4, 6, 8], 2)).toEqual([2, 3, 5, 7]);
+  });
+
+  it("averages the values there are before a full window exists", () => {
+    expect(trailingAverage([3, 6, 9], 6)).toEqual([3, 4.5, 6]);
+  });
+
+  it("returns nothing for no values", () => {
+    expect(trailingAverage([], 6)).toEqual([]);
+  });
+});

--- a/frontend/src/common/trailing-average.ts
+++ b/frontend/src/common/trailing-average.ts
@@ -1,0 +1,17 @@
+/**
+ * The trailing average of the last `window` values, one per input value. A
+ * point early in the series has fewer than `window` values behind it, and its
+ * average covers the values there are, so the line spans the whole chart
+ * instead of starting a window late.
+ */
+export function trailingAverage(values: number[], window: number): number[] {
+  return values.map((_, index) => {
+    const start = Math.max(0, index - window + 1);
+    const slice = values.slice(start, index + 1);
+    const sum = slice.reduce((total, value) => total + value, 0);
+    return sum / slice.length;
+  });
+}
+
+/** Buckets in 6 months, for a chart bucketed per week or per month. */
+export const TRAILING_6_MONTHS = { week: 26, month: 6 } as const;

--- a/frontend/src/pages/admin/games-per-month.tsx
+++ b/frontend/src/pages/admin/games-per-month.tsx
@@ -1,11 +1,13 @@
 import React, { useMemo } from "react";
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis, ReferenceLine } from "recharts";
 import { useEventDbContext } from "../../wrappers/event-db-context";
+import { TRAILING_6_MONTHS, trailingAverage } from "../../common/trailing-average";
 
 interface MonthlyData {
   month: string;
   count: number;
   timestamp: number;
+  trailingAverage: number;
 }
 
 export const GamesPerMonthChart: React.FC = () => {
@@ -43,7 +45,7 @@ export const GamesPerMonthChart: React.FC = () => {
     const maxTimestamp = Math.max(...timestamps);
 
     // Generate all months in the range
-    const allMonthsData: MonthlyData[] = [];
+    const allMonthsData: Omit<MonthlyData, "trailingAverage">[] = [];
     const startDate = new Date(minTimestamp);
     const endDate = new Date(maxTimestamp);
 
@@ -68,7 +70,15 @@ export const GamesPerMonthChart: React.FC = () => {
       currentDate.setMonth(currentDate.getMonth() + 1);
     }
 
-    const sortedMonthlyData = allMonthsData.sort((a, b) => a.timestamp - b.timestamp);
+    const orderedMonths = allMonthsData.sort((a, b) => a.timestamp - b.timestamp);
+    const averages = trailingAverage(
+      orderedMonths.map((entry) => entry.count),
+      TRAILING_6_MONTHS.month,
+    );
+    const sortedMonthlyData: MonthlyData[] = orderedMonths.map((entry, index) => ({
+      ...entry,
+      trailingAverage: averages[index],
+    }));
 
     // Filter tournaments that fall within the data range
     const tournaments = context.eventStore.tournamentsProjector.getTournamentConfigs();
@@ -133,6 +143,7 @@ export const GamesPerMonthChart: React.FC = () => {
                   <div className="bg-secondary-background text-secondary-text p-3 rounded-lg shadow-lg border border-secondary-text">
                     <p className="font-semibold">{formatMonth(label as string)}</p>
                     <p>{`Games: ${data.count}`}</p>
+                    <p>{`6 month average: ${data.trailingAverage.toFixed(1)}`}</p>
                   </div>
                 );
               }
@@ -176,6 +187,17 @@ export const GamesPerMonthChart: React.FC = () => {
               r: 6,
               fill: "rgb(var(--color-tertiary-background))",
             }}
+          />
+
+          <Line
+            type="monotone"
+            dataKey="trailingAverage"
+            stroke="rgb(var(--color-primary-text))"
+            strokeWidth={2}
+            strokeDasharray="2 6"
+            strokeLinecap="round"
+            dot={false}
+            activeDot={false}
           />
         </LineChart>
       </ResponsiveContainer>

--- a/frontend/src/pages/admin/games-per-week.tsx
+++ b/frontend/src/pages/admin/games-per-week.tsx
@@ -1,11 +1,13 @@
 import React, { useMemo } from "react";
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis, ReferenceLine } from "recharts";
 import { useEventDbContext } from "../../wrappers/event-db-context";
+import { TRAILING_6_MONTHS, trailingAverage } from "../../common/trailing-average";
 
 interface WeeklyData {
   week: string;
   count: number;
   timestamp: number;
+  trailingAverage: number;
 }
 
 export const GamesPerWeekChart: React.FC = () => {
@@ -47,7 +49,7 @@ export const GamesPerWeekChart: React.FC = () => {
     const maxTimestamp = Math.max(...timestamps);
 
     // Generate all weeks in the range
-    const allWeeksData: WeeklyData[] = [];
+    const allWeeksData: Omit<WeeklyData, "trailingAverage">[] = [];
     const startWeek = new Date(minTimestamp);
     const endWeek = new Date(maxTimestamp);
 
@@ -70,7 +72,15 @@ export const GamesPerWeekChart: React.FC = () => {
       currentWeek.setDate(currentWeek.getDate() + 7);
     }
 
-    const sortedWeeklyData = allWeeksData.sort((a, b) => a.timestamp - b.timestamp);
+    const orderedWeeks = allWeeksData.sort((a, b) => a.timestamp - b.timestamp);
+    const averages = trailingAverage(
+      orderedWeeks.map((entry) => entry.count),
+      TRAILING_6_MONTHS.week,
+    );
+    const sortedWeeklyData: WeeklyData[] = orderedWeeks.map((entry, index) => ({
+      ...entry,
+      trailingAverage: averages[index],
+    }));
 
     // Filter tournaments that fall within the data range
     const tournaments = context.eventStore.tournamentsProjector.getTournamentConfigs();
@@ -145,6 +155,7 @@ export const GamesPerWeekChart: React.FC = () => {
                       {formatWeek(label as string)} - {formatWeek(weekEnd.toISOString().split("T")[0])}
                     </p>
                     <p>{`Games: ${data.count}`}</p>
+                    <p>{`6 month average: ${data.trailingAverage.toFixed(1)}`}</p>
                   </div>
                 );
               }
@@ -188,6 +199,17 @@ export const GamesPerWeekChart: React.FC = () => {
               r: 6,
               fill: "rgb(var(--color-tertiary-background))",
             }}
+          />
+
+          <Line
+            type="monotone"
+            dataKey="trailingAverage"
+            stroke="rgb(var(--color-primary-text))"
+            strokeWidth={2}
+            strokeDasharray="2 6"
+            strokeLinecap="round"
+            dot={false}
+            activeDot={false}
           />
         </LineChart>
       </ResponsiveContainer>

--- a/frontend/src/pages/statistics/activity-tab.tsx
+++ b/frontend/src/pages/statistics/activity-tab.tsx
@@ -15,6 +15,7 @@ import {
 import { useEventDbContext } from "../../wrappers/event-db-context";
 import { PillSelect } from "../../common/pill-select";
 import { getPeriodKey, Period } from "../../common/period-utils";
+import { TRAILING_6_MONTHS, trailingAverage } from "../../common/trailing-average";
 import { ContentCard } from "../player/content-card";
 import { NotEnoughGames, StatTile, StatTileRow } from "./stat-tile";
 import { ACCENT_COLOR, AXIS_COLOR, percentLabel, percentTick, SERIES_COLOR, TooltipCard } from "./percent-chart";
@@ -26,7 +27,9 @@ import {
   weekdayShares,
 } from "./statistics-aggregations";
 
-const TREND_OPTIONS: { value: Period; label: string }[] = [
+type TrendPeriod = keyof typeof TRAILING_6_MONTHS;
+
+const TREND_OPTIONS: { value: TrendPeriod; label: string }[] = [
   { value: "month", label: "Monthly" },
   { value: "week", label: "Weekly" },
 ];
@@ -49,13 +52,20 @@ const formatPeriodLabel = (key: string, period: Period): string => {
 
 export const ActivityTab: React.FC = () => {
   const context = useEventDbContext();
-  const [period, setPeriod] = useState<Period>("month");
+  const [period, setPeriod] = useState<TrendPeriod>("month");
 
   // `context.games` sorts and returns a new array on every read, so it is
   // pinned here. Depending on it directly would rebuild every chart on every
   // render.
   const games = useMemo(() => context.games, [context]);
-  const trend = useMemo(() => activityTrend(games, period), [games, period]);
+  const trend = useMemo(() => {
+    const points = activityTrend(games, period);
+    const averages = trailingAverage(
+      points.map((point) => point.share),
+      TRAILING_6_MONTHS[period],
+    );
+    return points.map((point, index) => ({ ...point, trailingAverage: averages[index] }));
+  }, [games, period]);
   const weekdays = useMemo(() => weekdayShares(games), [games]);
   const slots = useMemo(() => timeOfDayShares(games), [games]);
   const highlights = useMemo(() => activityHighlights(games), [games]);
@@ -88,7 +98,7 @@ export const ActivityTab: React.FC = () => {
 
       <ContentCard
         title="Activity over time"
-        description="Each period against the busiest one, which reads 100%. The chart shows when the league is busy, not how many games it plays."
+        description="Each period against the busiest one, which reads 100%. The dotted line is the trailing average over 6 months. The chart shows when the league is busy, not how many games it plays."
         action={<PillSelect label="" options={TREND_OPTIONS} value={period} onChange={setPeriod} />}
       >
         <ResponsiveContainer width="100%" height={320}>
@@ -107,9 +117,11 @@ export const ActivityTab: React.FC = () => {
             <Tooltip
               content={({ active, payload, label }) => {
                 if (!active || !payload?.length) return null;
+                const entry = payload[0].payload as { share: number; trailingAverage: number };
                 return (
                   <TooltipCard title={formatPeriodLabel(String(label), period)}>
-                    <p>{percentLabel(Number(payload[0].value))} of the busiest {period}</p>
+                    <p>{percentLabel(entry.share)} of the busiest {period}</p>
+                    <p>{percentLabel(entry.trailingAverage)} on average over 6 months</p>
                   </TooltipCard>
                 );
               }}
@@ -132,6 +144,16 @@ export const ActivityTab: React.FC = () => {
               />
             ))}
             <Line type="monotone" dataKey="share" stroke={SERIES_COLOR} strokeWidth={3} dot={false} activeDot={{ r: 5, fill: ACCENT_COLOR }} />
+            <Line
+              type="monotone"
+              dataKey="trailingAverage"
+              stroke={AXIS_COLOR}
+              strokeWidth={2}
+              strokeDasharray="2 6"
+              strokeLinecap="round"
+              dot={false}
+              activeDot={false}
+            />
           </LineChart>
         </ResponsiveContainer>
       </ContentCard>


### PR DESCRIPTION
## Summary
Adds a 6-month trailing average overlay to three activity charts: the Activity tab's activity-over-time chart, and the admin dashboard's games-per-month and games-per-week charts. The trailing average is displayed as a dashed line to help visualize trends over longer periods.

## Changes
- **New utility module** (`trailing-average.ts`): Implements a `trailingAverage()` function that calculates a rolling average with a configurable window size. Early values in the series use fewer than the full window of data points, allowing the line to span the entire chart rather than starting late.
- **Activity Tab** (`activity-tab.tsx`):
  - Computes trailing averages for activity trend data using a 6-month window
  - Adds a dashed line to the chart displaying the trailing average
  - Updates the tooltip to show both the current period's share and the 6-month average
  - Updates the card description to explain the new line
- **Games Per Month Chart** (`games-per-month.tsx`):
  - Computes trailing averages for monthly game counts
  - Adds a dashed line to the chart
  - Updates the tooltip to display the 6-month average
- **Games Per Week Chart** (`games-per-week.tsx`):
  - Computes trailing averages for weekly game counts
  - Adds a dashed line to the chart
  - Updates the tooltip to display the 6-month average
- **Tests** (`trailing-average.test.ts`): Unit tests for the trailing average function covering normal operation, partial windows, and edge cases.

## Implementation Details
- The `TRAILING_6_MONTHS` constant defines window sizes per period type: 26 weeks or 6 months
- Type safety is improved by introducing `TrendPeriod` type in the Activity Tab to ensure only valid period keys are used
- All trailing average lines use consistent styling: dashed stroke with rounded line caps for visual distinction from the main data line

https://claude.ai/code/session_01Nw4CJydaU726AzwmUYrZMB