### PR TITLE
Replace the loading animation with a simulated rally

### DIFF
--- a/frontend/src/common/paddle-rally-loader.tsx
+++ b/frontend/src/common/paddle-rally-loader.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+
+/**
+ * The previous loading screen, kept for later use.
+ *
+ * Two bats tick and the ball crosses on one fixed flat arc, mirrored back and forth.
+ * It is pure SVG and CSS keyframes, with no frame loop and no canvas, so it is the
+ * cheaper of the two loaders and the one to reach for if the simulated rally in
+ * `ping-loader.tsx` ever needs to be swapped out.
+ *
+ * Nothing renders this today. It is deliberately kept rather than left in the git
+ * history so it stays easy to find and to put back.
+ */
+export const PaddleRallyLoader: React.FC = () => {
+  const size = 400;
+  const strokeWidth = 4;
+  const speed = 2;
+  const duration = 1.2 / speed;
+  const racket1Color = "rgb(var(--color-tertiary-background))";
+  const racket2Color = "rgb(var(--color-tertiary-background))";
+  const tableColor = "rgb(var(--color-secondary-background))";
+  const netColor = "rgb(var(--color-secondary-background))";
+  const ballColor = "rgb(var(--color-primary-text))";
+
+  return (
+    <div className="flex items-center justify-center p-8">
+      <svg width={size} height={size * 0.5} viewBox="0 0 200 100" fill="none" className="overflow-visible">
+        {/* Simple table line */}
+        <line x1="60" y1="70" x2="140" y2="70" stroke={tableColor} strokeWidth={strokeWidth} />
+
+        {/* Net */}
+        <line x1="100" y1="50" x2="100" y2="70" stroke={netColor} strokeWidth={strokeWidth} />
+
+        {/* Left paddle - simple circle */}
+        <g
+          style={{
+            animation: `minimalPaddleLeft ${duration}s ease-in-out infinite`,
+            transformOrigin: "40px 50px",
+          }}
+        >
+          <circle cx="40" cy="50" r="15" stroke={racket1Color} strokeWidth={strokeWidth} fill="none" />
+          <line x1="40" y1="65" x2="40" y2="80" stroke={racket1Color} strokeWidth={strokeWidth * 1.5} />
+        </g>
+
+        {/* Right paddle - simple circle */}
+        <g
+          style={{
+            animation: `minimalPaddleRight ${duration}s ease-in-out infinite`,
+            animationDelay: `${duration / 2}s`,
+            transformOrigin: "160px 50px",
+          }}
+        >
+          <circle cx="160" cy="50" r="15" stroke={racket2Color} strokeWidth={strokeWidth} fill="none" />
+          <line x1="160" y1="65" x2="160" y2="80" stroke={racket2Color} strokeWidth={strokeWidth * 1.5} />
+        </g>
+
+        {/* Ball - simple dot */}
+        <circle
+          cx="100"
+          cy="50"
+          r="4"
+          fill={ballColor}
+          style={{
+            animation: `minimalBall ${duration}s linear infinite`,
+          }}
+        />
+
+        <style>{`
+          @keyframes minimalPaddleLeft {
+            0%, 100% { 
+              transform: rotate(0deg);
+            }
+            50% { 
+              transform: rotate(-10deg) translateY(-3px);
+            }
+          }
+          
+          @keyframes minimalPaddleRight {
+            0%, 100% { 
+              transform: rotate(0deg);
+            }
+            50% { 
+              transform: rotate(10deg) translateY(-3px);
+            }
+          }
+          
+          @keyframes minimalBall {
+            0%, 100% { 
+              transform: translate(-45px, 0px);
+            }
+            12.5% {
+              transform: translate(-22.5px, -8px);
+            }
+            25% {
+              transform: translate(0px, -10px);
+            }
+            37.5% {
+              transform: translate(22.5px, -8px);
+            }
+            50% { 
+              transform: translate(45px, 0px);
+            }
+            62.5% {
+              transform: translate(22.5px, -8px);
+            }
+            75% {
+              transform: translate(0px, -10px);
+            }
+            87.5% {
+              transform: translate(-22.5px, -8px);
+            }
+          }
+        `}</style>
+      </svg>
+    </div>
+  );
+};

