### PR TITLE
Add relative scale toggle to Hall of Fame score graph

### DIFF
--- a/frontend/src/client/changelog/changelog-posts.ts
+++ b/frontend/src/client/changelog/changelog-posts.ts
@@ -186,6 +186,9 @@ export const CHANGELOG_POSTS: ChangelogPost[] = [
       text(
         "A second toggle selects what the graph shows. Cumulative stacks the 9 sections as areas, with a solid color for each section. The top edge of the stack is the total score. A legend below the graph shows which color is which section. Delta gives the points the player gained in each period. A section picker filters both to the total score or to 1 of the 9 sections.",
       ),
+      text(
+        "A scale toggle sets how the app stacks the sections. Absolute stacks the score in points. Relative stacks the share of each section, so every point in time fills the full height and the 9 shares add up to 100%.",
+      ),
       list(
         "The first point is the day the player was created.",
         "The last point is now.",

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-score-over-time.tsx
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-score-over-time.tsx
@@ -24,9 +24,15 @@ import { useHallOfFameHistoryWorker } from "../../hooks/use-hall-of-fame-history
 import { useLocalStorage } from "../../hooks/use-local-storage";
 import { deltaBars } from "./hall-of-fame-delta-bars";
 import { FACTORS } from "./hall-of-fame-factors";
+import { stackedShares } from "./hall-of-fame-stacked-shares";
 
 type GraphMode = "cumulative" | "delta";
 const GRAPH_MODE_STORAGE_KEY = "hall-of-fame-score-over-time-mode";
+
+/** "Absolute" stacks the score in points. "Relative" stacks the share of each
+ * section, so every point in time fills the full height. */
+type StackScale = "absolute" | "relative";
+const STACK_SCALE_STORAGE_KEY = "hall-of-fame-score-over-time-scale";
 
 /** "Total" plus the 9 sections. Filters both the line and the bars. */
 type SeriesKey = "total" | HallOfFameFactorKey;
@@ -40,6 +46,8 @@ export const HallOfFameScoreOverTime: React.FC<{ playerId: string; playerName: s
   const { startComputation, result, progress, failed } = useHallOfFameHistoryWorker();
   const [storedMode, setStoredMode] = useLocalStorage(GRAPH_MODE_STORAGE_KEY, "cumulative");
   const mode: GraphMode = storedMode === "delta" ? "delta" : "cumulative";
+  const [storedScale, setStoredScale] = useLocalStorage(STACK_SCALE_STORAGE_KEY, "absolute");
+  const scale: StackScale = storedScale === "relative" ? "relative" : "absolute";
   const [series, setSeries] = useState<SeriesKey>("total");
 
   useEffect(() => {
@@ -64,9 +72,16 @@ export const HallOfFameScoreOverTime: React.FC<{ playerId: string; playerName: s
     return points.map((point) => ({ time: point.time, total: point.total, ...point.factors }));
   }, [points]);
 
+  const shareData = useMemo(() => (points ? stackedShares(points) : []), [points]);
+
   const deltaData = useMemo(() => deltaBars(graphData), [graphData]);
 
   const chartData = mode === "delta" ? deltaData : graphData;
+
+  /** The sections are only stacked on the total, and only in the cumulative
+   * graph. The relative scale therefore applies to that graph alone. */
+  const stacked = mode === "cumulative" && series === "total";
+  const relative = stacked && scale === "relative";
 
   const spansMoreThanAYear = useMemo(() => {
     if (graphData.length < 2) return false;
@@ -128,7 +143,7 @@ export const HallOfFameScoreOverTime: React.FC<{ playerId: string; playerName: s
         The score of {playerName} as it was at each point in time, from the day the player joined until now.
       </p>
 
-      <div className="flex flex-col xs:flex-row xs:items-end gap-3 xs:justify-between">
+      <div className="flex flex-col xs:flex-row xs:flex-wrap xs:items-end gap-3 xs:justify-between">
         <PillSelect<GraphMode>
           label="Graph"
           options={[
@@ -138,6 +153,17 @@ export const HallOfFameScoreOverTime: React.FC<{ playerId: string; playerName: s
           value={mode}
           onChange={setStoredMode}
         />
+        {stacked && (
+          <PillSelect<StackScale>
+            label="Scale"
+            options={[
+              { value: "absolute", label: "Absolute" },
+              { value: "relative", label: "Relative" },
+            ]}
+            value={scale}
+            onChange={setStoredScale}
+          />
+        )}
         <div className="flex flex-col gap-1">
           <span className="text-xs md:text-sm text-primary-text/60">Section</span>
           <select
@@ -160,7 +186,7 @@ export const HallOfFameScoreOverTime: React.FC<{ playerId: string; playerName: s
         <ResponsiveContainer width="100%" height="100%">
           {mode === "cumulative" ? (
             <AreaChart
-              data={series === "total" ? stackedData : graphData}
+              data={series === "total" ? (relative ? shareData : stackedData) : graphData}
               margin={{ top: 5, right: 8, left: -12, bottom: 0 }}
             >
               <CartesianGrid
@@ -182,8 +208,10 @@ export const HallOfFameScoreOverTime: React.FC<{ playerId: string; playerName: s
               />
               <YAxis
                 type="number"
-                domain={["auto", "auto"]}
-                tickFormatter={(value: number) => fmtNum(value) ?? ""}
+                domain={relative ? [0, 100] : ["auto", "auto"]}
+                tickFormatter={
+                  relative ? (value: number) => `${fmtNum(value) ?? ""}%` : (value: number) => fmtNum(value) ?? ""
+                }
                 stroke="rgb(var(--color-primary-text))"
                 fontSize={11}
                 tickLine={false}
@@ -193,7 +221,7 @@ export const HallOfFameScoreOverTime: React.FC<{ playerId: string; playerName: s
               <Tooltip
                 content={
                   series === "total" ? (
-                    <StackedTooltip />
+                    <StackedTooltip relative={relative} />
                   ) : (
                     <ScoreTooltip mode={mode} seriesLabel={seriesLabel} />
                   )
@@ -271,7 +299,7 @@ export const HallOfFameScoreOverTime: React.FC<{ playerId: string; playerName: s
         </ResponsiveContainer>
       </div>
 
-      {mode === "cumulative" && series === "total" && (
+      {stacked && (
         <div className="flex flex-wrap gap-x-3 gap-y-1.5">
           {FACTORS.map((factor) => (
             <span key={factor.key} className="flex items-center gap-1.5 text-xs text-primary-text">
@@ -294,7 +322,9 @@ export const HallOfFameScoreOverTime: React.FC<{ playerId: string; playerName: s
           <span className="bg-secondary-background/50 text-secondary-text/75 px-2 py-1 rounded">
             {mode === "delta"
               ? `${deltaData.length} periods, gain in each`
-              : `${graphData.length} points, score at each`}
+              : relative
+                ? `${graphData.length} points, share of the score at each`
+                : `${graphData.length} points, score at each`}
           </span>
         </div>
       )}
@@ -306,9 +336,17 @@ export const HallOfFameScoreOverTime: React.FC<{ playerId: string; playerName: s
 const shortDate = (time: number) =>
   new Date(time).toLocaleDateString("nb-NO", { day: "numeric", month: "short" });
 
-const StackedTooltip = ({ active, payload }: TooltipProps<ValueType, NameType>) => {
+const StackedTooltip = ({
+  active,
+  payload,
+  relative,
+}: TooltipProps<ValueType, NameType> & { relative: boolean }) => {
   if (!active || !payload || payload.length === 0) return null;
-  const data = payload[0].payload as { time: number; total: number } & Record<HallOfFameFactorKey, number>;
+  const data = payload[0].payload as {
+    time: number;
+    total: number;
+    absolute?: Record<HallOfFameFactorKey, number>;
+  } & Record<HallOfFameFactorKey, number>;
 
   return (
     <div className="p-3 bg-primary-background/95 backdrop-blur-sm ring-1 ring-primary-text/20 rounded-lg text-primary-text shadow-lg">
@@ -319,7 +357,12 @@ const StackedTooltip = ({ active, payload }: TooltipProps<ValueType, NameType>) 
           <div key={factor.key} className="flex items-center gap-1.5 text-xs">
             <span className="w-2.5 h-2.5 rounded-sm shrink-0" style={{ backgroundColor: factor.color }} />
             <span className="opacity-75">{factor.name}</span>
-            <span className="ml-auto pl-4 font-bold">{fmtNum(data[factor.key])}</span>
+            <span className="ml-auto pl-4 font-bold">
+              {relative ? `${fmtNum(data[factor.key], { digits: 1 })}%` : fmtNum(data[factor.key])}
+            </span>
+            {relative && data.absolute && (
+              <span className="opacity-60 w-10 text-right">{fmtNum(data.absolute[factor.key])}</span>
+            )}
           </div>
         ))}
       </div>

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-stacked-shares.test.ts
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-stacked-shares.test.ts
@@ -1,0 +1,56 @@
+import { HallOfFameFactorKey } from "../../client/client-db/hall-of-fame";
+import { HallOfFameHistoryPoint } from "../../client/client-db/hall-of-fame-history";
+import { FACTORS } from "./hall-of-fame-factors";
+import { stackedShares } from "./hall-of-fame-stacked-shares";
+
+const KEYS = FACTORS.map((factor) => factor.key);
+
+function point(time: number, factors: Partial<Record<HallOfFameFactorKey, number>>): HallOfFameHistoryPoint {
+  const full = {} as Record<HallOfFameFactorKey, number>;
+  for (const key of KEYS) {
+    full[key] = factors[key] ?? 0;
+  }
+  return { time, total: KEYS.reduce((sum, key) => sum + full[key], 0), factors: full };
+}
+
+describe("Hall of Fame stacked shares", () => {
+  it("gives no points for no points", () => {
+    expect(stackedShares([])).toEqual([]);
+  });
+
+  it("makes the shares of a point add up to 100", () => {
+    const [share] = stackedShares([point(1, { peakElo: 30, experience: 10, longevity: 60 })]);
+    const sum = KEYS.reduce((total, key) => total + share[key], 0);
+    expect(sum).toBeCloseTo(100);
+  });
+
+  it("gives each section its share of the score", () => {
+    const [share] = stackedShares([point(1, { peakElo: 75, experience: 25 })]);
+    expect(share.peakElo).toBeCloseTo(75);
+    expect(share.experience).toBeCloseTo(25);
+    expect(share.longevity).toBe(0);
+  });
+
+  it("gives 0 to every section when the player has no score", () => {
+    const [share] = stackedShares([point(1, {})]);
+    for (const key of KEYS) {
+      expect(share[key]).toBe(0);
+    }
+  });
+
+  it("keeps the time and the score in points", () => {
+    const [share] = stackedShares([point(42, { peakElo: 8, dataVolume: 2 })]);
+    expect(share.time).toBe(42);
+    expect(share.total).toBe(10);
+    expect(share.absolute.peakElo).toBe(8);
+  });
+
+  it("scales one point at a time, so a growing score keeps its shares", () => {
+    const shares = stackedShares([
+      point(1, { peakElo: 50, experience: 50 }),
+      point(2, { peakElo: 500, experience: 500 }),
+    ]);
+    expect(shares[0].peakElo).toBeCloseTo(50);
+    expect(shares[1].peakElo).toBeCloseTo(50);
+  });
+});

--- a/frontend/src/pages/hall-of-fame/hall-of-fame-stacked-shares.ts
+++ b/frontend/src/pages/hall-of-fame/hall-of-fame-stacked-shares.ts
@@ -1,0 +1,34 @@
+import { HallOfFameFactorKey } from "../../client/client-db/hall-of-fame";
+import { HallOfFameHistoryPoint } from "../../client/client-db/hall-of-fame-history";
+
+/** One point of the stacked graph in the relative view.
+ *
+ * The share of each section is on the point itself, because the graph stacks
+ * one area per section key. The scores in points stay available for the
+ * tooltip. */
+export type StackedSharePoint = {
+  time: number;
+  /** The score at the point, in points. */
+  total: number;
+  /** The score of each section at the point, in points. */
+  absolute: Record<HallOfFameFactorKey, number>;
+} & Record<HallOfFameFactorKey, number>;
+
+/** Converts each point to the share of each section, in percent.
+ *
+ * The shares of a point add up to 100, so the stacked graph fills the full
+ * height and shows how the sections divide the score at that time. A point
+ * where the player has no score yet gets 0 for every section. */
+export function stackedShares(points: HallOfFameHistoryPoint[]): StackedSharePoint[] {
+  return points.map((point) => {
+    const keys = Object.keys(point.factors) as HallOfFameFactorKey[];
+    const sum = keys.reduce((total, key) => total + point.factors[key], 0);
+
+    const shares = {} as Record<HallOfFameFactorKey, number>;
+    for (const key of keys) {
+      shares[key] = sum > 0 ? (point.factors[key] / sum) * 100 : 0;
+    }
+
+    return { time: point.time, total: point.total, absolute: point.factors, ...shares };
+  });
+}


### PR DESCRIPTION
## Summary
Adds a "Scale" toggle to the Hall of Fame score-over-time graph that lets players switch between absolute (points) and relative (percentage share) views when displaying stacked sections.

## Changes
- **New `stackedShares` utility** (`hall-of-fame-stacked-shares.ts`): Converts score history points to percentage shares of each section, with absolute values preserved for tooltips
- **Scale toggle UI**: Conditionally displays a "Scale" selector (Absolute/Relative) when viewing cumulative graph with total score
- **Graph rendering updates**:
  - Y-axis domain switches to `[0, 100]` in relative mode
  - Y-axis tick formatter adds `%` suffix in relative mode
  - Data source switches between stacked points and share percentages based on scale selection
- **Tooltip enhancement**: `StackedTooltip` now displays percentages in relative mode and shows absolute point values as secondary info
- **Layout adjustment**: Added `xs:flex-wrap` to control container to accommodate the new toggle
- **Changelog entry**: Documents the new scale toggle feature
- **Test coverage**: Comprehensive test suite for `stackedShares` function covering edge cases (empty data, zero scores, growing scores)

## Implementation Details
- Scale preference persists via localStorage (`hall-of-fame-score-over-time-scale`)
- Scale toggle only appears when sections are stacked (cumulative mode + total series selected)
- Relative view maintains the original absolute scores in the data structure for tooltip display
- Legend and info text update appropriately based on scale selection

https://claude.ai/code/session_018EDXJe3tjVciu4ePmEqBcS