### PR TITLE
Add Bad Side Bandit achievement

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -42,6 +42,25 @@ const list = (...items: string[]): ChangelogBlock => ({ kind: "list", items });
  */
 export const CHANGELOG_POSTS: ChangelogPost[] = [
   {
+    slug: "bad-side-bandit-achievement",
+    title: "New achievement: Bad Side Bandit 😵",
+    date: "2026-08-24",
+    tags: ["feature-update"],
+    summary: "Bad Side Bandit 😵 is a new achievement. Win 10 sets from the bad side of the table.",
+    body: [
+      text(
+        "A game can record the player who has the bad side of the table in each set. A set counts when the player on the bad side wins it. The count is for your career, and you earn the achievement 1 time.",
+      ),
+      text(
+        "A set needs the recorded side and the set points. The side names the player on the bad side, and the points name the player who wins the set. A set with 2 equal sides, or with no recorded side, does not count.",
+      ),
+      text(
+        "The result of the game does not matter. A player who loses the game gets the credit for each set they win from the bad side.",
+      ),
+      text("The Progress tab on the player page shows how many of the 10 sets you have."),
+    ],
+  },
+  {
     slug: "correct-start-time-on-tracked-games",
     title: "Correct start time on tracked games",
     date: "2026-08-23",

--- a/frontend/src/client/client-db/__tests__/achievements/bad-side-bandit.test.ts
+++ b/frontend/src/client/client-db/__tests__/achievements/bad-side-bandit.test.ts
@@ -1,0 +1,338 @@
+import { EventType, EventTypeEnum } from "../../event-store/event-types";
+import { TennisTable } from "../../tennis-table";
+
+// Bad Side Bandit: win 10 sets from the bad side of the table. A set counts
+// when the game records the side of the set ("B" = the game winner had the
+// bad side, "G" = the game loser had it) and the points of the set name the
+// player on the bad side as the set winner. Either player can win a
+// qualifying set, whoever wins the game. One-time achievement, awarded on the
+// crossing.
+
+describe("Bad Side Bandit Achievement", () => {
+  const baseEvents: EventType[] = [
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "alice", time: 1, data: { name: "Alice" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "bob", time: 2, data: { name: "Bob" } },
+    { type: EventTypeEnum.PLAYER_CREATED, stream: "chris", time: 3, data: { name: "Chris" } },
+  ];
+
+  type SetPoints = { gameWinner: number; gameLoser: number };
+  type Side = "G" | "B" | "N" | null;
+
+  const game = (params: {
+    id: string;
+    time: number;
+    winner: string;
+    loser: string;
+    setPoints?: SetPoints[];
+    sides?: Side[];
+  }): EventType[] => {
+    const { id, time, winner, loser, setPoints, sides } = params;
+    const setsWon = {
+      gameWinner: (setPoints ?? []).filter((set) => set.gameWinner > set.gameLoser).length,
+      gameLoser: (setPoints ?? []).filter((set) => set.gameLoser > set.gameWinner).length,
+    };
+    return [
+      { type: EventTypeEnum.GAME_CREATED, stream: id, time, data: { winner, loser, playedAt: time } },
+      {
+        type: EventTypeEnum.GAME_SCORE,
+        stream: id,
+        time: time + 1,
+        data: { setsWon, setPoints, gameWinnerSides: sides },
+      },
+    ];
+  };
+
+  // A 2-0 game where the game winner had the bad side in both sets, so the
+  // game winner takes 2 qualifying sets and the game loser none.
+  const twoBadSideSetsForWinner = (id: string, time: number, winner: string, loser: string): EventType[] =>
+    game({
+      id,
+      time,
+      winner,
+      loser,
+      setPoints: [
+        { gameWinner: 11, gameLoser: 4 },
+        { gameWinner: 11, gameLoser: 6 },
+      ],
+      sides: ["B", "B"],
+    });
+
+  const awardsOf = (tt: TennisTable, playerId: string) =>
+    tt.achievements.getAchievements(playerId).filter((a) => a.type === "bad-side-bandit");
+
+  const progressOf = (tt: TennisTable, playerId: string) =>
+    tt.achievements.getPlayerProgression(playerId)["bad-side-bandit"];
+
+  const calculated = (events: EventType[]): TennisTable => {
+    const tt = new TennisTable({ events });
+    tt.achievements.calculateAchievements();
+    return tt;
+  };
+
+  it("awards after 10 sets won on the bad side, stamped at the crossing game", () => {
+    const events: EventType[] = [...baseEvents];
+    for (let i = 0; i < 5; i++) {
+      events.push(...twoBadSideSetsForWinner(`g${i}`, 100 + i * 10, "alice", "bob"));
+    }
+
+    const tt = calculated(events);
+
+    const awards = awardsOf(tt, "alice");
+    expect(awards).toHaveLength(1);
+    // The 5th game, which takes Alice from 8 sets to 10, is played at 140.
+    expect(awards[0].earnedAt).toBe(140);
+  });
+
+  it("awards the game loser for the sets they won on the bad side", () => {
+    // Bob loses every game 1-2, but the 1 set he wins is from the bad side:
+    // "G" means the game winner had the good side, so Bob had the bad one.
+    const events: EventType[] = [...baseEvents];
+    for (let i = 0; i < 10; i++) {
+      events.push(
+        ...game({
+          id: `g${i}`,
+          time: 100 + i * 10,
+          winner: "alice",
+          loser: "bob",
+          setPoints: [
+            { gameWinner: 11, gameLoser: 5 },
+            { gameWinner: 7, gameLoser: 11 },
+            { gameWinner: 11, gameLoser: 9 },
+          ],
+          sides: ["B", "G", "N"],
+        }),
+      );
+    }
+
+    const tt = calculated(events);
+
+    // Bob won 1 bad-side set per game and crosses on the 10th, at time 190.
+    const bobAwards = awardsOf(tt, "bob");
+    expect(bobAwards).toHaveLength(1);
+    expect(bobAwards[0].earnedAt).toBe(190);
+    // Alice won set 1 from the bad side too, so she crosses at the same game.
+    expect(awardsOf(tt, "alice")).toHaveLength(1);
+  });
+
+  it("does NOT count a set the player won from the good side", () => {
+    // The game winner takes both sets, but from the good side every time.
+    const events: EventType[] = [...baseEvents];
+    for (let i = 0; i < 10; i++) {
+      events.push(
+        ...game({
+          id: `g${i}`,
+          time: 100 + i * 10,
+          winner: "alice",
+          loser: "bob",
+          setPoints: [
+            { gameWinner: 11, gameLoser: 4 },
+            { gameWinner: 11, gameLoser: 6 },
+          ],
+          sides: ["G", "G"],
+        }),
+      );
+    }
+
+    const tt = calculated(events);
+
+    expect(awardsOf(tt, "alice")).toHaveLength(0);
+    expect(progressOf(tt, "alice").current).toBe(0);
+    // Bob was on the bad side of both sets and lost both, so he gets nothing.
+    expect(progressOf(tt, "bob").current).toBe(0);
+  });
+
+  it("does NOT count a set with 2 equally good sides", () => {
+    const events: EventType[] = [...baseEvents];
+    for (let i = 0; i < 10; i++) {
+      events.push(
+        ...game({
+          id: `g${i}`,
+          time: 100 + i * 10,
+          winner: "alice",
+          loser: "bob",
+          setPoints: [
+            { gameWinner: 11, gameLoser: 4 },
+            { gameWinner: 11, gameLoser: 6 },
+          ],
+          sides: ["N", "N"],
+        }),
+      );
+    }
+
+    const tt = calculated(events);
+
+    expect(awardsOf(tt, "alice")).toHaveLength(0);
+    expect(progressOf(tt, "alice").current).toBe(0);
+  });
+
+  it("does NOT count a set with no recorded side", () => {
+    const events: EventType[] = [...baseEvents];
+    for (let i = 0; i < 10; i++) {
+      // Only the first set has a side. The second one is unrecorded.
+      events.push(
+        ...game({
+          id: `g${i}`,
+          time: 100 + i * 10,
+          winner: "alice",
+          loser: "bob",
+          setPoints: [
+            { gameWinner: 11, gameLoser: 4 },
+            { gameWinner: 11, gameLoser: 6 },
+          ],
+          sides: ["B", null],
+        }),
+      );
+    }
+
+    const tt = calculated(events);
+
+    // 1 counted set per game: 10 games take Alice exactly to the target.
+    const awards = awardsOf(tt, "alice");
+    expect(awards).toHaveLength(1);
+    expect(awards[0].earnedAt).toBe(190);
+  });
+
+  it("does NOT count a game that records the sides without the points", () => {
+    const events: EventType[] = [...baseEvents];
+    for (let i = 0; i < 10; i++) {
+      events.push(
+        ...[
+          {
+            type: EventTypeEnum.GAME_CREATED,
+            stream: `g${i}`,
+            time: 100 + i * 10,
+            data: { winner: "alice", loser: "bob", playedAt: 100 + i * 10 },
+          } as EventType,
+          {
+            type: EventTypeEnum.GAME_SCORE,
+            stream: `g${i}`,
+            time: 100 + i * 10 + 1,
+            data: { setsWon: { gameWinner: 2, gameLoser: 0 }, gameWinnerSides: ["B", "B"] },
+          } as EventType,
+        ],
+      );
+    }
+
+    const tt = calculated(events);
+
+    // Who won each set is unknown without the points, so nothing counts.
+    expect(awardsOf(tt, "alice")).toHaveLength(0);
+    expect(progressOf(tt, "alice").current).toBe(0);
+  });
+
+  it("does NOT count a game that records the points without the sides", () => {
+    const events: EventType[] = [...baseEvents];
+    for (let i = 0; i < 10; i++) {
+      events.push(
+        ...game({
+          id: `g${i}`,
+          time: 100 + i * 10,
+          winner: "alice",
+          loser: "bob",
+          setPoints: [
+            { gameWinner: 11, gameLoser: 4 },
+            { gameWinner: 11, gameLoser: 6 },
+          ],
+        }),
+      );
+    }
+
+    const tt = calculated(events);
+
+    expect(awardsOf(tt, "alice")).toHaveLength(0);
+    expect(progressOf(tt, "alice").current).toBe(0);
+  });
+
+  it("does NOT award before the 10th set", () => {
+    const events: EventType[] = [...baseEvents];
+    for (let i = 0; i < 4; i++) {
+      events.push(...twoBadSideSetsForWinner(`g${i}`, 100 + i * 10, "alice", "bob"));
+    }
+
+    const tt = calculated(events);
+
+    expect(awardsOf(tt, "alice")).toHaveLength(0);
+    expect(progressOf(tt, "alice").current).toBe(8);
+  });
+
+  it("awards on the game that crosses the target, not only on an exact hit", () => {
+    const events: EventType[] = [...baseEvents];
+    // 3 sets per game: 3 games give 9 sets, and the 4th game crosses from 9.
+    for (let i = 0; i < 4; i++) {
+      events.push(
+        ...game({
+          id: `g${i}`,
+          time: 100 + i * 10,
+          winner: "alice",
+          loser: "bob",
+          setPoints: [
+            { gameWinner: 11, gameLoser: 4 },
+            { gameWinner: 4, gameLoser: 11 },
+            { gameWinner: 11, gameLoser: 6 },
+          ],
+          sides: ["B", "G", "B"],
+        }),
+      );
+    }
+
+    const tt = calculated(events);
+
+    // Alice wins sets 1 and 3 from the bad side: 2 per game, 8 after 4 games.
+    expect(progressOf(tt, "alice").current).toBe(8);
+    // Bob wins set 2 from the bad side: 1 per game, 4 after 4 games.
+    expect(progressOf(tt, "bob").current).toBe(4);
+
+    const events5 = [...events, ...twoBadSideSetsForWinner("g4", 200, "alice", "bob")];
+    const tt5 = calculated(events5);
+
+    // Alice goes from 8 to 10 in one game and is awarded at that game.
+    const awards = awardsOf(tt5, "alice");
+    expect(awards).toHaveLength(1);
+    expect(awards[0].earnedAt).toBe(200);
+  });
+
+  it("counts sets against different opponents", () => {
+    const events: EventType[] = [
+      ...baseEvents,
+      ...twoBadSideSetsForWinner("g1", 100, "alice", "bob"),
+      ...twoBadSideSetsForWinner("g2", 110, "alice", "chris"),
+      ...twoBadSideSetsForWinner("g3", 120, "alice", "bob"),
+      ...twoBadSideSetsForWinner("g4", 130, "alice", "chris"),
+      ...twoBadSideSetsForWinner("g5", 140, "alice", "bob"),
+    ];
+
+    const tt = calculated(events);
+
+    const awards = awardsOf(tt, "alice");
+    expect(awards).toHaveLength(1);
+    expect(awards[0].earnedAt).toBe(140);
+    // Neither opponent won a set, so neither has any progress.
+    expect(progressOf(tt, "bob").current).toBe(0);
+    expect(progressOf(tt, "chris").current).toBe(0);
+  });
+
+  it("is awarded only once, even as the count keeps growing", () => {
+    const events: EventType[] = [...baseEvents];
+    for (let i = 0; i < 12; i++) {
+      events.push(...twoBadSideSetsForWinner(`g${i}`, 100 + i * 10, "alice", "bob"));
+    }
+
+    const tt = calculated(events);
+
+    expect(awardsOf(tt, "alice")).toHaveLength(1);
+  });
+
+  it("caps progression at the target so the career total is not exposed", () => {
+    const events: EventType[] = [...baseEvents];
+    for (let i = 0; i < 12; i++) {
+      events.push(...twoBadSideSetsForWinner(`g${i}`, 100 + i * 10, "alice", "bob"));
+    }
+
+    const tt = calculated(events);
+
+    const progression = progressOf(tt, "alice");
+    expect(progression.current).toBe(10);
+    expect(progression.target).toBe(10);
+    expect(progression.earned).toBe(1);
+  });
+});

--- a/frontend/src/client/client-db/achievements.ts
+++ b/frontend/src/client/client-db/achievements.ts
@@ -94,6 +94,41 @@ export function isTrackedGame(game: Game): boolean {
   return (game.score?.pointSequences?.length ?? 0) > 0;
 }
 
+// Career sets won from the bad side of the table for "Bad Side Bandit". One
+// side of a table is often worse than the other, and a game can record which
+// player had it in each set. A set counts when the player on the bad side won
+// it, so the achievement rewards the wins the worse side makes harder — not
+// only taking part in a game where the sides are recorded. Recording the sides
+// is optional and takes effort, so the target is deliberately low.
+export const BAD_SIDE_BANDIT_TARGET = 10;
+
+// The sets of one game that each player won while on the bad side of the
+// table. A set counts only when the game records both its side and its points:
+// the side names who was on the bad side, the points name who won the set. A
+// set with no recorded side, or with 2 equally good sides ("N"), holds no bad
+// side and never counts.
+export function badSideSetsWon(game: Game): { gameWinner: number; gameLoser: number } {
+  const sides = game.score?.gameWinnerSides;
+  const setPoints = game.score?.setPoints;
+  if (sides === undefined || setPoints === undefined) return { gameWinner: 0, gameLoser: 0 };
+
+  let gameWinner = 0;
+  let gameLoser = 0;
+  sides.forEach((side, index) => {
+    if (side !== "B" && side !== "G") return;
+    const set = setPoints[index];
+    if (set === undefined || set.gameWinner === set.gameLoser) return;
+
+    // "B" means the game winner had the bad side, so the set went to the bad
+    // side when the game winner also won the set.
+    const gameWinnerWonSet = set.gameWinner > set.gameLoser;
+    if (gameWinnerWonSet !== (side === "B")) return;
+    if (gameWinnerWonSet) gameWinner++;
+    else gameLoser++;
+  });
+  return { gameWinner, gameLoser };
+}
+
 // Fewest players a season must have for "Full Coverage" — playing everyone
 // in a tiny season is not a feat. Matches the ≥5 cohort gate the rank and
 // full-house achievements use.
@@ -323,6 +358,7 @@ export class Achievements {
         edgeLordCount: number;
         consistencyCount: number;
         deuceSetsWon: number; // Career deuce sets won, for Deuce Demon
+        badSideSetsWon: number; // Career sets won on the bad side, for Bad Side Bandit
         trackedGamesPlayed: number; // Career tracked games played, for On the Record
         opponentsPlayed: Set<string>;
         gamesPerOpponent: Map<string, { count: number; firstGame: number; lastGame: number }>;
@@ -382,6 +418,7 @@ export class Achievements {
           edgeLordCount: 0,
           consistencyCount: 0,
           deuceSetsWon: 0,
+          badSideSetsWon: 0,
           trackedGamesPlayed: 0,
           opponentsPlayed: new Set(),
           gamesPerOpponent: new Map(),
@@ -413,6 +450,7 @@ export class Achievements {
           edgeLordCount: 0,
           consistencyCount: 0,
           deuceSetsWon: 0,
+          badSideSetsWon: 0,
           trackedGamesPlayed: 0,
           opponentsPlayed: new Set(),
           gamesPerOpponent: new Map(),
@@ -762,6 +800,11 @@ export class Achievements {
         // Check for "Deuce Demon": career deuce sets won. Either player can
         // win a qualifying set regardless of who wins the game.
         this.#checkDeuceDemonAchievement(game, winner, loser);
+
+        // Check for "Bad Side Bandit": career sets won from the bad side of
+        // the table. It needs the recorded sides as well as the points, so it
+        // only moves on a game that has both.
+        this.#checkBadSideBanditAchievement(game, winner, loser);
       }
 
       // Check for "On the Record": career games tracked point by point.
@@ -1997,6 +2040,31 @@ export class Achievements {
     applyDeuceSets(game.loser, loserTracker, loserDeuceSets);
   }
 
+  // "Bad Side Bandit": the career count of sets a player won while on the bad
+  // side of the table reaches BAD_SIDE_BANDIT_TARGET. Either player can win a
+  // qualifying set, whoever wins the game, so both counts can move on one game.
+  #checkBadSideBanditAchievement(
+    game: Game,
+    winnerTracker: { badSideSetsWon: number },
+    loserTracker: { badSideSetsWon: number },
+  ) {
+    const setsWon = badSideSetsWon(game);
+
+    const applyBadSideSets = (playerId: string, tracker: { badSideSetsWon: number }, sets: number) => {
+      if (sets === 0) return;
+      const before = tracker.badSideSetsWon;
+      tracker.badSideSetsWon += sets;
+      if (before < BAD_SIDE_BANDIT_TARGET && tracker.badSideSetsWon >= BAD_SIDE_BANDIT_TARGET) {
+        this.#addAchievement(
+          playerId,
+          this.#createAchievement("bad-side-bandit", playerId, game.playedAt, undefined),
+        );
+      }
+    };
+    applyBadSideSets(game.winner, winnerTracker, setsWon.gameWinner);
+    applyBadSideSets(game.loser, loserTracker, setsWon.gameLoser);
+  }
+
   // The sets that count toward a game's Shootout score: its
   // SHOOTOUT_SETS_COUNTED highest-scoring ones (all of them when the game has
   // fewer, earlier sets winning ties), returned in the order they were
@@ -3020,6 +3088,7 @@ export class Achievements {
       "consistency-is-key": { current: 0, target: 5, earned: 0 },
       "deuce-demon": { current: 0, target: DEUCE_DEMON_TARGET, earned: 0 },
       "on-the-record": { current: 0, target: ON_THE_RECORD_TARGET, earned: 0 },
+      "bad-side-bandit": { current: 0, target: BAD_SIDE_BANDIT_TARGET, earned: 0 },
       "photo-finish": { earned: 0 },
       "marathon-set": {
         earned: 0,
@@ -3119,6 +3188,7 @@ export class Achievements {
     let consistencyCount = 0;
     let bestDeuceSetWon = 0;
     let deuceSetsWonCount = 0;
+    let badSideSetsWonCount = 0;
     let trackedGamesPlayedCount = 0;
     const streaksPerOpponent = new Map<string, number>();
     // Highest win streak the player has EVER held against a single opponent —
@@ -3335,6 +3405,11 @@ export class Achievements {
         trackedGamesPlayedCount++;
       }
 
+      // Count the sets this player won on the bad side of the table, whether
+      // they won or lost the game.
+      const badSideSets = badSideSetsWon(game);
+      badSideSetsWonCount += isWinner ? badSideSets.gameWinner : badSideSets.gameLoser;
+
       // Track highest deuce-set winning score this player has won
       // (regardless of overall game outcome — the achievement is
       // awarded to set winners).
@@ -3378,6 +3453,8 @@ export class Achievements {
     // count never resets. Uncap it if a higher tracked-games tier is added,
     // the way Edge Lord keeps the Close Calls count uncapped.
     progression["on-the-record"].current = Math.min(trackedGamesPlayedCount, ON_THE_RECORD_TARGET);
+    // Bad Side Bandit caps at the target for the same reason.
+    progression["bad-side-bandit"].current = Math.min(badSideSetsWonCount, BAD_SIDE_BANDIT_TARGET);
     progression["variety-player"].current = opponentsPlayed.size;
     progression["variety-player"].opponents = opponentsPlayed;
     progression["global-player"].current = opponentsPlayed.size;
@@ -4121,6 +4198,9 @@ type AchievementDefinitions = {
   // Career games tracked point by point reached ON_THE_RECORD_TARGET.
   // A pure counter crossing — no game to point at.
   "on-the-record": undefined;
+  // Career sets won on the bad side of the table reached
+  // BAD_SIDE_BANDIT_TARGET. A pure counter crossing — no game to point at.
+  "bad-side-bandit": undefined;
   // Won GIANT_HUNTING_TARGET games against higher-ranked opponents within
   // one local calendar day. `day` is that day's local midnight; `giants` the
   // wins that filled the day's tally, each with the pre-match ranks and
@@ -4243,6 +4323,7 @@ export const ACHIEVEMENT_IS_REACHIEVABLE: Record<AchievementType, boolean> = {
   "everybodys-opponent": false,
   "deuce-demon": false,
   "on-the-record": false,
+  "bad-side-bandit": false,
   "giant-hunting": true, // Per qualifying day
   "party-pooper": true, // Per spoiled perfect day
   "earliest-game": true, // League records — can be retaken
@@ -4551,6 +4632,7 @@ export type AchievementProgression = {
   "everybodys-opponent": MissingPlayersProgression;
   "deuce-demon": ProgressionWithTarget;
   "on-the-record": ProgressionWithTarget;
+  "bad-side-bandit": ProgressionWithTarget;
   "giant-hunting": ProgressionWithTarget;
   "party-pooper": BaseProgression;
   "earliest-game": TimeOfDayRecordProgression;

--- a/frontend/src/pages/player/achievement-groups.ts
+++ b/frontend/src/pages/player/achievement-groups.ts
@@ -82,6 +82,7 @@ export const ACHIEVEMENT_GROUPS: AchievementGroup[] = [
       "consistency-is-key",
       "deuce-demon",
       "on-the-record",
+      "bad-side-bandit",
       "photo-finish",
       "marathon-set",
       "shootout",

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -365,13 +365,12 @@ export const ACHIEVEMENT_LABELS: Record<AchievementType, { title: string; descri
   },
   "on-the-record": {
     title: "On the Record",
-    description: "Play 5 games tracked point by point — the games marked 🔴",
+    description: "Play 5 games tracked point by point",
     icon: "🔴",
   },
   "bad-side-bandit": {
     title: "Bad Side Bandit",
-    description:
-      "Win 10 sets from the bad side of the table — the games that record the sides are marked 😵",
+    description: "Win 10 sets from the bad side of the table",
     icon: "😵",
   },
   "giant-hunting": {

--- a/frontend/src/pages/player/player-achievements.tsx
+++ b/frontend/src/pages/player/player-achievements.tsx
@@ -368,6 +368,12 @@ export const ACHIEVEMENT_LABELS: Record<AchievementType, { title: string; descri
     description: "Play 5 games tracked point by point — the games marked 🔴",
     icon: "🔴",
   },
+  "bad-side-bandit": {
+    title: "Bad Side Bandit",
+    description:
+      "Win 10 sets from the bad side of the table — the games that record the sides are marked 😵",
+    icon: "😵",
+  },
   "giant-hunting": {
     title: "Giant Hunting",
     description: "Win 3 games against higher-ranked players in a single day (the same player can count more than once)",


### PR DESCRIPTION
Adds a new achievement that rewards players for winning sets from the bad side of the table.

## Summary
Bad Side Bandit is a one-time achievement earned when a player wins 10 sets from the bad side of the table across their career. A set counts only when the game records both the side (which player had the bad side) and the set points (who won the set). The achievement can be earned by either the game winner or loser, depending on who won sets from the bad side.

## Changes
- **Achievement logic** (`achievements.ts`):
  - Added `badSideSetsWon()` function to calculate sets won from the bad side for each player in a game
  - Added `BAD_SIDE_BANDIT_TARGET` constant (10 sets)
  - Implemented `#checkBadSideBanditAchievement()` to track progress and award when target is crossed
  - Integrated achievement check into the game processing pipeline
  - Added progression tracking and capping at target (to avoid exposing career totals)

- **Test coverage** (`bad-side-bandit.test.ts`):
  - Comprehensive test suite covering all qualifying conditions
  - Tests for both game winner and loser earning sets
  - Tests for invalid cases (good side, neutral sides, missing data)
  - Tests for progression capping and one-time award behavior
  - Tests for cross-opponent counting

- **UI and changelog**:
  - Added achievement label with title, description, and 😵 icon
  - Added to achievement groups list
  - Added changelog post explaining the feature and its rules

## Implementation Details
A set qualifies when:
- The game records both `gameWinnerSides` and `setPoints`
- The side is either "B" (bad side) or "G" (good side), not "N" (neutral) or null
- The player on the bad side won the set (determined by comparing side marker with set winner)

The achievement is awarded when a player's career count crosses or reaches 10, stamped at the game where the crossing occurs. Progress is capped at the target to prevent exposing total career counts in the progression display.

https://claude.ai/code/session_013tHbjTdwXtqsSSGwRN3BLp