--- a/frontend/src/common/ping-loader.tsx
+++ b/frontend/src/common/ping-loader.tsx
@@ -65,6 +65,10 @@ function rgba(channels: string, alpha: number): string {
  * that is never cleared is the usual way to do this, but it leaves a permanent
  * ghost: below about 5/255 the 8 bit alpha multiply rounds back to itself, so the
  * oldest part of the path stops fading and builds up behind the rally.
+ *
+ * The loader this replaced is kept as `PaddleRallyLoader` in `paddle-rally-loader.tsx`.
+ * It is pure SVG and CSS keyframes, and it is there to swap back in if this one ever
+ * needs to go.
  */
 export const PingPongLoader: React.FC = () => {
   const rootRef = useRef<HTMLDivElement>(null);

--- a/frontend/src/common/ping-loader.tsx
+++ b/frontend/src/common/ping-loader.tsx
@@ -1,106 +1,308 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
+import { CONTACT_Y, Direction, Point, RALLY, Stroke, planStroke, positionAt } from "./rally-simulation";
 
+/** How fast the rally is played back. */
+const PACE = 1.45;
+/** How much of the ball's path is still visible behind it, in seconds. */
+const TRAIL_SECONDS = 0.85;
+/** How widely the speed and the bounce point vary from stroke to stroke. */
+const VARIATION = 0.7;
+
+/** The physics runs on a fixed step, so a fast ball still traces its curve. */
+const SUBSTEP = 0.004;
+/** Enough positions to hold the longest trail. */
+const HISTORY = 256;
+/** How wide the trail is where it leaves the ball, and how fast it narrows. */
+const TRAIL_WIDTH = 2.8;
+const TRAIL_TAPER = 0.9;
+const TRAIL_ALPHA = 0.85;
+
+/** The slice of the court the canvas shows. */
+const VIEW_WIDTH = 200;
+const VIEW_TOP = 14;
+const VIEW_HEIGHT = 92;
+
+const TABLE_WIDTH = 3.2;
+const BOUNCE_RING_SECONDS = 0.3;
+/** How much the ball flattens as it meets the table. */
+const SQUASH = 0.32;
+
+type Palette = { ball: string; table: string; trail: string };
+
+/**
+ * Read the theme through the element itself, so the loader follows whichever
+ * `theme-*` class is on an ancestor. The tokens hold "r,g,b" rather than a colour.
+ */
+function readPalette(element: HTMLElement): Palette {
+  const style = getComputedStyle(element);
+  const token = (name: string, fallback: string) => style.getPropertyValue(name).trim() || fallback;
+  return {
+    ball: token("--color-primary-text", "255,255,255"),
+    table: token("--color-secondary-background", "107,114,128"),
+    trail: token("--color-tertiary-background", "255,255,255"),
+  };
+}
+
+function rgba(channels: string, alpha: number): string {
+  return `rgba(${channels},${alpha})`;
+}
+
+/**
+ * The loading screen: a table tennis rally, simulated rather than animated.
+ *
+ * It draws to two stacked canvases. The trail layer draws the recorded path of the
+ * ball, and the scene layer holds the table, the net and the ball. Keeping them
+ * apart stops the ball painting its own width into the trail.
+ *
+ * The trail is one filled polygon: a ribbon that runs up one side of the recorded
+ * path and back down the other, narrowing to a point at the far end. Drawing it in
+ * one piece is what keeps it smooth. Every way of building the same fade out of
+ * many strokes shows the joins between them, because a stroke that overlaps its
+ * neighbour composites brighter at the overlap and one that stops short of its
+ * neighbour leaves a notch on the outside of a turn.
+ *
+ * The trail is rebuilt from a ring buffer of positions every frame. Fading a canvas
+ * that is never cleared is the usual way to do this, but it leaves a permanent
+ * ghost: below about 5/255 the 8 bit alpha multiply rounds back to itself, so the
+ * oldest part of the path stops fading and builds up behind the rally.
+ */
 export const PingPongLoader: React.FC = () => {
-  const size = 400;
-  const strokeWidth = 4;
-  const speed = 2;
-  const duration = 1.2 / speed;
-  const racket1Color = "rgb(var(--color-tertiary-background))";
-  const racket2Color = "rgb(var(--color-tertiary-background))";
-  const tableColor = "rgb(var(--color-secondary-background))";
-  const netColor = "rgb(var(--color-secondary-background))";
-  const ballColor = "rgb(var(--color-primary-text))";
+  const rootRef = useRef<HTMLDivElement>(null);
+  const trailRef = useRef<HTMLCanvasElement>(null);
+  const sceneRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    const trailCanvas = trailRef.current;
+    const sceneCanvas = sceneRef.current;
+    if (!root || !trailCanvas || !sceneCanvas) return;
+
+    const trail = trailCanvas.getContext("2d");
+    const scene = sceneCanvas.getContext("2d");
+    if (!trail || !scene) return;
+
+    let palette = readPalette(root);
+    const prefersStill =
+      typeof window.matchMedia === "function" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    // --- the rally ---------------------------------------------------------
+    let stroke: Stroke = planStroke(1, RALLY.leftX, 60, VARIATION);
+    let elapsed = 0;
+    let leftover = 0;
+    const ball: Point = { x: stroke.x0, y: stroke.y0 };
+
+    const historyX = new Float32Array(HISTORY);
+    const historyY = new Float32Array(HISTORY);
+    let head = 0;
+    let recorded = 0;
+
+    let bounceX = 0;
+    let bounceAge = -1;
+
+    /** Advance the rally by exactly one substep and record where the ball is. */
+    function advance() {
+      const before = elapsed;
+      elapsed += SUBSTEP;
+
+      if (before < stroke.bounceTime && elapsed >= stroke.bounceTime) {
+        bounceX = stroke.bounceX;
+        bounceAge = 0;
+      }
+      // The bat reverses the ball in the same step it arrives, and time past the end
+      // of the stroke is carried into the next one, so the ball never waits.
+      if (elapsed >= stroke.duration) {
+        const carried = elapsed - stroke.duration;
+        const next: Direction = stroke.direction > 0 ? -1 : 1;
+        stroke = planStroke(next, stroke.targetX, stroke.targetY, VARIATION);
+        elapsed = carried;
+      }
+
+      positionAt(stroke, elapsed, ball);
+      historyX[head] = ball.x;
+      historyY[head] = ball.y;
+      head = (head + 1) % HISTORY;
+      if (recorded < HISTORY) recorded++;
+    }
+
+    // --- the canvases ------------------------------------------------------
+    function scaleCanvas(canvas: HTMLCanvasElement, context: CanvasRenderingContext2D) {
+      const ratio = Math.min(window.devicePixelRatio || 1, 2);
+      const width = canvas.clientWidth || VIEW_WIDTH;
+      canvas.width = Math.round(width * ratio);
+      canvas.height = Math.round(((width * VIEW_HEIGHT) / VIEW_WIDTH) * ratio);
+      const scale = canvas.width / VIEW_WIDTH;
+      context.setTransform(scale, 0, 0, scale, 0, -VIEW_TOP * scale);
+      context.lineCap = "round";
+      context.lineJoin = "round";
+    }
+
+    function resize() {
+      if (!trailCanvas || !sceneCanvas || !trail || !scene || !root) return;
+      // Setting the width clears the canvas, so anything on it has to be put back.
+      scaleCanvas(trailCanvas, trail);
+      scaleCanvas(sceneCanvas, scene);
+      palette = readPalette(root);
+      // While the rally is running the next frame repaints anyway. A still frame
+      // has no next frame, so it is repainted here or it is lost.
+      if (prefersStill) repaint();
+    }
+
+    // --- drawing -----------------------------------------------------------
+    // The unit normal to the path at each recorded position, so the ribbon can be
+    // offset to either side. Allocated once and rewritten in place.
+    const normalX = new Float32Array(HISTORY);
+    const normalY = new Float32Array(HISTORY);
+
+    function recordedAt(stepsBack: number): number {
+      return (head - 1 - stepsBack + HISTORY * 2) % HISTORY;
+    }
+
+    function drawTrail(context: CanvasRenderingContext2D) {
+      context.clearRect(0, VIEW_TOP, VIEW_WIDTH, VIEW_HEIGHT);
+
+      const segments = Math.min(recorded - 1, Math.round(TRAIL_SECONDS / SUBSTEP));
+      if (segments <= 2) return;
+
+      // A one sided difference, looking back in time. A centred one would average
+      // the two legs where the ball reverses off a bat, cancel out, and leave the
+      // cross section pointing nowhere; this keeps the corner instead.
+      for (let step = 0; step <= segments; step++) {
+        const here = recordedAt(Math.min(segments - 1, step));
+        const older = recordedAt(Math.min(segments, step + 1));
+        const dx = historyX[here] - historyX[older];
+        const dy = historyY[here] - historyY[older];
+        const length = Math.hypot(dx, dy);
+        if (length < 1e-6) {
+          normalX[step] = normalX[Math.max(0, step - 1)];
+          normalY[step] = normalY[Math.max(0, step - 1)];
+        } else {
+          normalX[step] = -dy / length;
+          normalY[step] = dx / length;
+        }
+      }
+
+      const halfWidth = (step: number) =>
+        (TRAIL_WIDTH / 2) * Math.pow(1 - step / segments, TRAIL_TAPER);
+
+      context.globalAlpha = TRAIL_ALPHA;
+      context.fillStyle = rgba(palette.trail, 1);
+      context.beginPath();
+      for (let step = 0; step <= segments; step++) {
+        const at = recordedAt(step);
+        const half = halfWidth(step);
+        const x = historyX[at] + normalX[step] * half;
+        const y = historyY[at] + normalY[step] * half;
+        if (step === 0) context.moveTo(x, y);
+        else context.lineTo(x, y);
+      }
+      for (let step = segments; step >= 0; step--) {
+        const at = recordedAt(step);
+        const half = halfWidth(step);
+        context.lineTo(historyX[at] - normalX[step] * half, historyY[at] - normalY[step] * half);
+      }
+      context.closePath();
+      context.fill();
+      context.globalAlpha = 1;
+    }
+
+    function drawScene(context: CanvasRenderingContext2D, seconds: number) {
+      context.clearRect(0, VIEW_TOP, VIEW_WIDTH, VIEW_HEIGHT);
+
+      context.strokeStyle = rgba(palette.table, 1);
+      context.lineWidth = TABLE_WIDTH;
+      context.beginPath();
+      context.moveTo(RALLY.tableX0, RALLY.tableY);
+      context.lineTo(RALLY.tableX1, RALLY.tableY);
+      context.moveTo(RALLY.netX, RALLY.netTop);
+      context.lineTo(RALLY.netX, RALLY.tableY);
+      context.stroke();
+
+      if (bounceAge >= 0) {
+        bounceAge += seconds;
+        const age = bounceAge / BOUNCE_RING_SECONDS;
+        if (age >= 1) {
+          bounceAge = -1;
+        } else {
+          context.strokeStyle = rgba(palette.trail, 0.45 * (1 - age));
+          context.lineWidth = 1.4;
+          context.beginPath();
+          context.arc(bounceX, RALLY.tableY, 3 + 11 * age, 0, Math.PI * 2);
+          context.stroke();
+        }
+      }
+
+      const nearness = Math.max(0, 1 - (CONTACT_Y - ball.y) / 7);
+      context.fillStyle = rgba(palette.ball, 1);
+      context.beginPath();
+      context.ellipse(
+        ball.x,
+        ball.y,
+        RALLY.ballRadius * (1 + SQUASH * nearness),
+        RALLY.ballRadius * (1 - SQUASH * 0.94 * nearness),
+        0,
+        0,
+        Math.PI * 2,
+      );
+      context.fill();
+    }
+
+    function draw(seconds: number) {
+      if (!trail || !scene) return;
+      leftover += seconds;
+      let guard = 0;
+      while (leftover >= SUBSTEP && guard++ < 200) {
+        leftover -= SUBSTEP;
+        advance();
+      }
+      drawTrail(trail);
+      drawScene(scene, seconds);
+    }
+
+    // --- the loop ----------------------------------------------------------
+    function repaint() {
+      if (!trail || !scene) return;
+      drawTrail(trail);
+      drawScene(scene, 0);
+    }
+
+    resize();
+
+    const observer = typeof ResizeObserver === "undefined" ? undefined : new ResizeObserver(() => resize());
+    observer?.observe(trailCanvas);
+    window.addEventListener("resize", resize);
+
+    let frame = 0;
+    if (prefersStill) {
+      // One readable frame of a rally, and then nothing moves.
+      for (let step = 0; step < 200; step++) draw(SUBSTEP);
+    } else {
+      let previous = 0;
+      const tick = (now: number) => {
+        if (!previous) previous = now;
+        draw(Math.min(0.05, (now - previous) / 1000) * PACE);
+        previous = now;
+        frame = requestAnimationFrame(tick);
+      };
+      frame = requestAnimationFrame(tick);
+    }
+
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+      observer?.disconnect();
+      window.removeEventListener("resize", resize);
+    };
+  }, []);
 
   return (
-    <div className="flex items-center justify-center p-8">
-      <svg width={size} height={size * 0.5} viewBox="0 0 200 100" fill="none" className="overflow-visible">
-        {/* Simple table line */}
-        <line x1="60" y1="70" x2="140" y2="70" stroke={tableColor} strokeWidth={strokeWidth} />
-
-        {/* Net */}
-        <line x1="100" y1="50" x2="100" y2="70" stroke={netColor} strokeWidth={strokeWidth} />
-
-        {/* Left paddle - simple circle */}
-        <g
-          style={{
-            animation: `minimalPaddleLeft ${duration}s ease-in-out infinite`,
-            transformOrigin: "40px 50px",
-          }}
-        >
-          <circle cx="40" cy="50" r="15" stroke={racket1Color} strokeWidth={strokeWidth} fill="none" />
-          <line x1="40" y1="65" x2="40" y2="80" stroke={racket1Color} strokeWidth={strokeWidth * 1.5} />
-        </g>
-
-        {/* Right paddle - simple circle */}
-        <g
-          style={{
-            animation: `minimalPaddleRight ${duration}s ease-in-out infinite`,
-            animationDelay: `${duration / 2}s`,
-            transformOrigin: "160px 50px",
-          }}
-        >
-          <circle cx="160" cy="50" r="15" stroke={racket2Color} strokeWidth={strokeWidth} fill="none" />
-          <line x1="160" y1="65" x2="160" y2="80" stroke={racket2Color} strokeWidth={strokeWidth * 1.5} />
-        </g>
-
-        {/* Ball - simple dot */}
-        <circle
-          cx="100"
-          cy="50"
-          r="4"
-          fill={ballColor}
-          style={{
-            animation: `minimalBall ${duration}s linear infinite`,
-          }}
-        />
-
-        <style>{`
-          @keyframes minimalPaddleLeft {
-            0%, 100% { 
-              transform: rotate(0deg);
-            }
-            50% { 
-              transform: rotate(-10deg) translateY(-3px);
-            }
-          }
-          
-          @keyframes minimalPaddleRight {
-            0%, 100% { 
-              transform: rotate(0deg);
-            }
-            50% { 
-              transform: rotate(10deg) translateY(-3px);
-            }
-          }
-          
-          @keyframes minimalBall {
-            0%, 100% { 
-              transform: translate(-45px, 0px);
-            }
-            12.5% {
-              transform: translate(-22.5px, -8px);
-            }
-            25% {
-              transform: translate(0px, -10px);
-            }
-            37.5% {
-              transform: translate(22.5px, -8px);
-            }
-            50% { 
-              transform: translate(45px, 0px);
-            }
-            62.5% {
-              transform: translate(22.5px, -8px);
-            }
-            75% {
-              transform: translate(0px, -10px);
-            }
-            87.5% {
-              transform: translate(-22.5px, -8px);
-            }
-          }
-        `}</style>
-      </svg>
+    <div ref={rootRef} className="flex w-full items-center justify-center p-6">
+      <div
+        className="relative aspect-[200/92] w-full max-w-xl"
+        role="img"
+        aria-label="Loading. A table tennis ball plays a rally."
+      >
+        <canvas ref={trailRef} className="absolute inset-0 h-full w-full" />
+        <canvas ref={sceneRef} className="absolute inset-0 h-full w-full" />
+      </div>
     </div>
   );
 };

--- a/frontend/src/common/rally-simulation.test.ts
+++ b/frontend/src/common/rally-simulation.test.ts
@@ -1,0 +1,148 @@
+import {
+  CONTACT_Y,
+  Direction,
+  FALLBACK_STROKE,
+  Point,
+  RALLY,
+  Stroke,
+  isStrokePlayable,
+  planStroke,
+  positionAt,
+} from "./rally-simulation";
+
+const NET_CLEARANCE_Y = RALLY.netTop - RALLY.ballRadius;
+
+/** Play a rally and hand back every stroke in it, exactly as the loader does. */
+function playRally(strokeCount: number, variation: number, random?: () => number): Stroke[] {
+  const strokes: Stroke[] = [];
+  let direction: Direction = 1;
+  let x: number = RALLY.leftX;
+  let y = 60;
+
+  for (let i = 0; i < strokeCount; i++) {
+    const stroke = planStroke(direction, x, y, variation, random);
+    strokes.push(stroke);
+    direction = stroke.direction > 0 ? -1 : 1;
+    x = stroke.targetX;
+    y = stroke.targetY;
+  }
+  return strokes;
+}
+
+/** The height of the ball as it passes the net, derived from the flight itself. */
+function heightAtNet(stroke: Stroke): number {
+  const time = (RALLY.netX - stroke.x0) / stroke.velocityX;
+  return positionAt(stroke, time, { x: 0, y: 0 }).y;
+}
+
+describe("planStroke", () => {
+  const variations = [0, 0.3, 0.7, 1];
+
+  it.each(variations)("plays a legal rally at variation %p", (variation) => {
+    const strokes = playRally(2000, variation);
+    const point: Point = { x: 0, y: 0 };
+
+    for (const stroke of strokes) {
+      // The ball passes over the net rather than into it.
+      expect(heightAtNet(stroke)).toBeLessThanOrEqual(NET_CLEARANCE_Y);
+
+      // It bounces once, on the far half, and on the table.
+      expect(stroke.direction * (stroke.bounceX - RALLY.netX)).toBeGreaterThan(0);
+      expect(stroke.bounceX).toBeGreaterThanOrEqual(RALLY.tableX0);
+      expect(stroke.bounceX).toBeLessThanOrEqual(RALLY.tableX1);
+      expect(positionAt(stroke, stroke.bounceTime, point).y).toBeCloseTo(CONTACT_Y, 6);
+
+      // It stays above the table from the bounce to the far bat.
+      for (let step = 1; step < 20; step++) {
+        const time = stroke.bounceTime + (stroke.returnTime * step) / 20;
+        expect(positionAt(stroke, time, point).y).toBeLessThanOrEqual(CONTACT_Y + 1e-6);
+      }
+
+      // It arrives where the far side can return it.
+      expect(stroke.targetY).toBeGreaterThanOrEqual(RALLY.hitHighest);
+      expect(stroke.targetY).toBeLessThanOrEqual(RALLY.hitLowest);
+      expect(positionAt(stroke, stroke.duration, point).x).toBeCloseTo(stroke.targetX, 6);
+
+      // It stays inside the frame.
+      expect(stroke.apexY).toBeGreaterThanOrEqual(RALLY.apexHighest);
+    }
+  });
+
+  it("alternates sides and starts each stroke where the last one landed", () => {
+    const strokes = playRally(500, 0.7);
+
+    for (let i = 1; i < strokes.length; i++) {
+      const previous = strokes[i - 1];
+      const stroke = strokes[i];
+      expect(stroke.direction).toBe(-previous.direction);
+      expect(stroke.x0).toBe(previous.targetX);
+      expect(stroke.y0).toBe(previous.targetY);
+    }
+  });
+
+  it("varies the speed, the arc and the bounce point from stroke to stroke", () => {
+    const strokes = playRally(2000, 0.7);
+    const spread = (values: number[]) => Math.max(...values) - Math.min(...values);
+
+    expect(spread(strokes.map((s) => s.speed))).toBeGreaterThan(100);
+    expect(spread(strokes.map((s) => RALLY.tableY - s.apexY))).toBeGreaterThan(20);
+    expect(spread(strokes.map((s) => s.duration))).toBeGreaterThan(0.2);
+    // A stroke lasts long enough to watch and short enough to keep the rally moving.
+    for (const stroke of strokes) {
+      expect(stroke.duration).toBeGreaterThan(0.3);
+      expect(stroke.duration).toBeLessThan(1.5);
+    }
+  });
+
+  it("still returns a playable stroke when every drawn plan fails", () => {
+    // A random source stuck at one end makes all 120 attempts identical, so the
+    // planner exhausts both searches and has to fall back.
+    for (const stuck of [() => 0, () => 0.999999]) {
+      for (const stroke of playRally(20, 0.7, stuck)) {
+        expect(isStrokePlayable(stroke)).toBe(true);
+      }
+    }
+  });
+
+  it("has a fallback that is playable from either bat", () => {
+    expect(isStrokePlayable(FALLBACK_STROKE(1, RALLY.leftX))).toBe(true);
+    expect(isStrokePlayable(FALLBACK_STROKE(-1, RALLY.rightX))).toBe(true);
+  });
+});
+
+describe("positionAt", () => {
+  const stroke = planStroke(1, RALLY.leftX, 60, 0.7, () => 0.5);
+
+  it("starts at the bat and ends at the far bat", () => {
+    expect(positionAt(stroke, 0, { x: 0, y: 0 })).toEqual({ x: stroke.x0, y: stroke.y0 });
+
+    const end = positionAt(stroke, stroke.duration, { x: 0, y: 0 });
+    expect(end.x).toBeCloseTo(stroke.targetX, 6);
+    expect(end.y).toBeCloseTo(stroke.targetY, 6);
+  });
+
+  it("is continuous across the bounce", () => {
+    const before = positionAt(stroke, stroke.bounceTime - 1e-9, { x: 0, y: 0 });
+    const after = positionAt(stroke, stroke.bounceTime + 1e-9, { x: 0, y: 0 });
+    expect(after.x).toBeCloseTo(before.x, 6);
+    expect(after.y).toBeCloseTo(before.y, 6);
+  });
+
+  it("moves at a constant horizontal speed", () => {
+    const a = positionAt(stroke, 0.1, { x: 0, y: 0 }).x;
+    const b = positionAt(stroke, 0.2, { x: 0, y: 0 }).x;
+    expect(b - a).toBeCloseTo(stroke.velocityX * 0.1, 6);
+  });
+
+  it("rises to the apex and comes back down", () => {
+    const timeToApex = -stroke.velocityY / RALLY.gravity;
+    expect(positionAt(stroke, timeToApex, { x: 0, y: 0 }).y).toBeCloseTo(stroke.apexY, 6);
+    expect(positionAt(stroke, timeToApex - 0.05, { x: 0, y: 0 }).y).toBeGreaterThan(stroke.apexY);
+    expect(positionAt(stroke, timeToApex + 0.05, { x: 0, y: 0 }).y).toBeGreaterThan(stroke.apexY);
+  });
+
+  it("writes into the point it is given instead of allocating", () => {
+    const point: Point = { x: 0, y: 0 };
+    expect(positionAt(stroke, 0.2, point)).toBe(point);
+  });
+});

--- a/frontend/src/common/rally-simulation.ts
+++ b/frontend/src/common/rally-simulation.ts
@@ -1,0 +1,212 @@
+/**
+ * A table tennis rally, solved rather than animated.
+ *
+ * The rally runs as a loop of four stages: the left side hits the ball, the ball
+ * bounces once on the right half, the right side hits it, the ball bounces once on
+ * the left half. Each stroke is planned on its own, so the speed, the arc and the
+ * bounce point change from stroke to stroke.
+ *
+ * The model is constant gravity and one restitution value. No drag and no spin.
+ * A stroke picks a horizontal speed and a bounce point, then solves for the launch
+ * angle that makes the ball meet the table exactly there. Solving the angle instead
+ * of choosing it keeps the speed and the arc tied together the way they are on a
+ * real table: a fast stroke comes through low over the net and lands deep, and a
+ * slow stroke has to be lifted and loops.
+ *
+ * All lengths are in the drawing units of the loader, not in centimetres.
+ */
+
+/** The court, in drawing units. The frame is 200 wide and spans y 14 to 106. */
+export const RALLY = {
+  /** Downwards, since y grows downwards. */
+  gravity: 900,
+  /** The share of vertical speed the table gives back on the bounce. */
+  restitution: 0.72,
+  ballRadius: 4,
+  tableY: 88,
+  tableX0: 26,
+  tableX1: 174,
+  netX: 100,
+  netTop: 70,
+  /** Where each side makes contact, just off each end of the table. */
+  leftX: 22,
+  rightX: 178,
+  /** The band of contact heights a player can return. */
+  hitHighest: 30,
+  hitLowest: 78,
+  /** The ball stays inside the frame. */
+  apexHighest: 20,
+} as const;
+
+/** The height of the ball's centre when it touches the table. */
+export const CONTACT_Y = RALLY.tableY - RALLY.ballRadius;
+
+/** The ball must pass this high over the net, with a little to spare. */
+const NET_CLEARANCE_Y = RALLY.netTop - RALLY.ballRadius - 1;
+
+/** How far into the far half the bounce must land, so it never clips the net. */
+const BOUNCE_MARGIN = 16;
+
+/** 1 plays left to right, -1 plays right to left. */
+export type Direction = 1 | -1;
+
+export type Point = { x: number; y: number };
+
+/** A source of numbers in [0, 1). Injected so the tests can drive it. */
+export type Random = () => number;
+
+/** One stroke: the flight from a bat, over the net, off the table, to the far bat. */
+export type Stroke = {
+  readonly direction: Direction;
+  /** Where the bat made contact. */
+  readonly x0: number;
+  readonly y0: number;
+  readonly velocityX: number;
+  readonly velocityY: number;
+  /** Time from the bat to the bounce. */
+  readonly bounceTime: number;
+  readonly bounceX: number;
+  /** Vertical speed leaving the bounce. */
+  readonly reboundVelocityY: number;
+  /** Time from the bounce to the far bat. */
+  readonly returnTime: number;
+  /** The whole flight, bat to bat. */
+  readonly duration: number;
+  /** Where the far side makes contact. */
+  readonly targetX: number;
+  readonly targetY: number;
+  /** Read out by the loader for nothing, and by the tests for everything. */
+  readonly apexY: number;
+  readonly speed: number;
+};
+
+function farBatX(direction: Direction): number {
+  return direction > 0 ? RALLY.rightX : RALLY.leftX;
+}
+
+/**
+ * Build a stroke from a horizontal speed and a bounce distance, with no checking.
+ * The launch angle is solved so the ball meets the table exactly at the bounce.
+ */
+function solve(direction: Direction, x0: number, y0: number, speed: number, distance: number): Stroke {
+  const velocityX = direction * speed;
+  const bounceX = x0 + direction * distance;
+  const bounceTime = distance / speed;
+
+  const velocityY = (CONTACT_Y - y0 - 0.5 * RALLY.gravity * bounceTime * bounceTime) / bounceTime;
+  const apexY = velocityY < 0 ? y0 - (velocityY * velocityY) / (2 * RALLY.gravity) : y0;
+
+  const reboundVelocityY = -RALLY.restitution * (velocityY + RALLY.gravity * bounceTime);
+  const targetX = farBatX(direction);
+  const returnTime = (targetX - bounceX) / velocityX;
+  const targetY =
+    CONTACT_Y + reboundVelocityY * returnTime + 0.5 * RALLY.gravity * returnTime * returnTime;
+
+  return {
+    direction,
+    x0,
+    y0,
+    velocityX,
+    velocityY,
+    bounceTime,
+    bounceX,
+    reboundVelocityY,
+    returnTime,
+    duration: bounceTime + returnTime,
+    targetX,
+    targetY,
+    apexY,
+    speed: Math.round(speed),
+  };
+}
+
+/**
+ * A stroke is playable when the ball clears the net, bounces once on the correct
+ * half, stays above the table until it reaches the far bat, and arrives at a height
+ * the far side can return.
+ */
+function isPlayable(stroke: Stroke): boolean {
+  const { direction, x0, y0, velocityX, velocityY, bounceTime, bounceX } = stroke;
+
+  if (stroke.apexY < RALLY.apexHighest) return false;
+
+  if (direction > 0 && (bounceX < RALLY.netX + BOUNCE_MARGIN || bounceX > RALLY.tableX1 - 4)) return false;
+  if (direction < 0 && (bounceX > RALLY.netX - BOUNCE_MARGIN || bounceX < RALLY.tableX0 + 4)) return false;
+
+  const netTime = (RALLY.netX - x0) / velocityX;
+  if (netTime <= 0 || netTime >= bounceTime) return false;
+  const netY = y0 + velocityY * netTime + 0.5 * RALLY.gravity * netTime * netTime;
+  if (netY > NET_CLEARANCE_Y) return false;
+
+  if (stroke.returnTime < 0.1) return false;
+  // The ball would land a second time before reaching the far bat.
+  if ((2 * -stroke.reboundVelocityY) / RALLY.gravity <= stroke.returnTime) return false;
+
+  return stroke.targetY >= RALLY.hitHighest && stroke.targetY <= RALLY.hitLowest;
+}
+
+/**
+ * Plan the next stroke from where the last one arrived.
+ *
+ * `variation` runs from 0 to 1 and widens the range the speed and the bounce point
+ * are drawn from. A plan that is not playable is thrown away and drawn again, which
+ * normally takes one to four tries.
+ */
+export function planStroke(
+  direction: Direction,
+  x0: number,
+  y0: number,
+  variation: number,
+  random: Random = Math.random,
+): Stroke {
+  const speedSpread = 45 + 115 * variation;
+  const distanceSpread = 8 + 22 * variation;
+
+  const attempt = (speedLow: number, speedHigh: number, distanceLow: number, distanceHigh: number): Stroke => {
+    const speed = speedLow + random() * (speedHigh - speedLow);
+    const distance = distanceLow + random() * (distanceHigh - distanceLow);
+    return solve(direction, x0, y0, speed, distance);
+  };
+
+  for (let i = 0; i < 40; i++) {
+    const stroke = attempt(
+      Math.max(120, 235 - speedSpread),
+      235 + speedSpread,
+      112 - distanceSpread,
+      112 + distanceSpread,
+    );
+    if (isPlayable(stroke)) return stroke;
+  }
+  // Widen the search before giving up.
+  for (let i = 0; i < 80; i++) {
+    const stroke = attempt(120, 400, 94, 136);
+    if (isPlayable(stroke)) return stroke;
+  }
+  // Neither search found anything, which no measured rally has ever needed. Fall back
+  // to a stroke from a contact height that is known to work, so a rally never stalls.
+  return FALLBACK_STROKE(direction, x0);
+}
+
+/**
+ * The last resort. Held apart so a test can check it is playable from both bats.
+ * It ignores the arriving height, so the ball would step; that is the price of
+ * always having a stroke to play.
+ */
+export const FALLBACK_STROKE = (direction: Direction, x0: number): Stroke => solve(direction, x0, 58, 210, 112);
+
+/** Exposed so the tests can check the same rule the planner applies. */
+export const isStrokePlayable = isPlayable;
+
+/** Where the ball is `time` seconds after the bat, written into `out`. */
+export function positionAt(stroke: Stroke, time: number, out: Point): Point {
+  if (time <= stroke.bounceTime) {
+    out.x = stroke.x0 + stroke.velocityX * time;
+    out.y = stroke.y0 + stroke.velocityY * time + 0.5 * RALLY.gravity * time * time;
+  } else {
+    const afterBounce = time - stroke.bounceTime;
+    out.x = stroke.bounceX + stroke.velocityX * afterBounce;
+    out.y =
+      CONTACT_Y + stroke.reboundVelocityY * afterBounce + 0.5 * RALLY.gravity * afterBounce * afterBounce;
+  }
+  return out;
+}


### PR DESCRIPTION
The loading screen played a CSS keyframe loop: two paddles ticked and the ball crossed on one fixed flat arc, mirrored back and forth. It now plays a continuous rally, solved rather than animated, so no two strokes are alike.

Settings are Fast pace, a long trail, and no bat contact marks.

## How the rally works

One cycle is four stages with no seam between them: the left side hits, the ball bounces once on the right half, the right side hits, the ball bounces once on the left half.

Each stroke picks a horizontal speed and a bounce point at random, then **solves for the launch angle** that makes the ball meet the table exactly there. The plan is checked before it is played — clear the net, bounce on the correct half, stay above the table until it reaches the far side, arrive at a height a player could return — and a plan that fails any check is thrown away and drawn again. It takes 1 to 4 tries.

Solving the angle rather than choosing it keeps speed and arc tied together the way they are on a real table: a fast stroke comes through low over the net and lands deep, a slow one has to be lifted and loops. The contact height each side gets is whatever the previous stroke delivered, so the rally builds its own rhythm without any of it being scripted.

Measured over 90,000 strokes: ball speed 133–393 units/s, arc peaking 26–68 units over the table, a stroke lasting 0.40–1.19 s.

The physics is a closed-form parabola with constant gravity and one restitution value, stepped at a fixed 4 ms. There is no integrator and no collision test — the bounce time is solved, not detected. **No dependency is added**; a physics engine can integrate a body forward but cannot tell you which velocity lands it on a chosen spot while clearing the net, which is the only hard part here.

## Rendering

Moved from SVG to two stacked canvases. The old version wrote 151 attributes per frame and drew the trail as 30 round-capped lines at stepped opacity, which beaded and made smooth motion read as stutter.

The trail is now **one filled polygon** — a ribbon running up one side of the recorded path and back down the other, narrowing to a point at the tail. It is drawn in one piece because every way of building the same fade out of many strokes shows the joins: a stroke that overlaps its neighbour composites brighter at the overlap, and one that stops short leaves a notch on the outside of a turn. Both were tried and both are visible.

Fading an uncleared canvas — the usual motion-trail trick — was tried first and rejected. Below about 5/255 the 8-bit alpha multiply rounds back to itself, so the oldest arcs stop fading and build a permanent ghost behind the rally. The trail is rebuilt from a ring buffer of positions each frame instead.

The ball lives on the scene layer, separate from the trail, so it never paints its own width into it.

## Testing

The solver is split into `rally-simulation.ts` with no DOM dependency, so it can be tested directly. The tests play 8,000 strokes across four variation levels and check every one against the net, the table, the returnable band and the frame, plus that sides alternate and each stroke starts exactly where the last one landed. The fallback path is exercised by driving the planner with a stuck random source.

- `npm test` — 1120 passed, 91 suites
- `npm run lint`, `tsc --noEmit`, `npm run build` — clean

Verified in the built app with Playwright: 60 fps with no frame over 20 ms, correct at 390 px and 900 px wide, and `prefers-reduced-motion` draws one still frame and stops.

## Notes

- Colour still comes only from the theme tokens: `--color-primary-text` for the ball, `--color-secondary-background` for the table and net, `--color-tertiary-background` for the trail and bounce ring.
- The table geometry changed. The old graphic's net was proportionally about 3× too tall relative to the table, which forces every physically valid shot into a lob; the table is longer and the net lower now, which is what makes the speed range possible.
- No changelog post. A replaced loading animation gives the reader no capability, no behaviour they need to know about, and no numbers to correct — happy to add one if you disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015N4s4JnpciUeGfEbcjFm6Q

---
_Generated by [Claude Code](https://claude.ai/code/session_015N4s4JnpciUeGfEbcjFm6Q)_